### PR TITLE
[PSR-7] Clarification of detach() method of StreamInterface

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -415,7 +415,7 @@ interface StreamInterface
      *
      * After the stream has been detached, the stream is in an unusable state.
      *
-     * @return void
+     * @return resource Underlying PHP stream
      */
     public function detach();
 


### PR DESCRIPTION
Updated `detach()` signature to indicate it should return the underlying PHP
stream.
