### PR TITLE
Technique -> Requirements

### DIFF
--- a/proposed/psr-4-autoloader/psr-4-autoloader.md
+++ b/proposed/psr-4-autoloader/psr-4-autoloader.md
@@ -122,7 +122,7 @@ _class part_.
     could follow this structure `\<Vendor Name>\(<Namespace Parts>\)*<Class Part>`.
 
 2. At least one _namespace prefix_ of each _autoloadable class name_ MUST
-correspond to a _resource base_.
+correspond to a _resource base_, using the following rules:
 
     a. A _namespace prefix_ MAY correspond to more than one _resource base_.
     (The order in which a _conforming autoloader_ processes more than one


### PR DESCRIPTION
Turning the original intention into wording most folks can agree on.

There is minimal autoloader specific content and the steps are made more generic so that people do not confuse them for pseudo-code outlining sequential steps that MUST be taken to comply - which was never the suggestion, but confusing wording apparently lead to this common misconception.

There is some remaining implementation-level information, for example we absolutely have to point out that autoloaders cannot and will not throw exceptions or raise errors. We have worded it to be vague and apply to all parties, as all parties need to know this.
