### PR TITLE
[PSR-7] Clarify superglobal usage

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -365,7 +365,7 @@ namespace Psr\Http\Message;
  * This interface further describes a server-side request and provides
  * accessors and mutators around common request data, such as query
  * string arguments, body parameters, upload file metadata, cookies, and
- * matched routing parameters.
+ * arbitrary attributes derived from the request.
  */
 interface IncomingRequestInterface extends RequestInterface
 {
@@ -378,10 +378,7 @@ interface IncomingRequestInterface extends RequestInterface
      * from PHP's $_COOKIE superglobal. The data IS NOT REQUIRED to come from
      * $_COOKIE, but MUST be compatible with the structure of $_COOKIE.
      *
-     * The return value can be either an array or an object that acts like
-     * an array (e.g., implements ArrayAccess, or an ArrayObject).
-     *
-     * @return array|\ArrayAccess
+     * @return array
      */
     public function getCookieParams();
 
@@ -394,11 +391,9 @@ interface IncomingRequestInterface extends RequestInterface
      * the original value, filter them, and re-inject into the incoming
      * request..
      *
-     * The value provided should be an array or array-like object
-     * (e.g., implements ArrayAccess, or an ArrayObject). The data MUST
-     * be compatible with the structure of $_COOKIE.
+     * The value provided MUST be compatible with the structure of $_COOKIE.
      *
-     * @param array|\ArrayAccess $cookies Cookie values/structs
+     * @param array $cookies Cookie values
      *
      * @return void
      */
@@ -417,9 +412,6 @@ interface IncomingRequestInterface extends RequestInterface
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
      *
-     * The return value can be either an array or an object that acts like
-     * an array (e.g., implements ArrayAccess, or an ArrayObject).
-     *
      * @return array
      */
     public function getQueryParams();
@@ -434,9 +426,6 @@ interface IncomingRequestInterface extends RequestInterface
      * request. They MAY be injected during instantiation, such as from PHP's
      * $_FILES superglobal, or MAY be derived from other sources.
      *
-     * The return value can be either an array or an object that acts like
-     * an array (e.g., implements ArrayAccess, or an ArrayObject).
-     *
      * @return array Upload file(s) metadata, if any.
      */
     public function getFileParams();
@@ -444,58 +433,52 @@ interface IncomingRequestInterface extends RequestInterface
     /**
      * Retrieve any parameters provided in the request body.
      *
-     * If the request body can be deserialized, and if the deserialized values
-     * can be represented as an array or object, this method can be used to
-     * retrieve them.
+     * If the request body can be deserialized to an array, this method can be
+     * used to retrieve them.
      *
      * In other cases, the parent getBody() method should be used to retrieve
      * the body content.
      *
-     * @return array|object The deserialized body parameters, if any. These may
-     *                      be either an array or an object, though an array or
-     *                      array-like object is recommended.
+     * @return array The deserialized body parameters, if any.
      */
     public function getBodyParams();
 
     /**
      * Set the request body parameters.
      *
-     * If the body content can be deserialized, the values obtained may then
-     * be injected into the response using this method. This method will
-     * typically be invoked by a factory marshaling request parameters.
+     * If the body content can be deserialized to an array, the values obtained
+     * may then be injected into the response using this method. This method
+     * will typically be invoked by a factory marshaling request parameters.
      *
-     * @param array|object $values The deserialized body parameters, if any.
-     *                             These may be either an array or an object,
-     *                             though an array or array-like object is
-     *                             recommended.
+     * @param array $values The deserialized body parameters, if any.
      *
      * @return void
      */
     public function setBodyParams($values);
 
     /**
-     * Retrieve parameters matched during routing.
+     * Retrieve attributes derived from the request.
      *
      * If a router or similar is used to match against the path and/or request,
      * this method can be used to retrieve the results, so long as those
-     * results can be represented as an array or array-like object.
+     * results can be represented as an array.
      *
-     * @return array|\ArrayAccess Path parameters matched by routing
+     * @return array Path parameters matched by routing
      */
-    public function getPathParams();
+    public function getAttributes();
 
     /**
-     * Set parameters discovered by matching that path
+     * Set attributes derived from the request
      *
      * If a router or similar is used to match against the path and/or request,
      * this method can be used to inject the request with the results, so long
-     * as those results can be represented as an array or array-like object.
+     * as those results can be represented as an array.
      *
-     * @param array|\ArrayAccess $values Path parameters matched by routing
+     * @param array $attributes Path parameters matched by routing
      *
      * @return void
      */
-    public function setPathParams(array $values);
+    public function setAttributes(array $attributes);
 }
 ```
 


### PR DESCRIPTION
Per [this thread](https://groups.google.com/d/msgid/php-fig/543C8821.7070602%40garfieldtech.com):
- Updated `getQueryParams()` to indicate that the value MAY come from `$_GET`, but may come from other sources, but MUST follow the same structure as `$_GET`.
- Updated `(get|set)CookieParams()` to indicate that the value MAY come from `$_COOKIE`, but may come from other sources, but MUST follow the same structure as `$_COOKIE`.
- Updated `getFileParams()` to indicate that the value MAY come from `$_FILES`, but may come from other sources, but MUST follow the same structure as `$_FILES`.

Per [this thread](https://groups.google.com/d/msgid/php-fig/543D4262.5010703%40garfieldtech.com):
- Updated `getQueryParams()` to indicate that if the value injected is from the URI, the same rules that PHP's `parse_str()` would use should be followed when dealing with duplicate query parameters and nested values.

Per [this thread](https://groups.google.com/d/msg/php-fig/jKOsGn_-vz8/qYyITzVsC1gJ):
- Updated `(get|set)BodyParams()` to ONLY use arrays, not objects. This means that you can only inject deserialized body parameters IF they can be coerced to an array. Note: you can get creative with this, and do something like `$request->setBodyParams([ 'payload' => $anObject ]);`. The point is having a consistent mechanism.
- Updated all methods in the `IncomingRequestInterface` to stipulate that arrays ONLY are accepted or returned; again, this is for consistency of implementation.
- Renamed `(get|set)PathParams()` to `(get|set)Attributes()`, per a suggestion from @simensen; the docblock was updated to indicate "attributes derived from the request."
