### PR TITLE
Removed redundant ttl parameter from set

### DIFF
--- a/proposed/cache.md
+++ b/proposed/cache.md
@@ -198,18 +198,10 @@ interface CacheItemInterface
      *
      * @param mixed $value
      *   The serializable value to be stored.
-     * @param int|\DateTime $ttl
-     *   - If an integer is passed, it is interpreted as the number of seconds
-     *     after which the item MUST be considered expired.
-     *   - If a DateTime object is passed, it is interpreted as the point in
-     *     time after which the item MUST be considered expired.
-     *   - If no value is passed, a default value MAY be used. If none is set,
-     *     the value should be stored permanently or for as long as the
-     *     implementation allows.
      * @return static
      *   The invoked object.
      */
-    public function set($value, $ttl = null);
+    public function set($value);
 
     /**
      * Confirms if the cache item lookup resulted in a cache hit.


### PR DESCRIPTION
Now that the "setExpiration" method exists there is no reason to include the ttl parameter in the set function, particularly since it already defaults to null.
