### PR TITLE
Require if exists

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -61,7 +61,7 @@ function autoload($className)
     }
     $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
-    if(file_exists($fileName)){
+    if (file_exists($fileName)) {
        require $fileName;
     }
 }


### PR DESCRIPTION
Only require the file if it exists. Allows multiple autoloaders to be used.
I was using this implementation of PSR-0 with PHPUnit and it wouldn't play nice until I used the above fix.
