### PR TITLE
Linking psr-4 autoloader examples to github

### DIFF
--- a/accepted/PSR-4-autoloader.md
+++ b/accepted/PSR-4-autoloader.md
@@ -75,4 +75,4 @@ as part of the specification and MAY change at any time.
 
 [autoloading]: http://php.net/autoload
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
-[examples file]: PSR-4-autoloader-examples.md
+[examples file]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md


### PR DESCRIPTION
Linking psr-4 autoloader examples to github since the previous link wasn't working.
