### PR TITLE
Fixed autoload fuction name

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -54,7 +54,7 @@ proposed standards are autoloaded.
 ```php
 <?php
 
-function autoload($className)
+function __autoload($className)
 {
     $className = ltrim($className, '\\');
     $fileName  = '';


### PR DESCRIPTION
Function autoload must be called __autoload See this: http://php.net/manual/en/function.autoload.php
