### PR TITLE
Missing PSR-4 reference in PSR-1

### DIFF
--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -106,7 +106,7 @@ if (! function_exists('bar')) {
 3. Namespace and Class Names
 ----------------------------
 
-Namespaces and classes MUST follow [PSR-0].
+Namespaces and classes MUST follow an "autoloading" PSR: [[PSR-0], [PSR-4]].
 
 This means each class is in a file by itself, and is in a namespace of at
 least one level: a top-level vendor name.


### PR DESCRIPTION
When I created the [Amendment bylaw](https://github.com/php-fig/fig-standards/blob/master/bylaws/006-psr-amendments.md) I [added a PSR-4 reference into PSR-1](https://github.com/php-fig/fig-standards/commit/0da2fc792762b33d56f70d2efe7c7c1c0d4f3e07) as part of the package, and that was all approved and voted on and good in the group.

It seems like I forgot to add a PSR-4 reference into the second "PSR-0 only" reference. This was a foolish mistake, so this PR seeks to correct that.
