### PR TITLE
Initial proposal for PSR-2, clarification attempt for PSR-0

### DIFF
--- a/proposed/PSR-2.md
+++ b/proposed/PSR-2.md
@@ -118,9 +118,10 @@ Example Class Implementation
                 if ( $lastNsPos > $prefixLen )
                 {
                     // Replacing '\' to '/' in namespace part
-                    $fileName .= substr(
-                        strtr( substr( $className, 0, $lastNsPos ), '\\', DIRECTORY_SEPARATOR ),
-                        $prefixLen
+                    $fileName .= str_replace(
+                        '\\',
+                        DIRECTORY_SEPARATOR,
+                        substr( $className, $prefixLen, $lastNsPos - $prefixLen )
                     ) . DIRECTORY_SEPARATOR;
                 }
     


### PR DESCRIPTION
This is a try at clearing some of the issues that came up during discussions in php-internals on splClassLoader rfc.

The issues that seems to come up where:
- case sensitivity
- handling of missing files
- include path handling
- questions on why pear compatibility was kept

The proposed changes (as of second commit) is currently two new lines:

```
* Namespace and class name is case sensitive as inherited from most
  file systems.
* If file is not present false is returned
```

And an extended example that shows this and which uses stream_resolve_include_path to maintain include path support if path is relative.

Formated version of proposal can be found here: https://github.com/andrerom/fig-standards/blob/psr2/proposed/PSR-2.md
