### PR TITLE
PSR-4 Autoloader class example contains typo

### DIFF
--- a/proposed/psr-4-autoloader/psr-4-autoloader-examples.md
+++ b/proposed/psr-4-autoloader/psr-4-autoloader-examples.md
@@ -219,7 +219,7 @@ class Psr4AutoloaderClass
                   . str_replace('\\', DIRECTORY_SEPARATOR, $relative_class)
                   . '.php';
             $file = $base_dir
-                  . str_replace('\\', '/', $relative_class)
+                  . str_replace('\\', '/', $file)
                   . '.php';
 
             // if the mapped file exists, require it


### PR DESCRIPTION
$file was immediately overwritten. The first entry did _nothing_.

The old code example:

``` php
$file = $base_dir
      . str_replace('\\', DIRECTORY_SEPARATOR, $relative_class)
      . '.php';
$file = $base_dir
      . str_replace('\\', '/', $relative_class)
      . '.php';
```

$file was never used and the first line had no side effects and thus did **nothing**.

Judging from the line from earlier in the class:

``` php
$base_dir = rtrim($base_dir, '/') . DIRECTORY_SEPARATOR;
$base_dir = rtrim($base_dir, DIRECTORY_SEPARATOR) . '/';
```

I have made the following change whereas the second `str_replace` is performed on $file rather than $relative_class
