### PR TITLE
Improvements to example autoloader.

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -49,11 +49,10 @@ function autoload($className)
 {
     $className = ltrim($className, '\\');
     $fileName  = '';
-    $namespace = '';
     if ($lastNsPos = strrpos($className, '\\')) {
-        $namespace = substr($className, 0, $lastNsPos);
+        $namespace = substr($className, 0, $lastNsPos + 1);
         $className = substr($className, $lastNsPos + 1);
-        $fileName  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
+        $fileName  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace);
     }
     $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 


### PR DESCRIPTION
`$namespace` only used inside of conditional block, no need to explicitly declare it outside.

Increasing the `substr()` length by 1, means the `str_replace()` handles the final `DIRECTORY_SEPARATOR`, so no need for the extra string operation appending it.
