### PR TITLE
Removed unused variable

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -53,7 +53,6 @@ function autoload($className)
 {
     $className = ltrim($className, '\\');
     $fileName  = '';
-    $namespace = '';
     if ($lastNsPos = strrpos($className, '\\')) {
         $namespace = substr($className, 0, $lastNsPos);
         $className = substr($className, $lastNsPos + 1);


### PR DESCRIPTION
$namespace is not used outside of the if statement in which it is redeclared. The initial declaration is unnecessary.
