### PR TITLE
[PSR-3] Fixed interpolate() to pass tests

### DIFF
--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -73,7 +73,10 @@ Users of loggers are refered to as `user`.
       // build a replacement array with braces around the context keys
       $replace = array();
       foreach ($context as $key => $val) {
-          $replace['{' . $key . '}'] = $val;
+          // check that the value can be casted to string
+          if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
+              $replace['{' . $key . '}'] = $val;
+          }
       }
 
       // interpolate replacement values into the message and return


### PR DESCRIPTION
The current implementation of the `interpolate()` provided in the PSR-3 RFC breaks tests of https://github.com/php-fig/log/blob/master/Psr/Log/Test/LoggerInterfaceTest.php and is not compliant with the RFC itself:
> Every method accepts an array as context data. This is meant to hold any extraneous information that does not fit well in a string. The array can contain anything. Implementors MUST ensure they treat context data with as much lenience as possible. A given value in the context MUST NOT throw an exception nor raise any php error, warning or notice.

This PR fixes that.