### PR TITLE
Bullets padronization

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -4,18 +4,18 @@ to for autoloader interoperability.
 Mandatory
 ---------
 
-* A fully-qualified namespace and class must have the following
-  structure `\<Vendor Name>\(<Namespace>\)*<Class Name>`
-* Each namespace must have a top-level namespace ("Vendor Name").
-* Each namespace can have as many sub-namespaces as it wishes.
-* Each namespace separator is converted to a `DIRECTORY_SEPARATOR` when
+  A fully-qualified namespace and class must have the following
+  structure `\<Vendor Name>\(<Namespace>\)*<Class Name>`.
+  Each namespace must have a top-level namespace ("Vendor Name").
+  Each namespace can have as many sub-namespaces as it wishes.
+  Each namespace separator is converted to a `DIRECTORY_SEPARATOR` when
   loading from the file system.
-* Each `_` character in the CLASS NAME is converted to a
+  Each `_` character in the CLASS NAME is converted to a
   `DIRECTORY_SEPARATOR`. The `_` character has no special meaning in the
   namespace.
-* The fully-qualified namespace and class is suffixed with `.php` when
+  The fully-qualified namespace and class is suffixed with `.php` when
   loading from the file system.
-* Alphabetic characters in vendor names, namespaces, and class names may
+  Alphabetic characters in vendor names, namespaces, and class names may
   be of any combination of lower case and upper case.
 
 Examples

--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -16,21 +16,21 @@ interpreted as described in [RFC 2119][].
 1. Overview
 -----------
 
-- Files MUST use only `<?php` and `<?=` tags.
+  Files MUST use only `<?php` and `<?=` tags.
 
-- Files MUST use only UTF-8 without BOM for PHP code.
+  Files MUST use only UTF-8 without BOM for PHP code.
 
-- Files SHOULD *either* declare symbols (classes, functions, constants, etc.)
+  Files SHOULD *either* declare symbols (classes, functions, constants, etc.)
   *or* cause side-effects (e.g. generate output, change .ini settings, etc.)
   but SHOULD NOT do both.
 
-- Namespaces and classes MUST follow [PSR-0][].
+  Namespaces and classes MUST follow [PSR-0][].
 
-- Class names MUST be declared in `StudlyCaps`.
+  Class names MUST be declared in `StudlyCaps`.
 
-- Class constants MUST be declared in all upper case with underscore separators.
+  Class constants MUST be declared in all upper case with underscore separators.
 
-- Method names MUST be declared in `camelCase`.
+  Method names MUST be declared in `camelCase`.
 
 
 2. Files

--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -25,33 +25,33 @@ interpreted as described in [RFC 2119][].
 1. Overview
 -----------
 
-- Code MUST follow [PSR-1][].
+  Code MUST follow [PSR-1][].
 
-- Code MUST use 4 spaces for indenting, not tabs.
+  Code MUST use 4 spaces for indenting, not tabs.
 
-- There MUST NOT be a hard limit on line length; the soft limit MUST be 120
+  There MUST NOT be a hard limit on line length; the soft limit MUST be 120
   characters; lines SHOULD be 80 characters or less.
 
-- There MUST be one blank line after the `namespace` declaration, and there
+  There MUST be one blank line after the `namespace` declaration, and there
   MUST be one blank line after the block of `use` declarations.
 
-- Opening braces for classes MUST go on the next line, and closing braces MUST
+  Opening braces for classes MUST go on the next line, and closing braces MUST
   go on the next line after the body.
 
-- Opening braces for methods MUST go on the next line, and closing braces MUST
+  Opening braces for methods MUST go on the next line, and closing braces MUST
   go on the next line after the body.
 
-- Visibility MUST be declared on all properties and methods; `abstract` and
+  Visibility MUST be declared on all properties and methods; `abstract` and
   `final` MUST be declared before the visibility; `static` MUST be declared
   after the visibility.
   
-- Control structure keywords MUST have one space after them; method and
+  Control structure keywords MUST have one space after them; method and
   function calls MUST NOT.
 
-- Opening braces for control structures MUST go on the same line, and closing
+  Opening braces for control structures MUST go on the same line, and closing
   braces MUST go on the next line after the body.
 
-- Opening parentheses for control structures MUST NOT have a space after them,
+  Opening parentheses for control structures MUST NOT have a space after them,
   and closing parentheses for control structures MUST NOT have a space before.
 
 ### 1.1. Example
@@ -392,7 +392,7 @@ if ($expr1) {
 } elseif ($expr2) {
     // elseif body
 } else {
-    // else body;
+    // else body
 }
 ```
 

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -25,11 +25,11 @@ Users of loggers are refered to as `user`.
 
 ### 1.1 Basics
 
-- The `LoggerInterface` exposes eight methods to write logs to the eight
+  The `LoggerInterface` exposes eight methods to write logs to the eight
   [RFC 5424][] levels (debug, info, notice, warning, error, critical, alert,
   emergency).
 
-- A ninth method, `log`, accepts a log level as first argument. Calling this
+  A ninth method, `log`, accepts a log level as first argument. Calling this
   method with one of the log level constants MUST have the same result as
   calling the level-specific method. Calling this method with a level not
   defined by this specification MUST throw a `Psr\Log\InvalidArgumentException`
@@ -40,11 +40,11 @@ Users of loggers are refered to as `user`.
 
 ### 1.2 Message
 
-- Every method accepts a string as the message, or an object with a
+  Every method accepts a string as the message, or an object with a
   `__toString()` method. Implementors MAY have special handling for the passed
   objects. If that is not the case, implementors MUST cast it to a string.
 
-- The message MAY contain placeholders which implementors MAY replace with
+  The message MAY contain placeholders which implementors MAY replace with
   values from the context array.
 
   Placeholder names MUST correspond to keys in the context array.


### PR DESCRIPTION
The PSRs weren't following the same pattern for the ponctual rules: some PSRs had bullets; some not. Because the most of them didn't have it, the most rational choice was remove those with.
