### PR TITLE
Proposal for a HTTP Client interface

### DIFF
--- a/proposed/http-client.md
+++ b/proposed/http-client.md
@@ -65,6 +65,11 @@ A value objects come with this interface, the Response which is returned from th
         
         /**
          * Return all headers of this response.
+         * 
+         * Header names are returned as lower-case keys. Their values are returned
+         * in an array themselves to support multiple occurances of headers.
+         * 
+         * @example array(array("content-type" => array("text/html"))
          *
          * @return array
          */
@@ -73,9 +78,9 @@ A value objects come with this interface, the Response which is returned from th
         /**
          * Return a specified header of this response or null if not found,
          *
-         * Returns an array if multiple occurances of a header are returned.
+         * Returns an array no matter if single or multiple occurances of a header exist.
          *
-         * @return string|array|null
+         * @return array|null
          */
         public function getHeader($name);
     }


### PR DESCRIPTION
From the introduction:

Many libraries and applications require an HTTP client to talk to other servers. In general all these libraries either ship their own HTTP client library, or use low-level PHP functionality such as `file_get_contents`, ext/curl or the ext/socket. Depending on the use-cases there are very tricky implementation details to be handled such as proxies, SSL, authentication protocols and many more. Not every small library can afford to implement all the different details. However there are only a few http client libraries that are widely used between different projects, because of NIH or fears of vendor lock-in.

Motivation:

Doctrine has about 4 projects that need an HTTP client. Currently every projects implements them itself, which is annoying. We could abstract this into our "Common" library, however that would mean we would start being a "http client" vendor. Now personally, i dont care about http clients and would rather let others do this, however i also don't want to face vendor lock-in by deciding for any of the many http clients.
