### PR TITLE
PSR-2 "Multi-line Arguments" Errata

### DIFF
--- a/accepted/PSR-2-coding-style-guide-meta.md
+++ b/accepted/PSR-2-coding-style-guide-meta.md
@@ -21,9 +21,9 @@ projects. Thus, the benefit of this guide is not in the rules themselves, but in
 3. Errata
 ---------
 
-1. _[09/08/2013]_ Using one or more multi-line arguments does not constitute splitting the argument list itself, 
-therefore Section 4.6 is not automatically enforced. Arrays and anonymous functions are able to span multiple
-lines.
+1. _[09/08/2013]_ Using one or more multi-line arguments (i.e: arrays or anonymous functions) does not constitute 
+splitting the argument list itself, therefore Section 4.6 is not automatically enforced. Arrays and anonymous 
+functions are able to span multiple lines.
 
 The following examples are perfectly valid in PSR-2:
 


### PR DESCRIPTION
Now that the [Errata Vote](https://groups.google.com/forum/?fromgroups=#!topic/php-fig/qTROKw07848) has passed we are able to add Errata to PSRs. This pull request adds the meta document, along with the first clarification I'd like to make: [Multi-line Arguments](https://gist.github.com/philsturgeon/6320152#file-multi-line-arguments-md).
