### PR TITLE
Proposal to allow Allman-style code in control structures

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -48,8 +48,8 @@ interpreted as described in [RFC 2119][].
 - Control structure keywords MUST have one space after them; method and
   function calls MUST NOT.
 
-- Opening braces for control structures MUST go on the same line, and closing
-  braces MUST go on the next line after the body.
+- Opening braces for control structures MUST either go on the same line, or the
+  next; closing braces MUST go on the next line after the body.
 
 - Opening parentheses for control structures MUST NOT have a space after them,
   and closing parentheses for control structures MUST NOT have a space before.


### PR DESCRIPTION
Not too important, perhaps, but I feel that Allman-style indetation can make for cleaner, more readable code. Not in the least when you're folding code-blocks:

```
    if ($foo === 'bar' || $bar === 'foo')
    {//short description of block
        echo 'foobar';
    }
```

Generally looks like this folded:

```
    if ($foo === 'bar' || $bar === 'foo')
    {//short description of block
```

Making it quite clear the comment belongs to the folded code. 
