### PR TITLE
PSR-2 PHP constant casing contradicts PSR-1.

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -131,7 +131,8 @@ Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
 
 PHP [keywords][] MUST be in lower case.
 
-The PHP constants `true`, `false`, and `null` MUST be in lower case.
+The PHP constants `TRUE`, `FALSE`, and `NULL` MUST be in upper case (see
+[PSR-1][] 4.1. Constants).
 
 [keywords]: http://php.net/manual/en/reserved.keywords.php
 


### PR DESCRIPTION
PSR-2 fails the most simple sanity check:  Its guide on Boolean/Null constants contradicts PSR-1.

I'm sorry, but I fail to see how this can be "acceptable."

Two possible options:
1. Make PSR-1 comply (lower-case [class] constants).  (ugh)
2. Fix PSR-2 to be consistent.
