### PR TITLE
Proposed Membership Bylaw

### DIFF
--- a/bylaws/003-membership.md
+++ b/bylaws/003-membership.md
@@ -113,7 +113,7 @@ Expulsion Of Member Projects
 ----------------------------
 
 A Member Project may be expelled from PHP-FIG if, in the judgement of PHP-FIG,
-that Member Project has not casted votes in three voting calls or all voting
+that Member Project has not casted votes in three consecutive voting calls or all voting
 calls over a period no less than six months whichever constitutes the greater
 period of time. It is the responsibility of Member Projects to ensure that they
 are actively represented by a Voting Representative.


### PR DESCRIPTION
This is intended to codify existing rules and to clarify the differences between PHP projects and the individuals who represent those projects and cast votes on their behalf. This should remove any need to re-vote each time a project needs to change its representative. I also included language to allow multiple representatives in recognition of projects which are founded on equal partnerships in the absence of a benevolent dictator or prominent meritocracy.
