### PR TITLE
[PSR-7] Clarifications

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -124,6 +124,21 @@ internal implementation of how a message manages its headers, and has a
 side-effect that messages are no longer aware of changes to their headers. This
 can lead to messages entering into an invalid or inconsistent state.
 
+#### Why are header values stored as arrays?
+
+RFC7230 indicates that headers MAY have multiple values; in some cases, this is
+accomplished via comma-separated values, and in others, by emitting multiple
+headers of the same name. Common headers with multiple values include `Accept`,
+`Cookie`, and `Set-Cookie`.
+
+Because multiple values may be present, and in order to ensure consistency, this
+proposal mandates header values as arrays when considering header return values.
+The consumer may then decide how to represent/consume them (e.g., using
+`array_reduce()`, or `implode()`, or emitting one at a time via `header()`).
+Having a consistent return value ensures predictability when consuming headers,
+preventing the need for conditional checking of the values when working with
+them.
+
 #### Mutability of messages
 
 The proposal models "context-specific" mutability. This means that a message is mutable based on its context. For example:

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -104,7 +104,7 @@ Note: Not all header values can be concatenated using a comma (e.g.,
 `MessageInterface`-based classes SHOULD rely on the `getHeaderAsArray()` method
 for retrieving such multi-valued headers.
 
-### 1.2 Streams
+### 1.3 Streams
 
 HTTP messages consist of a start-line, headers, and a body. The body of an HTTP
 message can be very small or extremely large. Attempting to represent the body


### PR DESCRIPTION
- Fixed number ordering in sections (specifically, "HTTP Headers" and "Streams" had the same number previously).
- Added clarifications in the meta document about why header valuess are stored as arrays internally and returned as arrays from `getHeaders()`.