### PR TITLE
Fix General-Purpose Implementation example

### DIFF
--- a/proposed/package-oriented-autoloader.md
+++ b/proposed/package-oriented-autoloader.md
@@ -217,7 +217,7 @@ classes on disk at the following paths ...
             Dib/
                 Zim.php         # Foo\Bar\Dib\Zim
 
-... one would register the path to the class files for the `Foo\Bar` namespace
+... one would register the path to the class files for the `Foo\Bar\` namespace
 prefix like so:
 
 ```php
@@ -227,7 +227,7 @@ $loader = new \Example\PackageOrientedLoader;
 
 // register the base directory for the namespace prefix
 $loader->setNamespacePrefixBase(
-    'Foo\Bar',
+    'Foo\\Bar\\',
     '/path/to/packages/foo-bar/src'
 );
 


### PR DESCRIPTION
In reference to mailing list conversation: https://groups.google.com/d/msg/php-fig/SJTL1ec46II/3DpYEzJ6Gz8J
- Example namespace prefix has a trailing `\` to show best practices for
  registering namespace prefixes to avoid `Foo\Bar` matching class `Foo\BarBaz`.
