### PR TITLE
Updated naming conventions for PSR-4

### DIFF
--- a/bylaws/002-psr-naming-conventions.md
+++ b/bylaws/002-psr-naming-conventions.md
@@ -4,7 +4,7 @@ Naming conventions for code released by PHP-FIG
 1. Interfaces MUST be suffixed by `Interface`: e.g. `Psr\Foo\BarInterface`.
 2. Abstract classes MUST be prefixed by `Abstract`: e.g. `Psr\Foo\AbstractBar`.
 3. Traits MUST be suffixed by `Trait`: e.g. `Psr\Foo\BarTrait`.
-4. PSR-0, 1 and 2 MUST be followed.
+4. PSR-1, 2 and 4 MUST be followed.
 5. The vendor namespace MUST be `Psr`.
 6. There MUST be a package/second-level namespace in relation with the PSR that
    covers the code.


### PR DESCRIPTION
Should we recommend PSR-4 for new standards, not PSR-0?

Also, is it needed to say PSR-1 since PSR-2 says you must follow PSR-1 to have PSR-2 valid code?
