### PR TITLE
[PSR-7] Message body MUST be Streamable

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -531,14 +531,13 @@ interface OutgoingResponseInterface extends MessageInterface
     /**
      * Sets the body of the message.
      *
-     * The body MUST be a StreamableInterface object. Setting the body to null MUST
-     * remove the existing body.
+     * The body MUST be a StreamableInterface object.
      *
-     * @param StreamableInterface|null $body Body.
+     * @param StreamableInterface $body Body.
      * @return void
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function setBody(StreamableInterface $body = null);
+    public function setBody(StreamableInterface $body);
 }
 ```
 
@@ -662,14 +661,13 @@ interface OutgoingRequestInterface extends MessageInterface
     /**
      * Sets the body of the message.
      *
-     * The body MUST be a StreamableInterface object. Setting the body to null MUST
-     * remove the existing body.
+     * The body MUST be a StreamableInterface object.
      *
-     * @param StreamableInterface|null $body Body.
+     * @param StreamableInterface $body Body.
      * @return void
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function setBody(StreamableInterface $body = null);
+    public function setBody(StreamableInterface $body);
 }
 ```
 


### PR DESCRIPTION
Missed this one with the last round of updates: per discussion on the mailing list, we're no longer allowing the possibility of null message bodies; they MUST be StreamableInterface instances.
