### PR TITLE
[PSR-7] Clarify MessageInterface header methods

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -226,8 +226,7 @@ interface MessageInterface
      * or an array of strings.
      *
      * @param string $header Header name
-     * @param string|string[] $value Header value(s). Values may be objects as
-     *                               long as they can be cast to strings.
+     * @param string|string[] $value Header value(s).
      *
      * @return void
      */
@@ -243,8 +242,7 @@ interface MessageInterface
      * value(s) will be appended to the existing list.
      *
      * @param string $header Header name to add
-     * @param string|string[] $value Header value(s). Values may be objects as
-     *                               long as they can be cast to strings.
+     * @param string|string[] $value Header value(s).
      *
      * @return void
      */


### PR DESCRIPTION
This edit contains a number of changes around the various header methods of the `MessageInterface` as proposed on the mailing list.

The original changes included syncing the `addHeaders()` and `setHeaders()` docblocks and behavior, and also clarifying that object header values MUST be cast to a string immediately.

The final changes proposed include:
- Removing `addHeaders()` and `setHeaders()` entirely; their behavior was ambiguous, and can be accomplished easily in userland.
- Modifying `addHeader()` and `setHeader()` to indicate that only strings and arrays of strings are valid arguments. Objects must be coerced to strings before being passed to these methods.

References:
- https://groups.google.com/d/msgid/php-fig/248eaec5-bf0b-4a8c-bdd1-66adb0992477%40googlegroups.com
- https://groups.google.com/d/msgid/php-fig/05dd990a-459e-4fa4-8617-04b820da51eb%40googlegroups.com
- https://groups.google.com/d/msg/php-fig/H_NR7qctw-8/EaBO5amhCSYJ
- https://groups.google.com/d/msg/php-fig/UaH3LZ1aw_I/tUEUI5ljGxQJ
