### PR TITLE
Update PSR-0.md

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -13,9 +13,6 @@ Mandatory
 * Each namespace can have as many sub-namespaces as it wishes.
 * Each namespace separator is converted to a `DIRECTORY_SEPARATOR` when
   loading from the file system.
-* Each `_` character in the CLASS NAME is converted to a
-  `DIRECTORY_SEPARATOR`. The `_` character has no special meaning in the
-  namespace.
 * The fully-qualified namespace and class is suffixed with `.php` when
   loading from the file system.
 * Alphabetic characters in vendor names, namespaces, and class names may
@@ -32,8 +29,8 @@ Examples
 Underscores in Namespaces and Class Names
 -----------------------------------------
 
-* `\namespace\package\Class_Name` => `/path/to/project/lib/vendor/namespace/package/Class/Name.php`
-* `\namespace\package_name\Class_Name` => `/path/to/project/lib/vendor/namespace/package_name/Class/Name.php`
+* `\namespace\package\Class_Name` => `/path/to/project/lib/vendor/namespace/package/Class_Name.php`
+* `\namespace\package_name\Class_Name` => `/path/to/project/lib/vendor/namespace/package_name/Class_Name.php`
 
 The standards we set here should be the lowest common denominator for
 painless autoloader interoperability. You can test that you are
@@ -59,7 +56,7 @@ function autoload($className)
         $className = substr($className, $lastNsPos + 1);
         $fileName  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
     }
-    $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
+    $fileName .= $className . '.php';
 
     require $fileName;
 }
@@ -73,5 +70,4 @@ load your classes if you follow the autoloader interoperability
 standards proposed above. It is the current recommended way to load PHP
 5.3 classes that follow these standards.
 
-* [http://gist.github.com/221634](http://gist.github.com/221634)
 


### PR DESCRIPTION
Removed replacement of underscores since it adds unexpected magic to namespace based autoloading. A standard should not contain technical debts like this, thanks alot :)
