### PR TITLE
Proposal for creating a standard for documenting types.

### DIFF
--- a/proposed/type-documentation.md
+++ b/proposed/type-documentation.md
@@ -1,0 +1,135 @@
+# Type documentation
+
+The following describes the mandatory code documentation.
+
+## Annotations
+
+Every class variable MUST be documented with an `@var` annotation:
+
+    /**
+     * @var string
+     */
+    private $name;
+
+Every method MUST be documented with one `@param` annotation per parameter:
+
+    /**
+     * @param string $firstname
+     * @param string $lastname
+     */
+    public function setName($firstname, $lastname)
+    {
+    }
+
+The return type of every method MUST be documented with an `@return` annotation, unless the return type is `void`, in which case the documentation MAY omit this annotation, or unless the method is a constructor, in which case the documentation MUST omit this annotation.
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+    }
+
+## Acceptable types
+
+The following native types are acceptable in a variable documentation:
+
+- `null`
+- `string`
+- `int`, `integer`
+- `float`, `double`
+- `bool`, `boolean`
+- `array`
+- `resource`
+- `callable`
+- `object`
+
+Two additional aggregate types can be used:
+
+- `number`: aggregates integer & float
+- `mixed`: aggregates all the types
+
+All these types are case-insensitive.
+
+Everything else will be considered a class or interface name. If the variable is documented as a class or interface, it may be documented using the Fully Qualified Class Name starting with the `\` character, or a relative class/interface name that MUST be resolvable with the `namespace` and `use` statements of the page, with the same [rules used by PHP](http://php.net/manual/en/language.namespaces.importing.php).
+
+    /**
+     * @var \Fully\Qualified\Class\Name
+     */
+    private $foo;
+
+    /**
+     * @var Relative\Class\Name
+     */
+    private $bar;
+
+## Mixed types
+
+If a variable can contain several possible types, these MUST be separated with the `|` character:
+
+    /**
+     * @var string|null
+     */
+    private $name;
+
+## Iterable types
+
+In all the following examples, `type` can be any native type, or class/interface name, as mentioned in the *Acceptable types* section.
+
+If a variable is iterable (either an `array`, or an object implementing the `\Traversable` interface), and the type of the iterated elements is known, the variable MAY be documented as such:
+
+    /**
+     * @var type[]
+     */
+    private $elements;
+
+If the variable follows the same description, but is know to be an `array`, the following syntax SHOULD be used instead:
+
+    /**
+     * @var array<type>
+     */
+    private $elements;
+
+If the variable follows the same description, but is known to be an instance of a specific class/interface implementing/extending the `\Traversable` interface, the following syntax SHOULD be used instead:
+
+    /**
+     * @var Collection<type>
+     */
+    private $elements;
+
+In this code, `Collection` is a class implementing the `\Traversable` interface.
+
+## Miscellaneous
+
+The aforementioned rules can be mixed together:
+
+    /**
+     * @var int|int[]
+     */
+    private $foo;
+
+    /**
+     * @var string|\My\Collection<string>
+     */
+    private $bar;
+
+    /**
+     * @var array<string|object>
+     */
+    private $baz;
+
+The iterable types can be nested:
+
+    /**
+     * @var \DOMElement[][]
+     */
+    private $foo;
+
+    /**
+     * @var array<array<\DOMElement>>
+    private $bar;
+
+    /**
+     * @var Collection<Collection<\DOMElement>>
+     */
+    private $baz;


### PR DESCRIPTION
A good documentation is not only essential for developers who read the code, but also for advanced IDE features such as autocompletion and static code analysis.

While no official standard exists for docblock documentation, _de-facto_ standards have emerged over time, the most famous being [PHPDocumentor](http://www.phpdoc.org/).

The following annotations are already supported by most, if not all documentation tools and IDE environments:
- `@var`
- `@param`
- `@return`
- `@throws`

This proposal targets the first three, and leaves `@throws` for a future proposal of its own, as some input from the community will be necessary to define a standard (in particular regarding whether or not to apply the Java checked/unchecked exception model).

Although IDE support is already good for simple type-hinted variables, such as `@var ClassName`, there is a clear lack of support for iterable variables (arrays and objects implementing the `Traversable` interface), that in turn contain other variables.

Some IDE environments, such as [PHPStorm](http://www.jetbrains.com/phpstorm/), have taken the lead, and already provide some level of support with a `ClassName[]` syntax. Unfortunately, this syntax does not allow to specify at the same time the type of the variable itself, _and_ the type of the variables it contains.

This proposal introduces a standard solving this problem, inspired by the Java generics syntax, and 100% compatible with these existing syntaxes.

This aims to make such a thing possible, and ideally adopted by all IDE vendors in the near future:

```
use Doctrine\Common\Collections\ArrayCollection;

class Foo
{
    /**
     * @var ArrayCollection<\DOMElement>
     */
    private $elements;

    public function bar()
    {
        // The IDE knows that `$elements` is of type `Collection`, and recognizes `count()`.
        $this->elements->count();

        foreach ($this->elements as $element) {
            // The IDE knows that $element is a `\DOMElement`.
        }
    }
}
```

[Please review!](https://github.com/BenMorel/fig-standards/blob/d9e2e769d469097a516167b838f7011e2f1aa3f8/proposed/type-documentation.md)
