### PR TITLE
Ensure the prefix is an array before pushing or unshifting

### DIFF
--- a/proposed/autoloader.md
+++ b/proposed/autoloader.md
@@ -171,6 +171,9 @@ class ClassLoader
     {
         $prefix = trim($prefix, '\\');
         $base = rtrim($base, DIRECTORY_SEPARATOR);
+        if (!isset($this->prefixes[$prefix])) {
+            $this->prefixes[$prefix] = array();
+        }
         if ($prepend) {
             array_unshift($this->prefixes[$prefix], $base);
         } else {


### PR DESCRIPTION
This was causing issues for me. It was only throwing a warning but it was not actually pushing or unshifting anything which resulted in no work being done in loadClass.

Ping @pmjones
