### PR TITLE
Replace occurences of disk with file system

### DIFF
--- a/proposed/package-oriented-autoloader.md
+++ b/proposed/package-oriented-autoloader.md
@@ -41,8 +41,8 @@ classes to map to shallower directory structures.
   `\Foo\Bar\Baz\Qux` and a `namespace prefix` of `\Foo\Bar\`, the `relative
   class name` is `Baz\Qux`.
 
-- `base directory`: The absolute directory path on disk where the files for
-  `relative class names` have their root.
+- `base directory`: The absolute directory path in the file system where the
+  files for `relative class names` have their root.
 
 
 3. Specification
@@ -196,7 +196,7 @@ class ClassLoader
 ```
 
 Given the example general-purpose implementation, and a `foo-bar` package of
-classes on disk at the following paths ...
+classes in the file system at the following paths ...
 
     /path/to/packages/foo-bar/
         src/


### PR DESCRIPTION
Using _file system_ instead of _disk_ may be a bit more appropriate as with changing technology, a lot of people nowadays don't even have disks anymore.
