### PR TITLE
[PSR-7] Remove `$maxLength` from StreamInterface::getContents()

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -499,7 +499,7 @@ interface StreamInterface
     public function read($length);
 
     /**
-     * Returns the remaining contents in a string, up to maxlength bytes.
+     * Returns the remaining contents in a string
      *
      * @return string
      */


### PR DESCRIPTION
Per @mtdowling, this will be rarely if ever be used, and actually makes implementations overly complex.
