### PR TITLE
Clarify abbreviations and acronyms in PSR-1 method names.

### DIFF
--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -170,3 +170,20 @@ or method-level.
 ### 4.3. Methods
 
 Method names MUST be declared in `camelCase()`.
+
+#### 4.3.1. Abbreviations in methods
+
+Method names MUST NOT contain abbreviations; they MUST be written out instead
+(e.g., `getTemplate()` vs. `getTpl()`).
+
+#### 4.3.2. Acronyms in methods
+
+Acronyms in method names SHOULD follow the letter casing of the more recent
+object-oriented extensions in PHP core; e.g., [DOM][], [PDOException][],
+[XMLReader][], [SimpleXMLElement][].
+
+[DOM]: http://php.net/manual/en/book.dom.php
+[PDOException]: http://php.net/manual/en/class.pdoexception.php
+[XMLReader]: http://php.net/manual/en/class.xmlreader.php
+[SimpleXMLElement]: http://php.net/manual/en/class.simplexmlelement.php
+


### PR DESCRIPTION
Warning: Given the wide-spread adoption of strict camelCase in user-space PHP code, I realize and naturally expect some push-back here.

However.  PHP core is crystal clear with regard to acronyms and abbreviations, at least in its more "recent" extensions.

Thus, _if_ PSR-\* has any goal of consistency, then it should definitely follow the lead of the very language interpreter it is trying to form standards for.  Otherwise, it would intentionally be inconsistent with class methods provided by PHP core.

Two possible options:
1. Diverge from PHP core and "do what others do."
   
   Essentially introducing and enforcing a huge inconsistency between user space method names and PHP core method names.
2. Do what PHP core does.  Native consistency.

_Background: http://drupal.org/node/1627350_
