### PR TITLE
[PSR-2] Fixed wrongly indented comments in documentation

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -543,7 +543,7 @@ $longArgs_noVars = function (
     $longerArgument,
     $muchLongerArgument
 ) {
-   // body
+    // body
 };
 
 $noArgs_longVars = function () use (
@@ -551,7 +551,7 @@ $noArgs_longVars = function () use (
     $longerVar2,
     $muchLongerVar3
 ) {
-   // body
+    // body
 };
 
 $longArgs_longVars = function (
@@ -563,7 +563,7 @@ $longArgs_longVars = function (
     $longerVar2,
     $muchLongerVar3
 ) {
-   // body
+    // body
 };
 
 $longArgs_shortVars = function (
@@ -571,7 +571,7 @@ $longArgs_shortVars = function (
     $longerArgument,
     $muchLongerArgument
 ) use ($var1) {
-   // body
+    // body
 };
 
 $shortArgs_longVars = function ($arg) use (
@@ -579,7 +579,7 @@ $shortArgs_longVars = function ($arg) use (
     $longerVar2,
     $muchLongerVar3
 ) {
-   // body
+    // body
 };
 ```
 


### PR DESCRIPTION
Been bulding a PSR-2 indentation mode for php-mode to Emacs. And was going through all the code examples to try the indentation out and found this error :)
