### PR TITLE
[PSR-7] Clarification to StreamInterface::detach

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -415,7 +415,7 @@ interface StreamInterface
      *
      * After the stream has been detached, the stream is in an unusable state.
      *
-     * @return resource Underlying PHP stream
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach();
 


### PR DESCRIPTION
Per @mtdowling's comment on #331, this modifies the `detach()` method return annotation further to allow `null` as a valid return in cases where an actual stream is not wrapped by the implementing instance.
