### PR TITLE
Relax on structure body with braces

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -374,7 +374,7 @@ The general style rules for control structures are as follows:
 - The structure body MUST be indented once
 - The closing brace MUST be on the next line after the body
 
-The body of each structure MUST be enclosed by braces. This standardizes how
+The body of each structure SHOULD be enclosed by braces. This standardizes how
 the structures look, and reduces the likelihood of introducing errors as new
 lines get added to the body.
 


### PR DESCRIPTION
Please change the restrictive **MUST** to a more lenient **SHOULD** as it pertains to single line bodies of structures in alignment with similar rule for `elseif` and `else if`.

This is the singular obstacle for us to reach a consensus on PSR-2 adoption which has already caused major controversy, see Respect/Validation#106. The only thing we agreed on was to request an amendment which prompted this action. I should add, the general assumption is it's beating a dead horse, for you to prove fallacy.

The argument of prone to induced error remains valid to an extent yet our preference has leaned towards the shortened construct in spite of the perceived quandary, as per our [coding example](https://github.com/Respect/project-info/blob/master/coding-standards-sample.php) used for the common practices survey.

Something like this:

``` php
function foo() 
{
  $str = 'some string has some token inside inside';
  if (0 < $len = strlen($str))
    if (print "len = $len\n")
      if (false !== $pos = strpos($str, 'token')) 
         if (print "pos = $pos\n")
            if (0 < $len = $len - $pos)
               if (print "len min pos = $len\n")
                  return substr($str, $pos, $len);
  return "bar";
}
```

or unnecessarily elaborate alternative: 

``` php
function foo() 
{
  $str = 'some string has some token inside inside';
  if (0 < $len = strlen($str)) {
    if (print "len = $len\n") {
      if (false !== $pos = strpos($str, 'token')) {
         if (print "pos = $pos\n") {
            if (0 < $len = $len - $pos) {
              if (print "len min pos = $len\n") {
                return substr($str, $pos, $len);
              }
            }
          }  
        }
      }
    }
  }
  return "bar";
}
```

I can argue for reduced code, more robust, no redundancy, increased efficiency, optimum resource utilisation, simplified maintenance, increased productivity and improved readability but YMMV. Besides a larger footprint the nuisance is an audacity to PHP which cannot be refuted. As you may know our philosophy in short is small code and Respect PHP so you can see the conflict.

You may argue that it is not compulsory but if it is optional lets call it that by definition. The true measure of any conformance guideline is its ability to be applied in its entirety. Relaxing this restriction will go a long way sealing your commitment to finding an attainable middle ground.

To conclude, it is an honour that you considered our code in your assessments. We are a small team lacking the resources to get involved in your procedures, at this time, but we agree and support what you are trying to accomplish. We have complete faith in your ability to continue the commendable work, as you've already done, in our absence. Kudos for that!

Thank you for your time in consideration. Keep up the great work!
