### PR TITLE
[PSR-7] Revert to original(-ish) interfaces

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -5,10 +5,11 @@ HTTP Message Meta Document
 ----------
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
-messages as described in [RFC 7230] and [RFC 7231].
+messages as described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
+[RFC 7231](http://tools.ietf.org/html/rfc7231).
 
-[RFC 7230]: http://www.ietf.org/rfc/rfc7230.txt
-[RFC 7231]: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
+- RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
 
 All HTTP messages consist of the HTTP protocol version being used, headers, and
 a message body. A _Request_ builds on the message to include the HTTP method
@@ -77,6 +78,7 @@ messages.
 
 * Provide the interfaces needed for describing HTTP messages.
 * Keep the interfaces as minimal as possible.
+* Focus on practical applications and usability.
 * Ensure that the API does not impose arbitrary limits on HTTP messages. For
   example, some HTTP message bodies can be too large to store in memory, so we
   must account for this.
@@ -109,7 +111,10 @@ messages, whether they are for requests or responses. These elements include:
 More specific interfaces are used to describe requests and responses, and more
 specifically the context of each (client- vs. server-side). These divisions are
 partly inspired by existing PHP usage, but also by other languages such as
-Ruby, Python, Go, Node, etc.
+Ruby's [Rack](https://rack.github.io),
+Python's [WSGI](https://www.python.org/dev/peps/pep-0333/),
+Go's [http package](http://golang.org/pkg/net/http/),
+Node's [http module](http://nodejs.org/api/http.html), etc.
 
 #### Why are there header methods on messages rather than in a header bag?
 
@@ -126,18 +131,7 @@ can lead to messages entering into an invalid or inconsistent state.
 
 #### Mutability of messages
 
-The proposal models "context-specific" mutability. This means that a message is mutable based on its context. For example:
-
-- Client-side requests are mutable, as they will be iterably built before being
-  sent.
-- Client-side responses are immutable, as they represent the result of a
-  request that has been made; changing the result would lead to inconsistent
-  state when multiple processes are passed the message.
-- Server-side requests are immutable, as they represent the state of the
-  current incoming request; changes to the message would lead to inconsistent
-  state when multiple processes are passed the message.
-- Server-side responses are mutable, as they are built iterably before being
-  returned to the client.
+The proposal models mutable messages.
 
 Real-world usage in clients requires mutable requests. As an example, most HTTP
 clients allow you to modify a request pre-flight in order to implement custom
@@ -156,34 +150,58 @@ This is not just a popular pattern in the PHP community:
 * Java's HttpClient: http://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/http/examples/client/ClientGZipContentCompression.java
 * etc...
 
+Moreover, most HTTP clients prefer mutable responses for a variety of reasons.
+As an example, the client may return the raw response, but allow passing it
+through pluggable filters in order to perform actions such as decompression,
+file extraction, deserialization, etc. Modeling the messages as immutable would
+dictate architecture and limit adoption in these scenarios.
+
 On the server-side, the application will write to the response instance in
 order to populate it before sending it back to the client. This is particularly
 useful when considering the fact that headers can no longer be emitted once
 _any_ output has been sent; aggregating headers and content in a response
 object is a useful and typically necessary abstraction.
 
-While server-side requests are primarily immutable, we have noted one element
-or property as _mutable_: "attributes". Most server-side applications utilize
-processes that match the request to specific criteria -- such as path segments,
-subdomains, etc. -- and then push the derived matches back into the request
-itself. Since these processes need to introspect the populated request, and are
-a product of the application itself, the proposal allows this property to be
-mutable. Possible use cases include:
+An argument can be made that server-side requests should be immutable, in order
+to reflect the request state at application initialization. However, this argument
+fails to address many real-world scenarios:
 
-* Body parameters are often "discovered" via deserialization of the incoming
-  request body, and the serialization method will need to be determined by
-  introspecting incoming `Content-Type` headers.
-* Cookies may be encrypted, and a process may decrypt them and re-inject them
-  into the request for later collaborators to access.
-* Routing and other tools are often used to "discover" request attributes (e.g.,
-  decomposing the URL `/user/phil` to assign the value "phil" to the attribute
-  "user"). Such logic is application-specific, but still considered part of the
-  request state; it can only be injected after instantiation.
+- PHP itself models the `$_GET`, `$_POST`, and `$_COOKIE` superglobals as mutable.
+- `$_POST` only models form-encoded data sent via POST. While this is arguably
+  still the most common scenario for web-submitted data, it fails to address the
+  very common needs of APIs, which may use methods such as PUT, PATCH, and DELETE
+  to submit data, and which are likely submitting JSON or XML. Since content type
+  can only be determined by inspecting the request itself, deserialization of
+  such body content can only happen within the application layer - suggesting
+  that body content parameters must be mutable.
+- Cookie encryption, while an arguable practice, is very common in modern
+  frameworks. For the practice to work, the cookie data must be mutable.
 
-Having context-specific mutability ensures the consistency of client-side
-responses and server-side requests, while simultaneously allowing for the full
-spectrum of operations on their counterparts, which are the product of the
-applications.
+Cookies, query string arguments, and body parameters can always be
+re-calculated from sources such as the `$_SERVER` superglobal, request content
+body, or even the URL. As such, we also include server parameters in the
+server request interface, but as an immutable property.
+
+One input source cannot be calculated at runtime, however: upload files.
+Technically, they _can_, but the logic for doing so is non-trivial, resource
+intensive, and prone to error. As such, we also model this input source as
+immutable.
+
+We note one element outside these input sources: "attributes". Most server-side
+applications utilize processes that match the request to specific criteria --
+such as path segments, subdomains, etc. -- and then push the derived matches
+back into the request itself. Since these processes need to introspect the
+populated request, and are a product of the application itself, the proposal
+allows this property to be mutable.
+
+Finally, we note that we chose mutability as a usability concern. Without
+mutability, the only way to accomplish some of the above scenarios -- body
+parameter deserialization and re-injection, cookie decryption, etc. -- would
+be through usage of proxies and decorators. While these concepts are not
+terribly difficult to accomplish, they are non-obvious and non-trivial for
+a plurality of PHP developers, for whom even basic OOP is often a new or
+arcane concept. Having mutable members simplifies usage, and should speed
+adoption of the interfaces.
 
 ### Using streams instead of X
 
@@ -218,13 +236,13 @@ like `isReadable()`, `isWritable()`, etc. This approach is used by Python,
 [Ruby](http://www.ruby-doc.org/core-2.0.0/IO.html),
 [Node](http://nodejs.org/api/stream.html), and likely others.
 
-#### Rationale for IncomingRequestInterface
+#### Rationale for ServerRequestInterface
 
-The `OutgoingRequestInterface`, `IncomingResponseInterface`, and
-`OutgoingResponseInterface`, have essentially 1:1 correlations with the request
-and response messages described in [RFC 7230](http://www.ietf.org/rfc/rfc7230.txt)
-They provide interfaces for implementing value objects that correspond to the
-specific HTTP message types they model.
+The `RequestInterface` and `ResponseInterface` have essentially 1:1
+correlations with the request and response messages described in
+[RFC 7230](http://www.ietf.org/rfc/rfc7230.txt) They provide interfaces for
+implementing value objects that correspond to the specific HTTP message types
+they model.
 
 For server-side applications, however, there are other considerations for
 incoming requests:
@@ -244,7 +262,7 @@ incoming requests:
 
 Uniform access to these parameters increases the viability of interoperability
 between frameworks and libraries, as they can now assume that if a request
-implements `IncomingRequestInterface`, they can get at these values. It also
+implements `ServerRequestInterface`, they can get at these values. It also
 solves problems within the PHP language itself:
 
 - Until 5.6.0, `php://input` was read-once; as such, instantiating multiple
@@ -253,12 +271,13 @@ solves problems within the PHP language itself:
   one to receive the data.
 - Unit testing against superglobals (e.g., `$_GET`, `$_FILES`, etc.) is
   difficult and typically brittle. Encapsulating them inside the
-  `IncomingRequestInterface` implementation eases testing considerations.
+  `ServerRequestInterface` implementation eases testing considerations.
 
-The interface as defined provides no mutators other than for derived
-attributes. The assumption is that values either (a) may be injected at
-instantiation from superglobals, and (b) should not change over the course of
-the incoming request.
+The interface as defined marks server and file parameters as _immutable_ as
+these are the values provided by PHP at the start of the request. The other
+parameters are all _mutable_, either to reflect mutability of the
+corresponding superglobal, or because the values can be calculated from the
+other input sources composed in the request.
 
 #### What about "special" header values?
 
@@ -278,6 +297,35 @@ Examples of this practice already exist in libraries such as
 [aura/accept](https://github.com/pmjones/Aura.Accept). So long as the object
 has functionality for casting the value to a string, these objects can be
 used to populate the headers of an HTTP message.
+
+#### Why the distinction between URL and base URL?
+
+[RFC 7230, section 5.3](http://tools.ietf.org/html/rfc7230#section-5.3)
+indicates that the target of a request can be one of four forms. The first,
+"origin-form," is the path and the query string, and often termed the "relative
+URL." The next three all include the scheme and host, and, if present, the
+authentication information and port; these can be referred to as "absolute
+URIs."
+
+For consistency and predictability, we can only return one form from the
+`getUrl()` method of a request.
+
+In many cases, proxies, local applications, etc. will not have anything but
+a relative URL available, so forcing `getUrl()` to return an absolute URI
+would pose a problem; implementors would either need to hard-code the scheme
+and host -- and thus effectively return false information -- or raise an
+error for what is an expected situation.
+
+For server-side applications, however, not returning the scheme, port, and
+host can also be problematic. These values often need to be calculated from
+the server environment (e.g., when the server is behind a proxy; when using
+URL rewriting on some server environments; etc.), and the messages should
+abstract these operations as much as possible.
+
+The solution presented is to have a separate "base URL" property for holding
+the other URL artifacts. This allows using the messages in application
+environments where the absolute URI is unknown or un-needed, while providing
+the information when it is desired.
 
 5. People
 ---------

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -176,6 +176,7 @@ fails to address many real-world scenarios:
   that body content parameters must be mutable.
 - Cookie encryption, while an arguable practice, is very common in modern
   frameworks. For the practice to work, the cookie data must be mutable.
+- Streams, per definition, cannot be immutable.
 
 Cookies, query string arguments, and body parameters can always be
 re-calculated from sources such as the `$_SERVER` superglobal, request content

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -2,15 +2,16 @@
 =======================
 
 This document describes common interfaces for representing HTTP messages as
-described in [RFC 7230] and [RFC 7231].
+described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
+[RFC 7231](http://tools.ietf.org/html/rfc7231).
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119].
+interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
-[RFC 2119]: http://www.ietf.org/rfc/rfc2119.txt
-[RFC 7230]: http://www.ietf.org/rfc/rfc7230.txt
-[RFC 7231]: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 2119: http://www.ietf.org/rfc/rfc2119.txt
+- RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
+- RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
 
 1. Specification
 ----------------
@@ -18,39 +19,42 @@ interpreted as described in [RFC 2119].
 ### 1.1 Messages
 
 An HTTP message is either a request from a client to a server or a response from
-a server to a client. This specification defines two pairs of interfaces for
-HTTP messages based on context:
+a server to a client. This specification defines interfaces for the HTTP messages
+`Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface` respectively.
 
-- Client-Side (i.e., making an HTTP request from PHP):
-  - `Psr\Http\Message\OutgoingRequestInterface`
-  - `Psr\Http\Message\IncomingResponseInterface`
-- Server-Side (i.e., processing a request made to a resource handled by PHP)
-  - `Psr\Http\Message\IncomingRequestInterface`
-  - `Psr\Http\Message\OutgoingResponseInterface`
+Both `Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface` extend
+`Psr\Http\Message\MessageInterface`. While `Psr\Http\Message\MessageInterface` MAY be
+implemented directly, implementors are encouraged to implement
+`Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface`.
 
-All of the above messages extend a base `Psr\Http\Message\MessageInterface`,
-which defines accessors for properties common across all implementations. While
-`Psr\Http\Message\MessageInterface` MAY be implemented directly, implementors are
-encouraged to implement one or both pairs of request/response interfaces, and
-consumers are encouraged to typehint on the relevant request/response interfaces.
 
-Interfaces are segregated by context. For HTTP client applications, the request is
-mutable, to allow consumers to incrementally build the request before sending it; the
-response, however, is immutable, as it is the product of an operation. Similarly, for
-server-side applications, the request is immutable and represents the specifics
-of the HTTP request made to the server; the response, however, will be incrementally
-built by the application prior to sending it back to the client.
+An additional interface, `Psr\Http\Message\ServerRequestInterface`, extends
+`Psr\Http\Message\RequestInterface` to model the various PHP superglobals and
+provide access to the various request input sources. These include:
 
-The `Psr\Http\Message\IncomingRequestInterface`, since it represents the incoming
-PHP request environment, is intended to model the various PHP superglobals.
+- cookies (`$_COOKIE`)
+- query string arguments (`$_GET`)
+- body parameters (typically `$_POST`, but these could be deserialized JSON or
+  other payloads)
+- file uploads (`$_FILES`)
+- the server environment (`$_SERVER`)
+
 This practice helps reduce coupling to the superglobals by consumers, and
-encourages and promotes the ability to test request consumers. The interface
-purposely does not provide mutators for the various superglobal properties to
-encourage treating them as immutable. However, it does provide one mutable
-property, "attributes", to allow consumers the ability to introspect,
-decompose, and match the request against application-specific rules (such as
-path matching, cookie decryption, etc.). As such, the request can also provide
-messaging between multiple request consumers.
+encourages and promotes the ability to test request consumers.
+
+Server variables and file upload information are considered immutable, as they
+are calculated by PHP and cannot be re-calculated or derived within the same
+request. Cookies, query string arguments, and body parameters, however, are
+mutable to reflect the mutable state of their corresponding superglobals, and
+to allow for common practices such as body deserialization, cookie decryption,
+etc. If the original values are desired, they can be retrieved from the server
+parameters and/or request body.
+
+The server request provides one additional mutable property, "attributes", to
+allow consumers the ability to introspect, decompose, and match the request
+against application-specific rules (such as path matching, scheme matching,
+host matching, etc.). As such, the request can also provide messaging between
+multiple request consumers.
 
 From here forward, the namespace `Psr\Http\Message` will be omitted when
 referring to these interfaces.
@@ -84,9 +88,9 @@ In order to accommodate headers with multiple values yet still provide the
 convenience of working with headers as strings, headers can be retrieved from
 an instance of a ``MessageInterface`` as an array or string. Use the
 `getHeader()` method to retrieve a header value as a string containing all
-header values of a header by name concatenated with a comma.
-Use `getHeaderAsArray()` to retrieve an array of all the header values for a
-particular header by name.
+header values of a case-insensitive header by name concatenated with a comma.
+Use `getHeaderLines()` to retrieve an array of all the header values for a
+particular case-insensitive header by name.
 
 ```php
 $message->setHeader('foo', 'bar');
@@ -95,13 +99,13 @@ $message->addHeader('foo', 'baz');
 $header = $message->getHeader('foo');
 // $header contains: 'bar, baz'
 
-$header = $message->getHeaderAsArray('foo');
-// $header contains: ['bar', 'baz']
+$header = $message->getHeaderLines('foo');
+// ['bar', 'baz']
 ```
 
 Note: Not all header values can be concatenated using a comma (e.g.,
 `Set-Cookie`). When working with such headers, consumers of
-`MessageInterface`-based classes SHOULD rely on the `getHeaderAsArray()` method
+`MessageInterface`-based classes SHOULD rely on the `getHeaderLines()` method
 for retrieving such multi-valued headers.
 
 ### 1.2 Streams
@@ -168,15 +172,15 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
-     * Gets the body of the message.
+     * Set the HTTP protocol version.
      *
-     * The returned body MUST be an instance of StreamableInterface. This may
-     * require that the implementation create a stream if none has been 
-     * set previously.
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
      *
-     * @return StreamableInterface Returns the body, or null if not set.
+     * @param string $version HTTP protocol version
+     * @return void
      */
-    public function getBody();
+    public function setProtocolVersion($version);
 
     /**
      * Gets all message headers.
@@ -232,15 +236,177 @@ interface MessageInterface
      * @param string $header Case-insensitive header name.
      * @return string[]
      */
-    public function getHeaderAsArray($header);
+    public function getHeaderLines($header);
+
+    /**
+     * Sets a header, replacing any existing values of any headers with the
+     * same case-insensitive name.
+     *
+     * The header name is case-insensitive. The header values MUST be a string
+     * or an array of strings.
+     *
+     * @param string $header Header name
+     * @param string|string[] $value Header value(s).
+     * @return void
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function setHeader($header, $value);
+
+    /**
+     * Appends a header value for the specified header.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list.
+     *
+     * @param string $header Header name to add
+     * @param string|string[] $value Header value(s).
+     * @return void
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function addHeader($header, $value);
+
+    /**
+     * Remove a specific header by case-insensitive name.
+     *
+     * @param string $header HTTP header to remove
+     * @return void
+     */
+    public function removeHeader($header);
+
+    /**
+     * Gets the body of the message.
+     *
+     * @return StreamableInterface|null Returns the body, or null if not set.
+     */
+    public function getBody();
+
+    /**
+     * Sets the body of the message.
+     *
+     * The body MUST be a StreamableInterface object.
+     *
+     * @param StreamableInterface $body Body.
+     * @return void
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function setBody(StreamableInterface $body);
 }
 ```
 
-### 3.2 Server-Side messages
+### 3.2 `Psr\Http\Message\RequestInterface`
 
-The `IncomingRequestInterface` and `OutgoingResponseInterface` describe the messages used when handling an incoming HTTP request via PHP.
+```php
+<?php
 
-#### 3.2.1 `Psr\Http\Message\IncomingRequestInterface`
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an outgoing, client-side request.
+ *
+ * Per the HTTP specification, this interface includes both accessors for
+ * and mutators for the following:
+ *
+ * - Protocol version
+ * - HTTP method
+ * - URL
+ * - Headers
+ * - Message body
+ *
+ * As the request CAN be built iteratively, the interface allows
+ * mutability of all properties.
+ */
+interface RequestInterface extends MessageInterface
+{
+    /**
+     * Retrieves the HTTP method of the request.
+     *
+     * @return string Returns the request method.
+     */
+    public function getMethod();
+
+    /**
+     * Sets the HTTP method to be performed on the resource identified by the
+     * Request-URI.
+     *
+     * While HTTP method names are typically all uppercase characters, HTTP
+     * method names are case-sensitive and thus implementations SHOULD NOT
+     * modify the given string.
+     *
+     * @param string $method Case-insensitive method.
+     * @return void
+     * @throws \InvalidArgumentException for invalid HTTP methods.
+     */
+    public function setMethod($method);
+
+    /**
+     * Retrieves the base request URL.
+     *
+     * The base URL consists of:
+     *
+     * - scheme
+     * - authentication (if any)
+     * - server name/host
+     * - port (if non-standard)
+     *
+     * This method is provided for convenience, particularly when considering
+     * server-side requests, where data such as the scheme and server name may
+     * need to be computed from more than one environmental variable.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @return string Returns the base URL as a string. The URL MUST include
+     *     the scheme and host; if the port is non-standard for the scheme,
+     *     the port MUST be included; authentication data MAY be provided.
+     */
+    public function getBaseUrl();
+
+    /**
+     * Sets the base request URL.
+     *
+     * The base URL MUST be a string, and MUST include the scheme and host.
+     *
+     * If the port is non-standard for the scheme, the port MUST be provided.
+     *
+     * Authentication data MAY be provided.
+     *
+     * If path, query string, or URL fragment are provided they SHOULD be
+     * stripped; optionally, an error MAY be raised in such situations.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @param string $url Base request URL.
+     * @return void
+     * @throws \InvalidArgumentException If the URL is invalid.
+     */
+    public function setBaseUrl($url);
+
+    /**
+     * Retrieves the request URL.
+     *
+     * The request URL is the same value as REQUEST_URI: the path and query
+     * string ONLY.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3
+     * @return string Returns the URL as a string. The URL MUST be an
+     *     origin-form (path + query string), per RFC 7230 section 5.3
+     */
+    public function getUrl();
+
+    /**
+     * Sets the request URL.
+     *
+     * The URL MUST be a string. The URL SHOULD be an origin-form (path + query
+     * string) per RFC 7230 section 5.3; if other URL parts are present, the
+     * method MUST raise an exception OR remove those parts.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3
+     * @param string $url Request URL, with path and optionally query string.
+     * @return void
+     * @throws \InvalidArgumentException If the URL is invalid.
+     */
+    public function setUrl($url);
+}
+```
+
+#### 3.2.1 `Psr\Http\Message\ServerRequestInterface`
 
 ```php
 <?php
@@ -259,7 +425,7 @@ namespace Psr\Http\Message;
  * - Headers
  * - Message body
  *
- * Additionally, it encapsulates all data as it has arrived to the 
+ * Additionally, it encapsulates all data as it has arrived to the
  * application from the PHP environment, including:
  *
  * - The values represented in $_SERVER.
@@ -268,40 +434,27 @@ namespace Psr\Http\Message;
  * - Upload files, if any (as represented by $_FILES)
  * - Deserialized body parameters (generally from $_POST)
  *
- * The above values MUST be immutable, in order to ensure that all consumers of
- * the request instance within a given request cycle receive the same information.
+ * $_SERVER and $_FILES values MUST be treated as immutable, as they represent
+ * application state at the time of request. The other values SHOULD be
+ * mutable, as they can be restored from $_SERVER, $_FILES, or the request
+ * body, and may need treatment during the application (e.g., body parameters
+ * may be deserialized based on content type).
  *
  * Additionally, this interface recognizes the utility of introspecting a
- * request to derive and match additional parameters (e.g., via URI path 
+ * request to derive and match additional parameters (e.g., via URI path
  * matching, decrypting cookie values, deserializing non-form-encoded body
  * content, matching authorization headers to users, etc). These parameters
  * are stored in an "attributes" property, which MUST be mutable.
  */
-interface IncomingRequestInterface extends MessageInterface
+interface ServerRequestInterface extends RequestInterface
 {
-    /**
-     * Retrieves the HTTP method of the request.
-     *
-     * @return string Returns the request method.
-     */
-    public function getMethod();
-
-    /**
-     * Retrieves the request URL.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the URL as a string. The URL SHOULD be an absolute
-     *     URI as specified in RFC 3986, but MAY be a relative URI.
-     */
-    public function getUrl();
-
     /**
      * Retrieve server parameters.
      *
-     * Retrieves data related to the incoming request environment, 
-     * typically derived from PHP's $_SERVER superglobal. The data IS NOT 
+     * Retrieves data related to the incoming request environment,
+     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
      * REQUIRED to originate from $_SERVER.
-     * 
+     *
      * @return array
      */
     public function getServerParams();
@@ -311,18 +464,38 @@ interface IncomingRequestInterface extends MessageInterface
      *
      * Retrieves cookies sent by the client to the server.
      *
-     * The assumption is these are injected during instantiation, typically
-     * from PHP's $_COOKIE superglobal. The data IS NOT REQUIRED to come from
-     * $_COOKIE, but MUST be compatible with the structure of $_COOKIE.
+     * The data MUST be compatible with the structure of the $_COOKIE
+     * superglobal.
      *
      * @return array
      */
     public function getCookieParams();
 
     /**
+     * Set cookies.
+     *
+     * Set cookies sent by the client to the server.
+     *
+     * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
+     * be compatible with the structure of $_COOKIE. Typically, this data will
+     * be injected at instantiation.
+     *
+     * @param array $cookies Array of key/value pairs representing cookies.
+     * @return void
+     */
+    public function setCookieParams(array $cookies);
+
+    /**
      * Retrieve query string arguments.
      *
      * Retrieves the deserialized query string arguments, if any.
+     *
+     * @return array
+     */
+    public function getQueryParams();
+
+    /**
+     * Set query string arguments.
      *
      * These values SHOULD remain immutable over the course of the incoming
      * request. They MAY be injected during instantiation, such as from PHP's
@@ -332,9 +505,11 @@ interface IncomingRequestInterface extends MessageInterface
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
      *
-     * @return array
+     * @param array $query Array of query string arguments, typically from
+     *     $_GET.
+     * @return void
      */
-    public function getQueryParams();
+    public function setQueryParams(array $query);
 
     /**
      * Retrieve the upload file metadata.
@@ -342,9 +517,9 @@ interface IncomingRequestInterface extends MessageInterface
      * This method MUST return file upload metadata in the same structure
      * as PHP's $_FILES superglobal.
      *
-     * These values SHOULD remain immutable over the course of the incoming
-     * request. They MAY be injected during instantiation, such as from PHP's
-     * $_FILES superglobal, or MAY be derived from other sources.
+     * These values MUST remain immutable over the course of the incoming
+     * request. They SHOULD be injected during instantiation, such as from PHP's
+     * $_FILES superglobal, but MAY be derived from other sources.
      *
      * @return array Upload file(s) metadata, if any.
      */
@@ -354,13 +529,27 @@ interface IncomingRequestInterface extends MessageInterface
      * Retrieve any parameters provided in the request body.
      *
      * If the request body can be deserialized to an array, this method MAY be
-     * used to retrieve them. These MAY be injected during instantiation from
-     * PHP's $_POST superglobal. The data IS NOT REQUIRED to come from $_POST,
-     * but MUST be an array.
+     * used to retrieve them.
      *
      * @return array The deserialized body parameters, if any.
      */
     public function getBodyParams();
+
+    /**
+     * Set parameters provided in the request body.
+     *
+     * These MAY be injected during instantiation from PHP's $_POST
+     * superglobal. The data IS NOT REQUIRED to come from $_POST, but MUST be
+     * an array. This method can be used during the request lifetime to inject
+     * parameters discovered and/or deserialized from the request body; as an
+     * example, if content negotiation determines that the request data is
+     * a JSON payload, this method could be used to inject the deserialized
+     * parameters.
+     *
+     * @param array $params The deserialized body parameters.
+     * @return void
+     */
+    public function setBodyParams(array $params);
 
     /**
      * Retrieve attributes derived from the request.
@@ -377,11 +566,11 @@ interface IncomingRequestInterface extends MessageInterface
 
     /**
      * Retrieve a single derived request attribute.
-     * 
+     *
      * Retrieves a single derived request attribute as described in
      * getAttributes(). If the attribute has not been previously set, returns
      * the default value as provided.
-     * 
+     *
      * @see getAttributes()
      * @param string $attribute Attribute name.
      * @param mixed $default Default value to return if the attribute does not exist.
@@ -403,7 +592,7 @@ interface IncomingRequestInterface extends MessageInterface
 
     /**
      * Set a single derived request attribute.
-     * 
+     *
      * This method allows setting a single derived request attribute as
      * described in getAttributes().
      *
@@ -416,7 +605,7 @@ interface IncomingRequestInterface extends MessageInterface
 }
 ```
 
-#### 3.2.2 `Psr\Http\Message\OutgoingResponseInterface`
+### 3.3 `Psr\Http\Message\ResponseInterface`
 
 ```php
 <?php
@@ -437,19 +626,8 @@ namespace Psr\Http\Message;
  * As the response CAN be built iteratively, the interface allows
  * mutability of all properties.
  */
-interface OutgoingResponseInterface extends MessageInterface
+interface ResponseInterface extends MessageInterface
 {
-    /**
-     * Set the HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * @param string $version HTTP protocol version
-     * @return void
-     */
-    public function setProtocolVersion($version);
-
     /**
      * Gets the response Status-Code.
      *
@@ -476,232 +654,6 @@ interface OutgoingResponseInterface extends MessageInterface
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
     public function setStatus($code, $reasonPhrase = null);
-
-    /**
-     * Gets the response Reason-Phrase, a short textual description of the Status-Code.
-     *
-     * Because a Reason-Phrase is not a required element in a response
-     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * Status-Code.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string|null Reason phrase, or null if unknown.
-     */
-    public function getReasonPhrase();
-
-    /**
-     * Sets a header, replacing any existing values of any headers with the
-     * same case-insensitive name.
-     *
-     * The header name is case-insensitive. The header values MUST be a string
-     * or an array of strings.
-     *
-     * @param string $header Header name
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * Appends a header value for the specified header.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list.
-     *
-     * @param string $header Header name to add
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function addHeader($header, $value);
-
-    /**
-     * Remove a specific header by case-insensitive name.
-     *
-     * @param string $header HTTP header to remove
-     * @return void
-     */
-    public function removeHeader($header);
-
-    /**
-     * Sets the body of the message.
-     *
-     * The body MUST be a StreamableInterface object.
-     *
-     * @param StreamableInterface $body Body.
-     * @return void
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function setBody(StreamableInterface $body);
-}
-```
-
-### 3.3 Client-Side Messages
-
-The `OutgoingRequestInterface` and `IncomingResponseInterface` describe messages associated with making an HTTP request from PHP.
-
-#### 3.3.1 `Psr\Http\Message\OutgoingRequestInterface`
-
-```php
-<?php
-
-namespace Psr\Http\Message;
-
-/**
- * Representation of an outgoing, client-side request.
- * 
- * Per the HTTP specification, this interface includes both accessors for
- * and mutators for the following:
- *
- * - Protocol version
- * - HTTP method
- * - URL
- * - Headers
- * - Message body
- *
- * As the request CAN be built iteratively, the interface allows
- * mutability of all properties.
- */
-interface OutgoingRequestInterface extends MessageInterface
-{
-    /**
-     * Set the HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * @param string $version HTTP protocol version
-     * @return void
-     */
-    public function setProtocolVersion($version);
-
-    /**
-     * Retrieves the HTTP method of the request.
-     *
-     * @return string Returns the request method.
-     */
-    public function getMethod();
-
-    /**
-     * Sets the HTTP method to be performed on the resource identified by the
-     * Request-URI.
-     *
-     * While HTTP method names are typically all uppercase characters, HTTP
-     * method names are case-sensitive and thus implementations SHOULD NOT
-     * modify the given string.
-     *
-     * @param string $method Case-insensitive method.
-     * @return void
-     * @throws \InvalidArgumentException for invalid HTTP methods.
-     */
-    public function setMethod($method);
-
-    /**
-     * Retrieves the request URL.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the URL as a string. The URL SHOULD be an
-     *     absolute URI as specified in RFC 3986, but MAY be a relative URI.
-     */
-    public function getUrl();
-
-    /**
-     * Sets the request URL.
-     *
-     * The URL MUST be a string. The URL SHOULD be an absolute URI as specified
-     * in RFC 3986, but MAY be a relative URI.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param string $url Request URL.
-     * @return void
-     * @throws \InvalidArgumentException If the URL is invalid.
-     */
-    public function setUrl($url);
-
-    /**
-     * Sets a header, replacing any existing values of any headers with the
-     * same case-insensitive name.
-     *
-     * The header name is case-insensitive. The header values MUST be a string
-     * or an array of strings.
-     *
-     * @param string $header Header name
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * Appends a header value for the specified header.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list.
-     *
-     * @param string $header Header name to add
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function addHeader($header, $value);
-
-    /**
-     * Remove a specific header by case-insensitive name.
-     *
-     * @param string $header HTTP header to remove
-     * @return void
-     */
-    public function removeHeader($header);
-
-    /**
-     * Sets the body of the message.
-     *
-     * The body MUST be a StreamableInterface object.
-     *
-     * @param StreamableInterface $body Body.
-     * @return void
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function setBody(StreamableInterface $body);
-}
-```
-
-#### 3.3.2 `Psr\Http\Message\IncomingResponseInterface`
-
-```php
-<?php
-
-namespace Psr\Http\Message;
-
-/**
- * Representation of an incoming, client-side response.
- * 
- * Per the HTTP specification, this interface includes accessors for
- * the following:
- *
- * - Protocol version
- * - Status code and reason phrase
- * - Headers
- * - Message body
- *
- * As the response is the result of making a request, it is considered
- * immutable.
- */
-interface IncomingResponseInterface extends MessageInterface
-{
-    /**
-     * Gets the response Status-Code.
-     *
-     * The Status-Code is a 3-digit integer result code of the server's attempt
-     * to understand and satisfy the request.
-     *
-     * @return integer Status code.
-     */
-    public function getStatusCode();
 
     /**
      * Gets the response Reason-Phrase, a short textual description of the Status-Code.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -339,50 +339,54 @@ interface RequestInterface extends MessageInterface
     public function setMethod($method);
 
     /**
-     * Retrieves the base request URL.
+     * Retrieves the absolute URI.
      *
-     * The base URL consists of:
+     * An absolute URI consists of minimally scheme and host, but can also
+     * contain:
      *
-     * - scheme
-     * - authentication (if any)
-     * - server name/host
+     * - authentication (user/pass) if provided
      * - port (if non-standard)
+     * - path (if any)
+     * - query string (if present)
+     * - fragment (if present)
      *
-     * This method is provided for convenience, particularly when considering
-     * server-side requests, where data such as the scheme and server name may
-     * need to be computed from more than one environmental variable.
+     * If either of the scheme or host are not present, this method MUST return
+     * null.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the base URL as a string. The URL MUST include
-     *     the scheme and host; if the port is non-standard for the scheme,
-     *     the port MUST be included; authentication data MAY be provided.
+     * @return string|null Returns the absolute URL as a string. The URL MUST
+     *     include the scheme and host; if the port is non-standard for the
+     *     scheme, the port MUST be included; authentication data MAY be
+     *     provided. If either host or scheme are missing, this method MUST
+     *     return null.
      */
-    public function getBaseUrl();
+    public function getAbsoluteUri();
 
     /**
-     * Sets the base request URL.
+     * Sets the absolute URI of the request.
      *
-     * The base URL MUST be a string, and MUST include the scheme and host.
+     * The absolute URI MUST be a string, and MUST include the scheme and host.
      *
      * If the port is non-standard for the scheme, the port MUST be provided.
      *
      * Authentication data MAY be provided.
      *
-     * If path, query string, or URL fragment are provided they SHOULD be
-     * stripped; optionally, an error MAY be raised in such situations.
+     * Path, query string, and fragment are optional.
+     *
+     * When setting the absolute URI, the url (see getUrl() and setUrl()) MUST
+     * be updated.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param string $url Base request URL.
+     * @param string $uri Absolute request URI.
      * @return void
-     * @throws \InvalidArgumentException If the URL is invalid.
+     * @throws \InvalidArgumentException If the URI is invalid.
      */
-    public function setBaseUrl($url);
+    public function setAbsoluteUri($uri);
 
     /**
      * Retrieves the request URL.
      *
-     * The request URL is the same value as REQUEST_URI: the path and query
-     * string ONLY.
+     * The request URL is the path and query string ONLY.
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3
      * @return string Returns the URL as a string. The URL MUST be an
@@ -396,6 +400,9 @@ interface RequestInterface extends MessageInterface
      * The URL MUST be a string. The URL SHOULD be an origin-form (path + query
      * string) per RFC 7230 section 5.3; if other URL parts are present, the
      * method MUST raise an exception OR remove those parts.
+     *
+     * When setting the URL, the absolute URI (see getAbsoluteUri() and
+     * setAbsoluteUri()) MUST be updated.
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3
      * @param string $url Request URL, with path and optionally query string.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -490,6 +490,11 @@ interface ServerRequestInterface extends RequestInterface
      *
      * Retrieves the deserialized query string arguments, if any.
      *
+     * Note: the query params might not be in sync with the URL or server
+     * params. If you need to ensure you are only getting the original
+     * values, you may need to parse the composed URL or the `QUERY_STRING`
+     * composed in the server params.
+     *
      * @return array
      */
     public function getQueryParams();
@@ -504,6 +509,9 @@ interface ServerRequestInterface extends RequestInterface
      * MUST be compatible with what PHP's `parse_str()` would return for
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
+     *
+     * Setting query string arguments MUST NOT change the URL stored by the
+     * request, nor the values in the server params.
      *
      * @param array $query Array of query string arguments, typically from
      *     $_GET.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -276,7 +276,7 @@ interface MessageInterface
     /**
      * Gets the body of the message.
      *
-     * @return StreamableInterface|null Returns the body, or null if not set.
+     * @return StreamableInterface Returns the body as a stream.
      */
     public function getBody();
 


### PR DESCRIPTION
This patch removes the client/server interface segregation, and re-instates full
mutability (with two notable exceptions). The rationale was discussed on the
mailing list; essentially, in practice, mutability will be simpler for consumers
and allow more varied architectures.

The interfaces presented now are:

- `StreamableInterface`
- `MessageInterface`
- `RequestInterface`
- `ServerRequestInterface` (was `IncomingRequestInterface`)
- `ResponseInterface`

The request interface also now has an "absolute URI" member. The "URL" member is only
used to store the path and query string, while the absolute URI is intended to store the full URI of the request - which is minimally scheme and host. If either scheme or host are not present, the getter will return null, and the setter will raise an exception.

Fixes #296
Fixes #394

#### Updates

- 2015-01-07: "base URL" was changed to "absolute URI", per discussions on #296 and in the mailing list.