### PR TITLE
Removed return value from implementation

### DIFF
--- a/proposed/psr-4-autoloader/psr-4-autoloader-examples.md
+++ b/proposed/psr-4-autoloader/psr-4-autoloader-examples.md
@@ -189,9 +189,6 @@ class Psr4AutoloaderClass
             // of strrpos()
             $prefix = rtrim($prefix, '\\');   
         }
-        
-        // never found a mapped file
-        return false;
     }
     
     /**


### PR DESCRIPTION
According to Specification 4, should not return false:

```
Autoloader implementations MUST NOT throw exceptions, MUST NOT raise errors of any level, and SHOULD NOT return a value.
```
