### PR TITLE
there should not be useless blank lines in the end of file

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -97,7 +97,7 @@ Code MUST follow all rules outlined in [PSR-1][].
 
 All PHP files MUST use the Unix LF (linefeed) line ending.
 
-All PHP files MUST end with a single blank line.
+All PHP files MUST NOT end with a single blank line.
 
 The closing `?>` tag MUST be omitted from files containing only PHP.
 


### PR DESCRIPTION
There is no reason to leave useless blank line in the end of file. At least it is very controversial rule and should not be part of standard.
