### PR TITLE
Remove vendor/ from PSR-0 examples

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -21,16 +21,16 @@ Mandatory
 Examples
 --------
 
-* `\Doctrine\Common\IsolatedClassLoader` => `/path/to/project/lib/Doctrine/Common/IsolatedClassLoader.php`
-* `\Symfony\Core\Request` => `/path/to/project/lib/Symfony/Core/Request.php`
-* `\Zend\Acl` => `/path/to/project/lib/Zend/Acl.php`
-* `\Zend\Mail\Message` => `/path/to/project/lib/Zend/Mail/Message.php`
+* `\Doctrine\Common\IsolatedClassLoader` => `/path/to/project/Doctrine/Common/IsolatedClassLoader.php`
+* `\Symfony\Core\Request` => `/path/to/project/Symfony/Core/Request.php`
+* `\Zend\Acl` => `/path/to/project/Zend/Acl.php`
+* `\Zend\Mail\Message` => `/path/to/project/Zend/Mail/Message.php`
 
 Underscores in Namespaces and Class Names
 -----------------------------------------
 
-* `\namespace\package\Class_Name` => `/path/to/project/lib/namespace/package/Class/Name.php`
-* `\namespace\package_name\Class_Name` => `/path/to/project/lib/namespace/package_name/Class/Name.php`
+* `\namespace\package\Class_Name` => `/path/to/project/namespace/package/Class/Name.php`
+* `\namespace\package_name\Class_Name` => `/path/to/project/namespace/package_name/Class/Name.php`
 
 The standards we set here should be the lowest common denominator for
 painless autoloader interoperability. You can test that you are


### PR DESCRIPTION
This has come up in conversation a few times, where some users were making a direct connection between Composer and PSR-0 due to having the "vendor/" directory in there.

This to me is a trivial change, which might help reduce some confusion. They think that EVERYTHING inside the vendor/ folder should be PSR-0, which if you're using Composer it wont be, as Composer vendor-name/package-name is not PSR-0 compatible nor is there any requirement for packages the selves to contain any PSR code at all.

Vote here: https://groups.google.com/forum/?fromgroups=#!topic/php-fig/VWpowatynOQ
