### PR TITLE
Fix issue #77: play nice with other autoloaders

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -58,7 +58,9 @@ function autoload($className)
     }
     $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
-    require $fileName;
+    if (stream_resolve_include_path($fileName)) {
+        require $fileName;
+    }
 }
 ```
 


### PR DESCRIPTION
PHP allows one to chain several autoloaders:
When the first fails to load a class, the next is asked.

The sample PSR-0 autoloader fatally fails when a class cannot be loaded.
This patch first checks if the file exists and only then includes it.
