### PR TITLE
[PSR-4] Move example implementation copy to the meta document.

### DIFF
--- a/proposed/psr-4-autoloader/psr-4-autolader.md
+++ b/proposed/psr-4-autoloader/psr-4-autolader.md
@@ -94,14 +94,3 @@ that corresponds with that namespace prefix ...
 
 - Namespace separators in the relative class name portion of the fully
   qualified class name MUST be replaced with directory separators.
-
-
-4. Implementations
-------------------
-
-Implementations MAY contain additional features and MAY differ in how they are
-implemented.
-
-For example implementations, see [Psr4AutoloaderTest.php](Psr4AutoloaderTest.php). Example
-implementations MUST NOT be regarded as part of the specification; they are
-examples only, and may change at any time.

--- a/proposed/psr-4-autoloader/psr-4-autoloader-meta.md
+++ b/proposed/psr-4-autoloader/psr-4-autoloader-meta.md
@@ -203,33 +203,40 @@ Cons:
 - Not in line with the wishes of poll respondents and some collaborators
 
 
-5. People
+5. Implementations
+------------------
+
+For example implementations, see [Psr4AutoloaderTest.php](Psr4AutoloaderTest.php).
+These impelementations are examples only and may change at any time.
+
+
+6. People
 ---------
 
-### 5.1 Editor
+### 6.1 Editor
 
 - Paul M. Jones, Solar/Aura
 
-### 5.2 Sponsors
+### 6.2 Sponsors
 
 - Phil Sturgeon, PyroCMS (Coordinator)
 - Larry Garfield, Drupal
 
-### 5.3 Contributors
+### 6.3 Contributors
 
 - Beau Simensen, for his work on defining and separating the transformation
   rules
 - Too many others to name and count
 
 
-6. Votes
+7. Votes
 --------
 
 - **Entrance Vote:** (tbd)
 - **Acceptance Vote:** (tbd)
 
 
-7. Relevant Links
+8. Relevant Links
 -----------------
 
 - [Autoloader, round 4](https://groups.google.com/forum/#!topicsearchin/php-fig/autoload/php-fig/lpmJcmkNYjM)


### PR DESCRIPTION
I think we've talked about this issue off and on. At some point I thought we'd agreed that the example implementation should be removed from the PSR itself. I think as it is written now is probably a decent compromise (since the actual implementation is no longer actually in the PSR) but there are a few things that kinda feel weird:

> Implementations MAY contain additional features and MAY differ in how they are implemented.

Clearly implementations will be different and may have different features. As much as I originally liked this line of text, I think it was only needed if the reference implementations were actually included in the doc itself. Otherwise, it just sounds like we're saying something obvious: implementations will differ.

> For example implementations, see [Psr4AutoloaderTest.php](Psr4AutoloaderTest.php). Example implementations MUST NOT be regarded as part of the specification; they are examples only, and may change at any time.

This sounds like meta documentation and we have a place for that now. This **is** a step up from having the code actually embedded int he doc, but we can avoid any problems by simply moving this to the meta doc where I would argue it belongs.

The only reason we need to warn that they are by example only and not to be considered a spec is because we're linking to a reference implementation in the spec itself. This was what happened with PSR-0. If we remove the link to code from the spec itself I think the whole thing will be cleaner.
