### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to the PHP-FIG
+
+Anybody who subscribes to the Google Group, is part of the PHP-FIG. As soon as
+you subscribe to the [mailing list](http://groups.google.com/group/php-fig/)
+and/or join the [IRC channel](http://www.php-fig.org/irc/) you are a PHP-FIG
+Community Member, who can influence standards, make suggestions, give feedback,
+etc. Only PHP-FIG Voting Members can start or participate in votes, but the
+discussion and formation stages involve everyone.
+
+See the [PHP-FIG FAQ](http://www.php-fig.org/faq/) for more information.


### PR DESCRIPTION
In #121, it was brought up that having a `CONTRIBUTING.md` would help guide people to the right places when wanting to get involved with the PHP-FIG, in accordance with the [Github Contributing Guidelines](https://github.com/blog/1184-contributing-guidelines).

The proposed file contains just one key paragraph from the [FAQ](http://www.php-fig.org/faq/), along with a link to it in order to keep duplicate documentation down.
