### PR TITLE
Add link to the PHP manual

### DIFF
--- a/proposed/autoloader.md
+++ b/proposed/autoloader.md
@@ -18,7 +18,7 @@ This PSR specifies the rules for an interoperable autoloader.
 - `class`: The term "class" refers to PHP classes, interfaces, and traits.
 
 - `fully qualified class name`: The full namespace and class name, with
-  leading backslash. (This is per the "Name Resolution Rules" from the PHP
+  leading backslash. (This is per the [Name Resolution Rules](http://php.net/manual/en/language.namespaces.rules.php) from the PHP
   manual.)
 
 - `namespace`: Given a `fully qualified class name` of `\Foo\Bar\Baz\Qux`, the


### PR DESCRIPTION
Seems useful to link to the PHP manual if we're going to reference it.
