### PR TITLE
[PSR-7] Add MessageInterface::setProtocolVersion()

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -130,6 +130,18 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
+     * Set the HTTP protocol version.
+     *
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
+     *
+     * @param string $version HTTP protocol version
+     *
+     * @return void
+     */
+    public function setProtocolVersion($version);
+
+    /**
      * Gets the body of the message.
      *
      * @return StreamableInterface|null Returns the body, or null if not set.


### PR DESCRIPTION
Per [discussion on the mailing list](https://groups.google.com/d/msgid/php-fig/cc4e5a30-f87d-4ce6-bbaa-8d86c10959db%40googlegroups.com), this patch adds a `setProtocolVersion()` method to the `MessageInterface`. Considering every other property of the message has both accessors and mutators, the lack of one for the protocol version was assymetric.
