### PR TITLE
[PSR-7] Clarify MessageInterface::getHeaders() return value

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -180,7 +180,15 @@ interface MessageInterface
      *         echo $name . ": " . implode(", ", $values);
      *     }
      *
-     * @return array Returns an associative array of the message's headers.
+     *     // Emit headers iteratively:
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         foreach ($values as $value) {
+     *             header(sprintf('%s: %s', $name, $value), false);
+     *         }
+     *     }
+     *
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings.
      */
     public function getHeaders();
 


### PR DESCRIPTION
Per [the mailing list](https://groups.google.com/d/msg/php-fig/H_NR7qctw-8/9jDffi4_j7cJ), clarified the return value of `getHeaders()` to indicate the structure of the returned array:
- Keys MUST be header names
- Values MUST be arrays of strings
