### PR TITLE
Fixed a docblock

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -146,8 +146,6 @@ interface MessageInterface
      * @return void
      *
      * @throws \InvalidArgumentException When the body is not valid.
-     *
-     * @return self Returns the message.
      */
     public function setBody(StreamInterface $body = null);
 


### PR DESCRIPTION
We can't have 2 different return comments within the same docblock.
