### PR TITLE
Fix Project-Specific Implementation example

### DIFF
--- a/proposed/package-oriented-autoloader.md
+++ b/proposed/package-oriented-autoloader.md
@@ -80,7 +80,7 @@ specification.
 <?php
 // if this closure is registered in a file at /path/to/project/autoload.php ...
 spl_autoload_register(function ($absoluteClass) {
-    $namespacePrefix = 'Foo\Bar';
+    $namespacePrefix = 'Foo\\Bar\\';
     $baseDirectory = __DIR__ . '/src/';
     if (0 === strncmp($namespacePrefix, $absoluteClass, strlen($namespacePrefix))) {
         $relativeClass = substr($absoluteClass, strlen($namespacePrefix));
@@ -88,10 +88,8 @@ spl_autoload_register(function ($absoluteClass) {
         $path = $baseDirectory . $relativeFile;
         if (is_readable($path)) {
             require $path;
-            return true;
         }
     }
-    return false;
 });
 
 // ... then the following line would cause the autoloader to attempt to load


### PR DESCRIPTION
In reference to mailing list conversation: https://groups.google.com/d/msg/php-fig/SJTL1ec46II/3DpYEzJ6Gz8J
- Ensure namespace prefix has a trailing `\` to ensure incorrect matches do not happen.
  (avoids `Foo\Bar` matching class `Foo\BarBaz`)
- Removed unneeded `return` statements.
