### PR TITLE
[PSR-6] Added "flag" function for stampede protection

### DIFF
--- a/proposed/cache.md
+++ b/proposed/cache.md
@@ -235,17 +235,15 @@ interface CacheItemInterface
     public function exists();
 
     /**
-     * Notifies the caching system that an Item's data is being regenerated.
+     * This method is used to tell future calls to this item if re-regeneration of
+     * this item's data is in progress or not.
      *
-     * Calling Libraries can use this to notify the Implementing Library that
-     * an Item is having its value regenerated. This can be used to prevent the
-     * dogpile effect by allowing Implementing Libraries to manage when write
-     * operations occur.
+     * This can be used to prevent the dogpile effect to stop lots of requests re-generating
+     * the fresh data over and over.
      *
-     * @return static
-     *   The invoked object.
+     * @return boolean
      */
-    public function flag();
+    public function isRegenerating();
 
     /**
      * Sets the expiration for this cache item.


### PR DESCRIPTION
This pull request is in response to a discussion on the mailing list: https://groups.google.com/forum/#!topic/php-fig/WYShSmYYk9M

The main idea is that a "flag" function would allow implementing libraries to respond to write operations intelligently and take measures to prevent the "stampede effect"/"dog pile" problem that can occur when a cache miss happens for an expensive item.
