### PR TITLE
[Spanish Translation] Fixed innacurate expression

### DIFF
--- a/accepted/es/PSR-2-guia-de-estilo-de-codificacion.md
+++ b/accepted/es/PSR-2-guia-de-estilo-de-codificacion.md
@@ -25,7 +25,7 @@ En el documento original se usa el RFC 2119 para el uso de las palabras MUST, MU
 
 - Las llaves de apertura de las clases DEBEN ir en la línea siguiente, y las llaves de cierre DEBEN ir en la línea siguiente al cuerpo de la clase.
 
-- Las llaves de apertura de los métodos DEBEN ir en la línea siguiente, y las llaves de cierre DEBEN de ir en la línea siguiente al cuerpo del método.
+- Las llaves de apertura de los métodos DEBEN ir en la línea siguiente, y las llaves de cierre DEBEN ir en la línea siguiente al cuerpo del método.
 
 - La visibilidad DEBE estar declarada en todas las propiedades y métodos; `abstract` y `final` DEBEN estar declaradas antes de la visibilidad; `static` DEBE estar declarada después de la visibilidad.
 


### PR DESCRIPTION
"Deben" means "it must be" while "deben de" is more like "it seems to be".

http://castellanoactual.com/deber-o-no-deber/
