### PR TITLE
[PSR-7] Add getMetadata() to StreamInterface

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -506,5 +506,21 @@ interface StreamInterface
      * @return string
      */
     public function getContents($maxLength = -1);
+
+    /**
+     * Get stream metadata as an associative array or retrieve a specific key.
+     *
+     * The keys returned are identical to the keys returned from PHP's
+     * stream_get_meta_data() function.
+     *
+     * @param string $key Specific metadata to retrieve.
+     *
+     * @return array|mixed|null Returns an associative array if no key is
+     *                          provided. Returns a specific key value if a key
+     *                          is provided and the value is found, or null if
+     *                          the key is not found.
+     * @see http://php.net/manual/en/function.stream-get-meta-data.php
+     */
+    public function getMetadata($key = null);
 }
 ```


### PR DESCRIPTION
Adds a `getMetadata()` method to the StreamInterface, as suggested by @mtdowling, and as originally defined at https://github.com/guzzle/streams/blob/3.0/src/StreamInterface.php#L142-L157
