### PR TITLE
PSR-1, a standard coding convention for PHP

### DIFF
--- a/proposed/PSR-1.md
+++ b/proposed/PSR-1.md
@@ -5,17 +5,17 @@ Rules
 -----
 
 * PHP code should be delimited by standard PHP tags. Short tags, ASP tags and script tags are not allowed.
-* Files that contain only PHP code should ommit the closing tag "?>" in order to avoid accidental injection of escape characters
+* Files that contain only PHP code should omit the closing tag "?>" in order to avoid accidental injection of escape characters.
 * Indentation consists of 4 spaces, tabs are not allowed.
 * Don't put spaces after opening parenthesis and before closing parenthesis.
 * After language keywords (if, else, while, switch, etc.) add a single space before the opening parenthesis.
 * Don't add trailing spaces after braces, parenthesis or line endings.
 * Native PHP types should be lowercase (false, null, true, array, etc.).
 * Use camelCase for variable, function and method names. Don't use underscores.
-* Use uppercase for constants, separe words with underscores.
+* Use uppercase for constants, separate words with underscores.
 * Class, method and function declarations should have braces on a new line.
 * Conditional statements should have braces on the same line, with a single space before the brace.
-* When there are no parameters for the constructor method, ommit the parenthesis.
+* When there are no parameters for the constructor method, omit the parenthesis.
 * Wrap operators with a single space (==, !=, &&).
 * A string that does not contain variable substitution should use single quotes.
 * A string that contains variable substitution should use double quotes. If the variable to be substituted is an array index, braces should be used. Never concatenate for this.


### PR DESCRIPTION
Each project can have it's own coding convention. For example: Symfony, Zend and Yii might have different naming conventions, as well other specific considerations (such as one class per file, line lenght, etc.). However, some rules are so generic that should be considered a standard. PSR-1 aims to be a set of generic guidelines for code formatting that can be extended by PHP projects. 

Right now we have various conventions, being the Zend Framework convention the most widely used. However, such conventions are very tied to the project itself and can become a hassle to port to other projects.

With PSR-1, we can have a cohesive standard that does not take into account personal preferences or project-specific considerations. This is why it's so important that you guys contribute to my initial commit. This HAS to be a community effort and discussed a lot. 
