### PR TITLE
Update accepted/PSR-2-coding-style-guide.md

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -421,7 +421,7 @@ switch ($expr) {
     case 3:
     case 4:
         echo 'Third case, return instead of break';
-        return;
+        break;
     default:
         echo 'Default case';
         break;


### PR DESCRIPTION
In switch example, case 4: return was used instead of break.
