### PR TITLE
[PSR-7] Immutability + URI interface

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -6,10 +6,12 @@ HTTP Message Meta Document
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
 messages as described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
-[RFC 7231](http://tools.ietf.org/html/rfc7231).
+[RFC 7231](http://tools.ietf.org/html/rfc7231), and URIs as described in
+[RFC 3986](http://tools.ietf.org/html/rfc3986) (in the context of HTTP messages).
 
 - RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
 - RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 3986: http://www.ietf.org/rfc/rfc3986.txt
 
 All HTTP messages consist of the HTTP protocol version being used, headers, and
 a message body. A _Request_ builds on the message to include the HTTP method
@@ -18,48 +20,115 @@ _Response_ includes the HTTP status code and reason phrase.
 
 In PHP, HTTP messages are used in two contexts:
 
-- To send an HTTP request from a client, such as cURL, a web browser, etc., to
-  be fulfilled by a server, which will return an HTTP response. In other words,
-  PHP can use HTTP messages when acting as an _HTTP client_.
-- To process an incoming HTTP request to a server, and return an HTTP response
+- To send an HTTP request, via the `ext/curl` extension, PHP's native stream
+  layer, etc., and process the received HTTP response. In other words, HTTP
+  messages are used when using PHP as an _HTTP client_.
+- To process an incoming HTTP request to the server, and return an HTTP response
   to the client making the request. PHP can use HTTP messages when used as a
   _server-side application_ to fulfill HTTP requests.
 
-This proposal presents an API for describing HTTP messages in PHP in a way
-that is as simple as possible while simultaneously producing no limits on
-functionality.
+This proposal presents an API for fully describing all parts of the various
+HTTP messages within PHP.
 
-2. Why Bother?
+2. HTTP Messages in PHP
+-----------------------
+
+PHP does not have built-in support for HTTP messages.
+
+### Client-side HTTP support
+
+PHP supports sending HTTP requests via several mechanisms:
+
+- [PHP streams](http://php.net/streams)
+- The [cURL extension](http://php.net/curl)
+- [ext/http](http://php.net/http) (v2 also attempts to address server-side support)
+
+PHP streams are the most convenient and ubiquitous way to send HTTP requests,
+but pose a number of limitations with regards to properly configuring SSL
+support, and provide a cumbersome interface around setting things such as
+headers. cURL provides a complete and expanded feature-set, but, as it is not a
+default extension, is often not present. The http extension suffers from the
+same problem as cURL, as well as the fact that it has traditionally had far
+fewer examples of usage.
+
+Most modern HTTP client libraries tend to abstract the implementation, to
+ensure they can work on whatever environment they are executed on, and across
+any of the above layers.
+
+### Server-side HTTP Support
+
+PHP uses Server APIs (SAPI) to interpret incoming HTTP requests, marshal input,
+and pass off handling to scripts. The original SAPI design mirrored [Common
+Gateway Interface](http://www.w3.org/CGI/), which would marshal request data
+and push it into environment variables before passing delegation to a script;
+the script would then pull from the environment variables in order to process
+the request and return a response.
+
+PHP's SAPI design abstracts common input sources such as cookies, query string
+arguments, and url-encoded POST content via superglobals (`$_COOKIE`, `$_GET`,
+and `$_POST`, respectively), providing a layer of convenience for web developers.
+
+On the response side of the equation, PHP was originally developed as a
+templating language, and allows intermixing HTML and PHP; any HTML portions of
+a file are immediately flushed to the output buffer. Modern applications and
+frameworks, however, eschew this practice, as it can lead to issues with
+regards to emitting a status line and/or response headers; they tend to
+aggregate all headers and content, and emit them at once when all other
+application processing is complete. Special care needs to be paid to ensure
+that error reporting and other actions that send content to the output buffer
+do not flush the output buffer.
+
+3. Why Bother?
 --------------
 
 HTTP messages are used in a wide number of PHP projects -- both clients and
 servers. In each case, we observe one or more of the following patterns or
 situations:
 
-1. Projects will create implementations from scratch.
-2. Projects may require a specific HTTP client/server library that provides
+1. Projects use PHP's superglobals directly.
+2. Projects will create implementations from scratch.
+3. Projects may require a specific HTTP client/server library that provides
    HTTP message implementations.
-3. Projects may create adapters for common HTTP message implementations.
+4. Projects may create adapters for common HTTP message implementations.
 
 As examples:
 
-1. Frameworks such as Symfony and Zend Framework each define HTTP components
+1. Just about any application that began development before the rise of
+   frameworks, which includes a number of very popular CMS, forum, and shopping
+   cart systems, have historically used superglobals.
+2. Frameworks such as Symfony and Zend Framework each define HTTP components
    that form the basis of their MVC layers; even small, single-purpose
    libraries such as oauth2-server-php provide and require their own HTTP
    request/response implementations. Guzzle, Buzz, and other HTTP client
    implementations each create their own HTTP message implementations as well.
-2. Projects such as Silex and Stack have hard dependencies on Symfony's HTTP
-   kernel. Any SDK built on Guzzle has a hard requirement on Guzzle's HTTP message
-   implementations.
-3. Projects such as Geocoder create redundant [adapters for common
+3. Projects such as Silex, Stack, and Drupal 8 have hard dependencies on
+   Symfony's HTTP kernel. Any SDK built on Guzzle has a hard requirement on
+   Guzzle's HTTP message implementations.
+4. Projects such as Geocoder create redundant [adapters for common
    libraries](https://github.com/geocoder-php/Geocoder/tree/6a729c6869f55ad55ae641c74ac9ce7731635e6e/src/Geocoder/HttpAdapter).
 
-The net result is that projects are not capable of interoperability or
+Direct usage of superglobals has a number of concerns. First, these are
+mutable, which makes it possible for libraries and code to alter the values,
+and thus alter state for the application. Additionally, superglobals make unit
+and integration testing difficult and brittle, leading to code quality
+degradation.
+
+In the current ecosystem of frameworks that implement HTTP message abstractions,
+the net result is that projects are not capable of interoperability or
 cross-pollination. In order to consume code targeting one framework from
 another, the first order of business is building a bridge layer between the
 HTTP message implementations. On the client-side, if a particular library does
 not have an adapter you can utilize, you need to bridge the request/response
 pairs if you wish to use an adapter from another library.
+
+Finally, when it comes to server-side responses, PHP gets in its own way: any
+content emitted before a call to `header()` will result in that call becoming a
+no-op; depending on error reporting settings, this can often mean headers
+and/or response status are not correctly sent. One way to work around this is
+to use PHP's output buffering features, but nesting of output buffers can
+become problematic and difficult to debug. Frameworks and applications thus
+tend to create response abstractions for aggregating headers and content that
+can be emitted at once - and these abstractions are often incompatible.
 
 Thus, the goal of this proposal is to abstract both client- and server-side
 request and response interfaces in order to promote interoperability between
@@ -71,32 +140,33 @@ current interfaces utilized by existing PHP libraries. This proposal is aimed
 at interoperability between PHP packages for the purpose of describing HTTP
 messages.
 
-3. Scope
+4. Scope
 --------
 
-### 3.1 Goals
+### 4.1 Goals
 
 * Provide the interfaces needed for describing HTTP messages.
-* Keep the interfaces as minimal as possible.
 * Focus on practical applications and usability.
+* Define the interfaces to model all elements of the HTTP message and URI
+  specifications.
 * Ensure that the API does not impose arbitrary limits on HTTP messages. For
   example, some HTTP message bodies can be too large to store in memory, so we
   must account for this.
 * Provide useful abstractions both for handling incoming requests for
-  server-side applications and sending outgoing requests in HTTP clients.
+  server-side applications and for sending outgoing requests in HTTP clients.
 
-### 3.2 Non-Goals
+### 4.2 Non-Goals
 
 * This proposal does not expect all HTTP client libraries or server-side
   frameworks to change their interfaces to conform. It is strictly meant for
   interoperability.
 * While everyone's perception of what is and is not an implementation detail
   varies, this proposal should not impose implementation details. However,
-  because RFC 7230 and RFC 7231 do not force any particular implementation,
+  because RFCs 7230, 7231, and 3986 do not force any particular implementation,
   there will be a certain amount of invention needed to describe HTTP message
   interfaces in PHP.
 
-4. Design Decisions
+5. Design Decisions
 -------------------
 
 ### Message design
@@ -116,93 +186,141 @@ Python's [WSGI](https://www.python.org/dev/peps/pep-0333/),
 Go's [http package](http://golang.org/pkg/net/http/),
 Node's [http module](http://nodejs.org/api/http.html), etc.
 
-#### Why are there header methods on messages rather than in a header bag?
+### Why are there header methods on messages rather than in a header bag?
 
-Moving headers to a "header bag" breaks the
-[Law of Demeter](http://en.wikipedia.org/wiki/Law_of_Demeter) and exposes the
-internal implementation of a message to its collaborators. In order for
-something to access the headers of a message, they need to reach into the
-message's header bag (`$message->getHeaders()->getHeader('Foo')`).
+The message itself is a container for the headers (as well as the other message
+properties). How these are represented internally is an implementation detail,
+but uniform access to headers is a responsibility of the message.
 
-Moving headers from messages into an externally mutable "header bag" exposes the
-internal implementation of how a message manages its headers, and has a
-side-effect that messages are no longer aware of changes to their headers. This
-can lead to messages entering into an invalid or inconsistent state.
+### Why are URIs represented as objects?
 
-#### Mutability of messages
+URIs are values, with identity defined by the value, and thus should be modeled
+as value objects.
 
-The proposal models mutable messages.
+Additionally, URIs contain a variety of segments which may be accessed many
+times in a give request -- and which would require parsing the URI in order to
+determine (e.g., via `parse_url()`). Modeling URIs as value objects allows
+parsing once only, and simplifies access to individual segments. It also
+provides convenience in client applications by allowing users to create new
+instances of a base URI instance with just the segments that change (e.g.,
+updating the path only).
 
-Real-world usage in clients requires mutable requests. As an example, most HTTP
-clients allow you to modify a request pre-flight in order to implement custom
-logic (for example, signing a request, compression, encryption, etc...).
-Examples include:
+### Why are URIs and request-targets merged in a single interface?
 
-* Guzzle: http://guzzlephp.org/guide/plugins.html
-* Buzz: https://github.com/kriswallsmith/Buzz/blob/master/lib/Buzz/Listener/BasicAuthListener.php
-* Requests/PHP:  https://github.com/rmccue/Requests/blob/master/docs/hooks.md
+RFC 7230 details the request line as containing a "request-target". Of the four
+forms of request-target, only one is a URI compliant with RFC 3986. However,
+since all forms are valid for purposes of requests, the proposal must
+accommodate each.
 
-This is not just a popular pattern in the PHP community:
+The most common use case for requests, however, will be specifying either
+absolute URIs (absolute-form) or relative URIs (origin-form) -- which are also
+the most commonly known request-target types. To keep verbiage familiar for
+developers, `RequestInterface` only references the term "URI".
 
-* Requests: http://docs.python-requests.org/en/latest/user/advanced/#event-hooks
-* Typhoeus: https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/request/before.rb
-* RestClient: https://github.com/archiloque/rest-client#hook
-* Java's HttpClient: http://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/http/examples/client/ClientGZipContentCompression.java
-* etc...
+Since the interface used to model the URI accommodates the other request-target
+forms, its name -- `UriTargetInterface` -- references both the verbiage "URI"
+and "target" in order to call attention to the fact that the non-URI forms
+(authority-form and asterisk-form) are also valid values.
 
-Moreover, most HTTP clients prefer mutable responses for a variety of reasons.
-As an example, the client may return the raw response, but allow passing it
-through pluggable filters in order to perform actions such as decompression,
-file extraction, deserialization, etc. Modeling the messages as immutable would
-dictate architecture and limit adoption in these scenarios.
+### Immutability of messages
 
-On the server-side, the application will write to the response instance in
-order to populate it before sending it back to the client. This is particularly
-useful when considering the fact that headers can no longer be emitted once
-_any_ output has been sent; aggregating headers and content in a response
-object is a useful and typically necessary abstraction.
+The proposal models immutable messages and URIs.
 
-An argument can be made that server-side requests should be immutable, in order
-to reflect the request state at application initialization. However, this argument
-fails to address many real-world scenarios:
+Messages are values where the identity is the aggregate of all parts of the
+message; a change to any aspect of the message is essentially a new message.
 
-- PHP itself models the `$_GET`, `$_POST`, and `$_COOKIE` superglobals as mutable.
-- `$_POST` only models form-encoded data sent via POST. While this is arguably
-  still the most common scenario for web-submitted data, it fails to address the
-  very common needs of APIs, which may use methods such as PUT, PATCH, and DELETE
-  to submit data, and which are likely submitting JSON or XML. Since content type
-  can only be determined by inspecting the request itself, deserialization of
-  such body content can only happen within the application layer - suggesting
-  that body content parameters must be mutable.
-- Cookie encryption, while an arguable practice, is very common in modern
-  frameworks. For the practice to work, the cookie data must be mutable.
-- Streams, per definition, cannot be immutable.
+However, the proposal also recognizes that most clients and server-side
+applications will need to be able to easily update message aspects, and, as
+such, provides interface methods that will create new message instances with
+the updates. These are generally prefixed with the verbiage `with` or
+`without`.
 
-Cookies, query string arguments, and body parameters can always be
-re-calculated from sources such as the `$_SERVER` superglobal, request content
-body, or even the URL. As such, we also include server parameters in the
-server request interface, but as an immutable property.
+Immutability provides several benefits:
 
-One input source cannot be calculated at runtime, however: upload files.
-Technically, they _can_, but the logic for doing so is non-trivial, resource
-intensive, and prone to error. As such, we also model this input source as
-immutable.
+- Changes in URI state cannot alter the request composing the URI instance.
+- Changes in headers cannot alter the message composing them.
 
-We note one element outside these input sources: "attributes". Most server-side
-applications utilize processes that match the request to specific criteria --
-such as path segments, subdomains, etc. -- and then push the derived matches
-back into the request itself. Since these processes need to introspect the
-populated request, and are a product of the application itself, the proposal
-allows this property to be mutable.
+In essence, immutability ensures the integrity of the message state, and
+prevents the need for bi-directional dependencies, which can often go
+out-of-sync or lead to debugging or performance issues.
 
-Finally, we note that we chose mutability as a usability concern. Without
-mutability, the only way to accomplish some of the above scenarios -- body
-parameter deserialization and re-injection, cookie decryption, etc. -- would
-be through usage of proxies and decorators. While these concepts are not
-terribly difficult to accomplish, they are non-obvious and non-trivial for
-a plurality of PHP developers, for whom even basic OOP is often a new or
-arcane concept. Having mutable members simplifies usage, and should speed
-adoption of the interfaces.
+For HTTP clients, they allow consumers to build a base request with data such
+as the base URI and required headers, without needing to build a brand new
+request or reset request state for each message the client sends:
+
+```php
+$uri = new Uri('http://api.example.com');
+$baseRequest = new Request($uri, null, [
+    'Authorization' => 'Bearer ' . $token,
+    'Accept'        => 'application/json',
+]);;
+
+$request = $baseRequest->withUri($uri->withPath('/user'))->withMethod('GET');
+$response = $client->send($request);
+
+// get user id from $response
+
+$body = new StringStream(json_encode(['tasks' => [
+    'Code',
+    'Coffee',
+]]));;
+$request = $baseRequest
+    ->withUri($uri->withPath('/tasks/user/' . $userId))
+    ->withMethod('POST')
+    ->withHeader('Content-Type' => 'application/json')
+    ->withBody($body);
+$response = $client->send($request)
+
+// No need to overwrite headers or body!
+$request = $baseRequest->withUri($uri->withPath('/tasks'))->withMethod('GET');
+$response = $client->send($request);
+```
+
+On the server-side, developers will need to:
+
+- Deserialize the request message body.
+- Decrypt HTTP cookies.
+- Write to the response.
+
+These operations can be accomplished with immutable objects as well, with a
+number of benefits:
+
+- The original request state can be stored for retrieval by any consumer.
+- A default response state can be created with default headers and/or message body. 
+
+Most popular PHP frameworks have mutable HTTP messages today. The main changes
+necessary in consuming immutable messages are:
+
+- Instead of calling setter methods or setting public properties, mutator
+  messages will be called, and the result assigned.
+- Developers must notify the application on a change in state.
+
+As an example, in Zend Framework 2, instead of the following:
+
+```php
+function (MvcEvent $e)
+{
+    $response = $e->getResponse();
+    $response->setHeaderLine('x-foo', 'bar');
+}
+```
+
+one would now write:
+
+```php
+function (MvcEvent $e)
+{
+    $response = $e->getResponse();
+    $e->setResponse(
+        $response->withHeader('x-foo', 'bar');
+    )
+}
+```
+
+The above combines assignment and notification in a single call.
+
+This practice has a side benefit of making explicit any changes to application
+state being made.
 
 ### Using streams instead of X
 
@@ -237,7 +355,22 @@ like `isReadable()`, `isWritable()`, etc. This approach is used by Python,
 [Ruby](http://www.ruby-doc.org/core-2.0.0/IO.html),
 [Node](http://nodejs.org/api/stream.html), and likely others.
 
-#### Rationale for ServerRequestInterface
+### Why are streams mutable?
+
+The `StreamableInterface` API includes methods such as `write()` which can
+change the message content -- which directly contradicts having immutable
+messages.
+
+The problem that arises is due to the fact that the interface is intended to
+wrap a PHP stream or similar. A write operation therefore will proxy to writing
+to the stream. Even if we made `StreamableInterface` immutable, once the stream
+has been updated, any instance that wraps that stream will also be updated --
+making immutability impossible to enforce.
+
+Our recommendation is that implementations use read-only streams for
+server-side requests and client-side responses.
+
+### Rationale for ServerRequestInterface
 
 The `RequestInterface` and `ResponseInterface` have essentially 1:1
 correlations with the request and response messages described in
@@ -250,16 +383,17 @@ incoming requests:
 
 - Access to server parameters (potentially derived from the request, but also
   potentially the result of server configuration, and generally represented
-  via the `$_SERVER` superglobal).
+  via the `$_SERVER` superglobal; these are part of the PHP Server API (SAPI)).
 - Access to the query string arguments (usually encapsulated in PHP via the
   `$_GET` superglobal).
 - Access to body parameters (i.e., data deserialized from the incoming request
-  body, and usually encapsulated by PHP in the `$_POST` superglobal).
-- Access to uploaded files (usually encapsulated in PHP via the `$_FILES`
-  superglobal).
-- Access to cookie values (usually encapsulated in PHP via the `$_COOKIE`
-  superglobal).
-- Access to attributes derived from the request (usually against the URL path).
+  body; in PHP, this is specific to POST requests in
+  `application/x-www-urlencoded` content types, and encapsulated in the
+  `$_POST` superglobal).
+- Access to uploaded files (encapsulated in PHP via the `$_FILES` superglobal).
+- Access to cookie values (encapsulated in PHP via the `$_COOKIE` superglobal).
+- Access to attributes derived from the request (usually, but not limited to,
+  those matched against the URL path).
 
 Uniform access to these parameters increases the viability of interoperability
 between frameworks and libraries, as they can now assume that if a request
@@ -274,17 +408,11 @@ solves problems within the PHP language itself:
   difficult and typically brittle. Encapsulating them inside the
   `ServerRequestInterface` implementation eases testing considerations.
 
-The interface as defined marks server and file parameters as _immutable_ as
-these are the values provided by PHP at the start of the request. The other
-parameters are all _mutable_, either to reflect mutability of the
-corresponding superglobal, or because the values can be calculated from the
-other input sources composed in the request.
-
-#### What about "special" header values?
+### What about "special" header values?
 
 A number of header values contain unique representation requirements which can
 pose problems both for consumption as well as generation; in particular, cookies
-and the Accept header.
+and the `Accept` header.
 
 This proposal does not provide any special treatment of any header types. The
 base `MessageInterface` provides methods for header retrieval and setting, and
@@ -299,48 +427,19 @@ Examples of this practice already exist in libraries such as
 has functionality for casting the value to a string, these objects can be
 used to populate the headers of an HTTP message.
 
-#### Why the distinction between URL and base URL?
-
-[RFC 7230, section 5.3](http://tools.ietf.org/html/rfc7230#section-5.3)
-indicates that the target of a request can be one of four forms. The first,
-"origin-form," is the path and the query string, and often termed the "relative
-URL." The next three all include the scheme and host, and, if present, the
-authentication information and port; these can be referred to as "absolute
-URIs."
-
-For consistency and predictability, we can only return one form from the
-`getUrl()` method of a request.
-
-In many cases, proxies, local applications, etc. will not have anything but
-a relative URL available, so forcing `getUrl()` to return an absolute URI
-would pose a problem; implementors would either need to hard-code the scheme
-and host -- and thus effectively return false information -- or raise an
-error for what is an expected situation.
-
-For server-side applications, however, not returning the scheme, port, and
-host can also be problematic. These values often need to be calculated from
-the server environment (e.g., when the server is behind a proxy; when using
-URL rewriting on some server environments; etc.), and the messages should
-abstract these operations as much as possible.
-
-The solution presented is to have a separate "base URL" property for holding
-the other URL artifacts. This allows using the messages in application
-environments where the absolute URI is unknown or un-needed, while providing
-the information when it is desired.
-
-5. People
+6. People
 ---------
 
-### 5.1 Editor(s)
+### 6.1 Editor(s)
 
 * Matthew Weier O'Phinney
 
-### 5.2 Sponsors
+### 6.2 Sponsors
 
 * Paul M. Jones
 * Beau Simensen (coordinator)
 
-### 5.3 Contributors
+### 6.3 Contributors
 
 * Michael Dowling
 * Phil Sturgeon

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -5,10 +5,11 @@ HTTP Message Meta Document
 ----------
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
-messages as described in [RFC 7230] and [RFC 7231].
+messages as described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
+[RFC 7231](http://tools.ietf.org/html/rfc7231).
 
-[RFC 7230]: http://www.ietf.org/rfc/rfc7230.txt
-[RFC 7231]: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
+- RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
 
 All HTTP messages consist of the HTTP protocol version being used, headers, and
 a message body. A _Request_ builds on the message to include the HTTP method
@@ -77,6 +78,7 @@ messages.
 
 * Provide the interfaces needed for describing HTTP messages.
 * Keep the interfaces as minimal as possible.
+* Focus on practical applications and usability.
 * Ensure that the API does not impose arbitrary limits on HTTP messages. For
   example, some HTTP message bodies can be too large to store in memory, so we
   must account for this.
@@ -109,7 +111,10 @@ messages, whether they are for requests or responses. These elements include:
 More specific interfaces are used to describe requests and responses, and more
 specifically the context of each (client- vs. server-side). These divisions are
 partly inspired by existing PHP usage, but also by other languages such as
-Ruby, Python, Go, Node, etc.
+Ruby's [Rack](https://rack.github.io),
+Python's [WSGI](https://www.python.org/dev/peps/pep-0333/),
+Go's [http package](http://golang.org/pkg/net/http/),
+Node's [http module](http://nodejs.org/api/http.html), etc.
 
 #### Why are there header methods on messages rather than in a header bag?
 
@@ -126,18 +131,7 @@ can lead to messages entering into an invalid or inconsistent state.
 
 #### Mutability of messages
 
-The proposal models "context-specific" mutability. This means that a message is mutable based on its context. For example:
-
-- Client-side requests are mutable, as they will be iterably built before being
-  sent.
-- Client-side responses are immutable, as they represent the result of a
-  request that has been made; changing the result would lead to inconsistent
-  state when multiple processes are passed the message.
-- Server-side requests are immutable, as they represent the state of the
-  current incoming request; changes to the message would lead to inconsistent
-  state when multiple processes are passed the message.
-- Server-side responses are mutable, as they are built iterably before being
-  returned to the client.
+The proposal models mutable messages.
 
 Real-world usage in clients requires mutable requests. As an example, most HTTP
 clients allow you to modify a request pre-flight in order to implement custom
@@ -156,34 +150,58 @@ This is not just a popular pattern in the PHP community:
 * Java's HttpClient: http://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/http/examples/client/ClientGZipContentCompression.java
 * etc...
 
+Moreover, most HTTP clients prefer mutable responses for a variety of reasons.
+As an example, the client may return the raw response, but allow passing it
+through pluggable filters in order to perform actions such as decompression,
+file extraction, deserialization, etc. Modeling the messages as immutable would
+dictate architecture and limit adoption in these scenarios.
+
 On the server-side, the application will write to the response instance in
 order to populate it before sending it back to the client. This is particularly
 useful when considering the fact that headers can no longer be emitted once
 _any_ output has been sent; aggregating headers and content in a response
 object is a useful and typically necessary abstraction.
 
-While server-side requests are primarily immutable, we have noted one element
-or property as _mutable_: "attributes". Most server-side applications utilize
-processes that match the request to specific criteria -- such as path segments,
-subdomains, etc. -- and then push the derived matches back into the request
-itself. Since these processes need to introspect the populated request, and are
-a product of the application itself, the proposal allows this property to be
-mutable. Possible use cases include:
+An argument can be made that server-side requests should be immutable, in order
+to reflect the request state at application initialization. However, this argument
+fails to address many real-world scenarios:
 
-* Body parameters are often "discovered" via deserialization of the incoming
-  request body, and the serialization method will need to be determined by
-  introspecting incoming `Content-Type` headers.
-* Cookies may be encrypted, and a process may decrypt them and re-inject them
-  into the request for later collaborators to access.
-* Routing and other tools are often used to "discover" request attributes (e.g.,
-  decomposing the URL `/user/phil` to assign the value "phil" to the attribute
-  "user"). Such logic is application-specific, but still considered part of the
-  request state; it can only be injected after instantiation.
+- PHP itself models the `$_GET`, `$_POST`, and `$_COOKIE` superglobals as mutable.
+- `$_POST` only models form-encoded data sent via POST. While this is arguably
+  still the most common scenario for web-submitted data, it fails to address the
+  very common needs of APIs, which may use methods such as PUT, PATCH, and DELETE
+  to submit data, and which are likely submitting JSON or XML. Since content type
+  can only be determined by inspecting the request itself, deserialization of
+  such body content can only happen within the application layer - suggesting
+  that body content parameters must be mutable.
+- Cookie encryption, while an arguable practice, is very common in modern
+  frameworks. For the practice to work, the cookie data must be mutable.
 
-Having context-specific mutability ensures the consistency of client-side
-responses and server-side requests, while simultaneously allowing for the full
-spectrum of operations on their counterparts, which are the product of the
-applications.
+Cookies, query string arguments, and body parameters can always be
+re-calculated from sources such as the `$_SERVER` superglobal, request content
+body, or even the URL. As such, we also include server parameters in the
+server request interface, but as an immutable property.
+
+One input source cannot be calculated at runtime, however: upload files.
+Technically, they _can_, but the logic for doing so is non-trivial, resource
+intensive, and prone to error. As such, we also model this input source as
+immutable.
+
+We note one element outside these input sources: "attributes". Most server-side
+applications utilize processes that match the request to specific criteria --
+such as path segments, subdomains, etc. -- and then push the derived matches
+back into the request itself. Since these processes need to introspect the
+populated request, and are a product of the application itself, the proposal
+allows this property to be mutable.
+
+Finally, we note that we chose mutability as a usability concern. Without
+mutability, the only way to accomplish some of the above scenarios -- body
+parameter deserialization and re-injection, cookie decryption, etc. -- would
+be through usage of proxies and decorators. While these concepts are not
+terribly difficult to accomplish, they are non-obvious and non-trivial for
+a plurality of PHP developers, for whom even basic OOP is often a new or
+arcane concept. Having mutable members simplifies usage, and should speed
+adoption of the interfaces.
 
 ### Using streams instead of X
 
@@ -218,13 +236,13 @@ like `isReadable()`, `isWritable()`, etc. This approach is used by Python,
 [Ruby](http://www.ruby-doc.org/core-2.0.0/IO.html),
 [Node](http://nodejs.org/api/stream.html), and likely others.
 
-#### Rationale for IncomingRequestInterface
+#### Rationale for ServerRequestInterface
 
-The `OutgoingRequestInterface`, `IncomingResponseInterface`, and
-`OutgoingResponseInterface`, have essentially 1:1 correlations with the request
-and response messages described in [RFC 7230](http://www.ietf.org/rfc/rfc7230.txt)
-They provide interfaces for implementing value objects that correspond to the
-specific HTTP message types they model.
+The `RequestInterface` and `ResponseInterface` have essentially 1:1
+correlations with the request and response messages described in
+[RFC 7230](http://www.ietf.org/rfc/rfc7230.txt) They provide interfaces for
+implementing value objects that correspond to the specific HTTP message types
+they model.
 
 For server-side applications, however, there are other considerations for
 incoming requests:
@@ -244,7 +262,7 @@ incoming requests:
 
 Uniform access to these parameters increases the viability of interoperability
 between frameworks and libraries, as they can now assume that if a request
-implements `IncomingRequestInterface`, they can get at these values. It also
+implements `ServerRequestInterface`, they can get at these values. It also
 solves problems within the PHP language itself:
 
 - Until 5.6.0, `php://input` was read-once; as such, instantiating multiple
@@ -253,12 +271,13 @@ solves problems within the PHP language itself:
   one to receive the data.
 - Unit testing against superglobals (e.g., `$_GET`, `$_FILES`, etc.) is
   difficult and typically brittle. Encapsulating them inside the
-  `IncomingRequestInterface` implementation eases testing considerations.
+  `ServerRequestInterface` implementation eases testing considerations.
 
-The interface as defined provides no mutators other than for derived
-attributes. The assumption is that values either (a) may be injected at
-instantiation from superglobals, and (b) should not change over the course of
-the incoming request.
+The interface as defined marks server and file parameters as _immutable_ as
+these are the values provided by PHP at the start of the request. The other
+parameters are all _mutable_, either to reflect mutability of the
+corresponding superglobal, or because the values can be calculated from the
+other input sources composed in the request.
 
 #### What about "special" header values?
 
@@ -278,6 +297,35 @@ Examples of this practice already exist in libraries such as
 [aura/accept](https://github.com/pmjones/Aura.Accept). So long as the object
 has functionality for casting the value to a string, these objects can be
 used to populate the headers of an HTTP message.
+
+#### Why the distinction between URL and base URL?
+
+[RFC 7230, section 5.3](http://tools.ietf.org/html/rfc7230#section-5.3)
+indicates that the target of a request can be one of four forms. The first,
+"origin-form," is the path and the query string, and often termed the "relative
+URL." The next three all include the scheme and host, and, if present, the
+authentication information and port; these can be referred to as "absolute
+URIs."
+
+For consistency and predictability, we can only return one form from the
+`getUrl()` method of a request.
+
+In many cases, proxies, local applications, etc. will not have anything but
+a relative URL available, so forcing `getUrl()` to return an absolute URI
+would pose a problem; implementors would either need to hard-code the scheme
+and host -- and thus effectively return false information -- or raise an
+error for what is an expected situation.
+
+For server-side applications, however, not returning the scheme, port, and
+host can also be problematic. These values often need to be calculated from
+the server environment (e.g., when the server is behind a proxy; when using
+URL rewriting on some server environments; etc.), and the messages should
+abstract these operations as much as possible.
+
+The solution presented is to have a separate "base URL" property for holding
+the other URL artifacts. This allows using the messages in application
+environments where the absolute URI is unknown or un-needed, while providing
+the information when it is desired.
 
 5. People
 ---------

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -176,6 +176,7 @@ fails to address many real-world scenarios:
   that body content parameters must be mutable.
 - Cookie encryption, while an arguable practice, is very common in modern
   frameworks. For the practice to work, the cookie data must be mutable.
+- Streams, per definition, cannot be immutable.
 
 Cookies, query string arguments, and body parameters can always be
 re-calculated from sources such as the `$_SERVER` superglobal, request content

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -2,15 +2,16 @@
 =======================
 
 This document describes common interfaces for representing HTTP messages as
-described in [RFC 7230] and [RFC 7231].
+described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
+[RFC 7231](http://tools.ietf.org/html/rfc7231).
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119].
+interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
-[RFC 2119]: http://www.ietf.org/rfc/rfc2119.txt
-[RFC 7230]: http://www.ietf.org/rfc/rfc7230.txt
-[RFC 7231]: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 2119: http://www.ietf.org/rfc/rfc2119.txt
+- RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
+- RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
 
 1. Specification
 ----------------
@@ -18,39 +19,42 @@ interpreted as described in [RFC 2119].
 ### 1.1 Messages
 
 An HTTP message is either a request from a client to a server or a response from
-a server to a client. This specification defines two pairs of interfaces for
-HTTP messages based on context:
+a server to a client. This specification defines interfaces for the HTTP messages
+`Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface` respectively.
 
-- Client-Side (i.e., making an HTTP request from PHP):
-  - `Psr\Http\Message\OutgoingRequestInterface`
-  - `Psr\Http\Message\IncomingResponseInterface`
-- Server-Side (i.e., processing a request made to a resource handled by PHP)
-  - `Psr\Http\Message\IncomingRequestInterface`
-  - `Psr\Http\Message\OutgoingResponseInterface`
+Both `Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface` extend
+`Psr\Http\Message\MessageInterface`. While `Psr\Http\Message\MessageInterface` MAY be
+implemented directly, implementors are encouraged to implement
+`Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface`.
 
-All of the above messages extend a base `Psr\Http\Message\MessageInterface`,
-which defines accessors for properties common across all implementations. While
-`Psr\Http\Message\MessageInterface` MAY be implemented directly, implementors are
-encouraged to implement one or both pairs of request/response interfaces, and
-consumers are encouraged to typehint on the relevant request/response interfaces.
 
-Interfaces are segregated by context. For HTTP client applications, the request is
-mutable, to allow consumers to incrementally build the request before sending it; the
-response, however, is immutable, as it is the product of an operation. Similarly, for
-server-side applications, the request is immutable and represents the specifics
-of the HTTP request made to the server; the response, however, will be incrementally
-built by the application prior to sending it back to the client.
+An additional interface, `Psr\Http\Message\ServerRequestInterface`, extends
+`Psr\Http\Message\RequestInterface` to model the various PHP superglobals and
+provide access to the various request input sources. These include:
 
-The `Psr\Http\Message\IncomingRequestInterface`, since it represents the incoming
-PHP request environment, is intended to model the various PHP superglobals.
+- cookies (`$_COOKIE`)
+- query string arguments (`$_GET`)
+- body parameters (typically `$_POST`, but these could be deserialized JSON or
+  other payloads)
+- file uploads (`$_FILES`)
+- the server environment (`$_SERVER`)
+
 This practice helps reduce coupling to the superglobals by consumers, and
-encourages and promotes the ability to test request consumers. The interface
-purposely does not provide mutators for the various superglobal properties to
-encourage treating them as immutable. However, it does provide one mutable
-property, "attributes", to allow consumers the ability to introspect,
-decompose, and match the request against application-specific rules (such as
-path matching, cookie decryption, etc.). As such, the request can also provide
-messaging between multiple request consumers.
+encourages and promotes the ability to test request consumers.
+
+Server variables and file upload information are considered immutable, as they
+are calculated by PHP and cannot be re-calculated or derived within the same
+request. Cookies, query string arguments, and body parameters, however, are
+mutable to reflect the mutable state of their corresponding superglobals, and
+to allow for common practices such as body deserialization, cookie decryption,
+etc. If the original values are desired, they can be retrieved from the server
+parameters and/or request body.
+
+The server request provides one additional mutable property, "attributes", to
+allow consumers the ability to introspect, decompose, and match the request
+against application-specific rules (such as path matching, scheme matching,
+host matching, etc.). As such, the request can also provide messaging between
+multiple request consumers.
 
 From here forward, the namespace `Psr\Http\Message` will be omitted when
 referring to these interfaces.
@@ -84,9 +88,9 @@ In order to accommodate headers with multiple values yet still provide the
 convenience of working with headers as strings, headers can be retrieved from
 an instance of a ``MessageInterface`` as an array or string. Use the
 `getHeader()` method to retrieve a header value as a string containing all
-header values of a header by name concatenated with a comma.
-Use `getHeaderAsArray()` to retrieve an array of all the header values for a
-particular header by name.
+header values of a case-insensitive header by name concatenated with a comma.
+Use `getHeaderLines()` to retrieve an array of all the header values for a
+particular case-insensitive header by name.
 
 ```php
 $message->setHeader('foo', 'bar');
@@ -95,13 +99,13 @@ $message->addHeader('foo', 'baz');
 $header = $message->getHeader('foo');
 // $header contains: 'bar, baz'
 
-$header = $message->getHeaderAsArray('foo');
-// $header contains: ['bar', 'baz']
+$header = $message->getHeaderLines('foo');
+// ['bar', 'baz']
 ```
 
 Note: Not all header values can be concatenated using a comma (e.g.,
 `Set-Cookie`). When working with such headers, consumers of
-`MessageInterface`-based classes SHOULD rely on the `getHeaderAsArray()` method
+`MessageInterface`-based classes SHOULD rely on the `getHeaderLines()` method
 for retrieving such multi-valued headers.
 
 ### 1.2 Streams
@@ -168,15 +172,15 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
-     * Gets the body of the message.
+     * Set the HTTP protocol version.
      *
-     * The returned body MUST be an instance of StreamableInterface. This may
-     * require that the implementation create a stream if none has been 
-     * set previously.
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
      *
-     * @return StreamableInterface Returns the body, or null if not set.
+     * @param string $version HTTP protocol version
+     * @return void
      */
-    public function getBody();
+    public function setProtocolVersion($version);
 
     /**
      * Gets all message headers.
@@ -232,15 +236,177 @@ interface MessageInterface
      * @param string $header Case-insensitive header name.
      * @return string[]
      */
-    public function getHeaderAsArray($header);
+    public function getHeaderLines($header);
+
+    /**
+     * Sets a header, replacing any existing values of any headers with the
+     * same case-insensitive name.
+     *
+     * The header name is case-insensitive. The header values MUST be a string
+     * or an array of strings.
+     *
+     * @param string $header Header name
+     * @param string|string[] $value Header value(s).
+     * @return void
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function setHeader($header, $value);
+
+    /**
+     * Appends a header value for the specified header.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list.
+     *
+     * @param string $header Header name to add
+     * @param string|string[] $value Header value(s).
+     * @return void
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function addHeader($header, $value);
+
+    /**
+     * Remove a specific header by case-insensitive name.
+     *
+     * @param string $header HTTP header to remove
+     * @return void
+     */
+    public function removeHeader($header);
+
+    /**
+     * Gets the body of the message.
+     *
+     * @return StreamableInterface|null Returns the body, or null if not set.
+     */
+    public function getBody();
+
+    /**
+     * Sets the body of the message.
+     *
+     * The body MUST be a StreamableInterface object.
+     *
+     * @param StreamableInterface $body Body.
+     * @return void
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function setBody(StreamableInterface $body);
 }
 ```
 
-### 3.2 Server-Side messages
+### 3.2 `Psr\Http\Message\RequestInterface`
 
-The `IncomingRequestInterface` and `OutgoingResponseInterface` describe the messages used when handling an incoming HTTP request via PHP.
+```php
+<?php
 
-#### 3.2.1 `Psr\Http\Message\IncomingRequestInterface`
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an outgoing, client-side request.
+ *
+ * Per the HTTP specification, this interface includes both accessors for
+ * and mutators for the following:
+ *
+ * - Protocol version
+ * - HTTP method
+ * - URL
+ * - Headers
+ * - Message body
+ *
+ * As the request CAN be built iteratively, the interface allows
+ * mutability of all properties.
+ */
+interface RequestInterface extends MessageInterface
+{
+    /**
+     * Retrieves the HTTP method of the request.
+     *
+     * @return string Returns the request method.
+     */
+    public function getMethod();
+
+    /**
+     * Sets the HTTP method to be performed on the resource identified by the
+     * Request-URI.
+     *
+     * While HTTP method names are typically all uppercase characters, HTTP
+     * method names are case-sensitive and thus implementations SHOULD NOT
+     * modify the given string.
+     *
+     * @param string $method Case-insensitive method.
+     * @return void
+     * @throws \InvalidArgumentException for invalid HTTP methods.
+     */
+    public function setMethod($method);
+
+    /**
+     * Retrieves the base request URL.
+     *
+     * The base URL consists of:
+     *
+     * - scheme
+     * - authentication (if any)
+     * - server name/host
+     * - port (if non-standard)
+     *
+     * This method is provided for convenience, particularly when considering
+     * server-side requests, where data such as the scheme and server name may
+     * need to be computed from more than one environmental variable.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @return string Returns the base URL as a string. The URL MUST include
+     *     the scheme and host; if the port is non-standard for the scheme,
+     *     the port MUST be included; authentication data MAY be provided.
+     */
+    public function getBaseUrl();
+
+    /**
+     * Sets the base request URL.
+     *
+     * The base URL MUST be a string, and MUST include the scheme and host.
+     *
+     * If the port is non-standard for the scheme, the port MUST be provided.
+     *
+     * Authentication data MAY be provided.
+     *
+     * If path, query string, or URL fragment are provided they SHOULD be
+     * stripped; optionally, an error MAY be raised in such situations.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @param string $url Base request URL.
+     * @return void
+     * @throws \InvalidArgumentException If the URL is invalid.
+     */
+    public function setBaseUrl($url);
+
+    /**
+     * Retrieves the request URL.
+     *
+     * The request URL is the same value as REQUEST_URI: the path and query
+     * string ONLY.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3
+     * @return string Returns the URL as a string. The URL MUST be an
+     *     origin-form (path + query string), per RFC 7230 section 5.3
+     */
+    public function getUrl();
+
+    /**
+     * Sets the request URL.
+     *
+     * The URL MUST be a string. The URL SHOULD be an origin-form (path + query
+     * string) per RFC 7230 section 5.3; if other URL parts are present, the
+     * method MUST raise an exception OR remove those parts.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3
+     * @param string $url Request URL, with path and optionally query string.
+     * @return void
+     * @throws \InvalidArgumentException If the URL is invalid.
+     */
+    public function setUrl($url);
+}
+```
+
+#### 3.2.1 `Psr\Http\Message\ServerRequestInterface`
 
 ```php
 <?php
@@ -259,7 +425,7 @@ namespace Psr\Http\Message;
  * - Headers
  * - Message body
  *
- * Additionally, it encapsulates all data as it has arrived to the 
+ * Additionally, it encapsulates all data as it has arrived to the
  * application from the PHP environment, including:
  *
  * - The values represented in $_SERVER.
@@ -268,40 +434,27 @@ namespace Psr\Http\Message;
  * - Upload files, if any (as represented by $_FILES)
  * - Deserialized body parameters (generally from $_POST)
  *
- * The above values MUST be immutable, in order to ensure that all consumers of
- * the request instance within a given request cycle receive the same information.
+ * $_SERVER and $_FILES values MUST be treated as immutable, as they represent
+ * application state at the time of request. The other values SHOULD be
+ * mutable, as they can be restored from $_SERVER, $_FILES, or the request
+ * body, and may need treatment during the application (e.g., body parameters
+ * may be deserialized based on content type).
  *
  * Additionally, this interface recognizes the utility of introspecting a
- * request to derive and match additional parameters (e.g., via URI path 
+ * request to derive and match additional parameters (e.g., via URI path
  * matching, decrypting cookie values, deserializing non-form-encoded body
  * content, matching authorization headers to users, etc). These parameters
  * are stored in an "attributes" property, which MUST be mutable.
  */
-interface IncomingRequestInterface extends MessageInterface
+interface ServerRequestInterface extends RequestInterface
 {
-    /**
-     * Retrieves the HTTP method of the request.
-     *
-     * @return string Returns the request method.
-     */
-    public function getMethod();
-
-    /**
-     * Retrieves the request URL.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the URL as a string. The URL SHOULD be an absolute
-     *     URI as specified in RFC 3986, but MAY be a relative URI.
-     */
-    public function getUrl();
-
     /**
      * Retrieve server parameters.
      *
-     * Retrieves data related to the incoming request environment, 
-     * typically derived from PHP's $_SERVER superglobal. The data IS NOT 
+     * Retrieves data related to the incoming request environment,
+     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
      * REQUIRED to originate from $_SERVER.
-     * 
+     *
      * @return array
      */
     public function getServerParams();
@@ -311,18 +464,38 @@ interface IncomingRequestInterface extends MessageInterface
      *
      * Retrieves cookies sent by the client to the server.
      *
-     * The assumption is these are injected during instantiation, typically
-     * from PHP's $_COOKIE superglobal. The data IS NOT REQUIRED to come from
-     * $_COOKIE, but MUST be compatible with the structure of $_COOKIE.
+     * The data MUST be compatible with the structure of the $_COOKIE
+     * superglobal.
      *
      * @return array
      */
     public function getCookieParams();
 
     /**
+     * Set cookies.
+     *
+     * Set cookies sent by the client to the server.
+     *
+     * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
+     * be compatible with the structure of $_COOKIE. Typically, this data will
+     * be injected at instantiation.
+     *
+     * @param array $cookies Array of key/value pairs representing cookies.
+     * @return void
+     */
+    public function setCookieParams(array $cookies);
+
+    /**
      * Retrieve query string arguments.
      *
      * Retrieves the deserialized query string arguments, if any.
+     *
+     * @return array
+     */
+    public function getQueryParams();
+
+    /**
+     * Set query string arguments.
      *
      * These values SHOULD remain immutable over the course of the incoming
      * request. They MAY be injected during instantiation, such as from PHP's
@@ -332,9 +505,11 @@ interface IncomingRequestInterface extends MessageInterface
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
      *
-     * @return array
+     * @param array $query Array of query string arguments, typically from
+     *     $_GET.
+     * @return void
      */
-    public function getQueryParams();
+    public function setQueryParams(array $query);
 
     /**
      * Retrieve the upload file metadata.
@@ -342,9 +517,9 @@ interface IncomingRequestInterface extends MessageInterface
      * This method MUST return file upload metadata in the same structure
      * as PHP's $_FILES superglobal.
      *
-     * These values SHOULD remain immutable over the course of the incoming
-     * request. They MAY be injected during instantiation, such as from PHP's
-     * $_FILES superglobal, or MAY be derived from other sources.
+     * These values MUST remain immutable over the course of the incoming
+     * request. They SHOULD be injected during instantiation, such as from PHP's
+     * $_FILES superglobal, but MAY be derived from other sources.
      *
      * @return array Upload file(s) metadata, if any.
      */
@@ -354,13 +529,27 @@ interface IncomingRequestInterface extends MessageInterface
      * Retrieve any parameters provided in the request body.
      *
      * If the request body can be deserialized to an array, this method MAY be
-     * used to retrieve them. These MAY be injected during instantiation from
-     * PHP's $_POST superglobal. The data IS NOT REQUIRED to come from $_POST,
-     * but MUST be an array.
+     * used to retrieve them.
      *
      * @return array The deserialized body parameters, if any.
      */
     public function getBodyParams();
+
+    /**
+     * Set parameters provided in the request body.
+     *
+     * These MAY be injected during instantiation from PHP's $_POST
+     * superglobal. The data IS NOT REQUIRED to come from $_POST, but MUST be
+     * an array. This method can be used during the request lifetime to inject
+     * parameters discovered and/or deserialized from the request body; as an
+     * example, if content negotiation determines that the request data is
+     * a JSON payload, this method could be used to inject the deserialized
+     * parameters.
+     *
+     * @param array $params The deserialized body parameters.
+     * @return void
+     */
+    public function setBodyParams(array $params);
 
     /**
      * Retrieve attributes derived from the request.
@@ -377,11 +566,11 @@ interface IncomingRequestInterface extends MessageInterface
 
     /**
      * Retrieve a single derived request attribute.
-     * 
+     *
      * Retrieves a single derived request attribute as described in
      * getAttributes(). If the attribute has not been previously set, returns
      * the default value as provided.
-     * 
+     *
      * @see getAttributes()
      * @param string $attribute Attribute name.
      * @param mixed $default Default value to return if the attribute does not exist.
@@ -403,7 +592,7 @@ interface IncomingRequestInterface extends MessageInterface
 
     /**
      * Set a single derived request attribute.
-     * 
+     *
      * This method allows setting a single derived request attribute as
      * described in getAttributes().
      *
@@ -416,7 +605,7 @@ interface IncomingRequestInterface extends MessageInterface
 }
 ```
 
-#### 3.2.2 `Psr\Http\Message\OutgoingResponseInterface`
+### 3.3 `Psr\Http\Message\ResponseInterface`
 
 ```php
 <?php
@@ -437,19 +626,8 @@ namespace Psr\Http\Message;
  * As the response CAN be built iteratively, the interface allows
  * mutability of all properties.
  */
-interface OutgoingResponseInterface extends MessageInterface
+interface ResponseInterface extends MessageInterface
 {
-    /**
-     * Set the HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * @param string $version HTTP protocol version
-     * @return void
-     */
-    public function setProtocolVersion($version);
-
     /**
      * Gets the response Status-Code.
      *
@@ -476,232 +654,6 @@ interface OutgoingResponseInterface extends MessageInterface
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
     public function setStatus($code, $reasonPhrase = null);
-
-    /**
-     * Gets the response Reason-Phrase, a short textual description of the Status-Code.
-     *
-     * Because a Reason-Phrase is not a required element in a response
-     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * Status-Code.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string|null Reason phrase, or null if unknown.
-     */
-    public function getReasonPhrase();
-
-    /**
-     * Sets a header, replacing any existing values of any headers with the
-     * same case-insensitive name.
-     *
-     * The header name is case-insensitive. The header values MUST be a string
-     * or an array of strings.
-     *
-     * @param string $header Header name
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * Appends a header value for the specified header.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list.
-     *
-     * @param string $header Header name to add
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function addHeader($header, $value);
-
-    /**
-     * Remove a specific header by case-insensitive name.
-     *
-     * @param string $header HTTP header to remove
-     * @return void
-     */
-    public function removeHeader($header);
-
-    /**
-     * Sets the body of the message.
-     *
-     * The body MUST be a StreamableInterface object.
-     *
-     * @param StreamableInterface $body Body.
-     * @return void
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function setBody(StreamableInterface $body);
-}
-```
-
-### 3.3 Client-Side Messages
-
-The `OutgoingRequestInterface` and `IncomingResponseInterface` describe messages associated with making an HTTP request from PHP.
-
-#### 3.3.1 `Psr\Http\Message\OutgoingRequestInterface`
-
-```php
-<?php
-
-namespace Psr\Http\Message;
-
-/**
- * Representation of an outgoing, client-side request.
- * 
- * Per the HTTP specification, this interface includes both accessors for
- * and mutators for the following:
- *
- * - Protocol version
- * - HTTP method
- * - URL
- * - Headers
- * - Message body
- *
- * As the request CAN be built iteratively, the interface allows
- * mutability of all properties.
- */
-interface OutgoingRequestInterface extends MessageInterface
-{
-    /**
-     * Set the HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * @param string $version HTTP protocol version
-     * @return void
-     */
-    public function setProtocolVersion($version);
-
-    /**
-     * Retrieves the HTTP method of the request.
-     *
-     * @return string Returns the request method.
-     */
-    public function getMethod();
-
-    /**
-     * Sets the HTTP method to be performed on the resource identified by the
-     * Request-URI.
-     *
-     * While HTTP method names are typically all uppercase characters, HTTP
-     * method names are case-sensitive and thus implementations SHOULD NOT
-     * modify the given string.
-     *
-     * @param string $method Case-insensitive method.
-     * @return void
-     * @throws \InvalidArgumentException for invalid HTTP methods.
-     */
-    public function setMethod($method);
-
-    /**
-     * Retrieves the request URL.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the URL as a string. The URL SHOULD be an
-     *     absolute URI as specified in RFC 3986, but MAY be a relative URI.
-     */
-    public function getUrl();
-
-    /**
-     * Sets the request URL.
-     *
-     * The URL MUST be a string. The URL SHOULD be an absolute URI as specified
-     * in RFC 3986, but MAY be a relative URI.
-     *
-     * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param string $url Request URL.
-     * @return void
-     * @throws \InvalidArgumentException If the URL is invalid.
-     */
-    public function setUrl($url);
-
-    /**
-     * Sets a header, replacing any existing values of any headers with the
-     * same case-insensitive name.
-     *
-     * The header name is case-insensitive. The header values MUST be a string
-     * or an array of strings.
-     *
-     * @param string $header Header name
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * Appends a header value for the specified header.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list.
-     *
-     * @param string $header Header name to add
-     * @param string|string[] $value Header value(s).
-     * @return void
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function addHeader($header, $value);
-
-    /**
-     * Remove a specific header by case-insensitive name.
-     *
-     * @param string $header HTTP header to remove
-     * @return void
-     */
-    public function removeHeader($header);
-
-    /**
-     * Sets the body of the message.
-     *
-     * The body MUST be a StreamableInterface object.
-     *
-     * @param StreamableInterface $body Body.
-     * @return void
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function setBody(StreamableInterface $body);
-}
-```
-
-#### 3.3.2 `Psr\Http\Message\IncomingResponseInterface`
-
-```php
-<?php
-
-namespace Psr\Http\Message;
-
-/**
- * Representation of an incoming, client-side response.
- * 
- * Per the HTTP specification, this interface includes accessors for
- * the following:
- *
- * - Protocol version
- * - Status code and reason phrase
- * - Headers
- * - Message body
- *
- * As the response is the result of making a request, it is considered
- * immutable.
- */
-interface IncomingResponseInterface extends MessageInterface
-{
-    /**
-     * Gets the response Status-Code.
-     *
-     * The Status-Code is a 3-digit integer result code of the server's attempt
-     * to understand and satisfy the request.
-     *
-     * @return integer Status code.
-     */
-    public function getStatusCode();
 
     /**
      * Gets the response Reason-Phrase, a short textual description of the Status-Code.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -3,7 +3,49 @@
 
 This document describes common interfaces for representing HTTP messages as
 described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
-[RFC 7231](http://tools.ietf.org/html/rfc7231).
+[RFC 7231](http://tools.ietf.org/html/rfc7231), and URIs for use with HTTP
+messages as described in [RFC 3986](http://tools.ietf.org/html/rfc3986).
+
+HTTP messages are the foundation of web development. Web browsers and HTTP
+clients such as cURL create HTTP request messages that are sent to a web server,
+which provides an HTTP response message. Server-side code receives an HTTP
+request message, and returns an HTTP response message.
+
+HTTP messages are typically abstracted from the end-user consumer, but as
+developers, we typically need to know how they are structured and how to
+access or manipulate them in order to perform our tasks, whether that might be
+making a request to an HTTP API, or handling an incoming request.
+
+Every HTTP request message has a specific form:
+
+```http
+POST /path HTTP/1.1
+Host: example.com
+
+foo=bar&baz=bat
+```
+
+The first line of a request is the "request line", and contains, in order, the
+HTTP request method, the request target (usually either an absolute URI or a
+path on the web server), and the HTTP protocol version. This is followed by one
+or more HTTP headers, an empty line, and the message body.
+
+HTTP response messages have a similar structure:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain
+
+This is the response body
+```
+
+The first line is the "status line", and contains, in order, the HTTP protocol
+version, the HTTP status code, and a "reason phrase," a human-readable
+description of the status code. Just like the request message, this is then
+followed by one or more HTTP headers, and empty line, and the message body.
+
+The interfaces described in this document are abstractions around HTTP messages
+and the elements composing them.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
@@ -12,6 +54,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 - RFC 2119: http://www.ietf.org/rfc/rfc2119.txt
 - RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
 - RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
+- RFC 3986: http://www.ietf.org/rfc/rfc3986.txt
 
 1. Specification
 ----------------
@@ -24,37 +67,8 @@ a server to a client. This specification defines interfaces for the HTTP message
 
 Both `Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface` extend
 `Psr\Http\Message\MessageInterface`. While `Psr\Http\Message\MessageInterface` MAY be
-implemented directly, implementors are encouraged to implement
+implemented directly, implementors SHOULD implement
 `Psr\Http\Message\RequestInterface` and `Psr\Http\Message\ResponseInterface`.
-
-
-An additional interface, `Psr\Http\Message\ServerRequestInterface`, extends
-`Psr\Http\Message\RequestInterface` to model the various PHP superglobals and
-provide access to the various request input sources. These include:
-
-- cookies (`$_COOKIE`)
-- query string arguments (`$_GET`)
-- body parameters (typically `$_POST`, but these could be deserialized JSON or
-  other payloads)
-- file uploads (`$_FILES`)
-- the server environment (`$_SERVER`)
-
-This practice helps reduce coupling to the superglobals by consumers, and
-encourages and promotes the ability to test request consumers.
-
-Server variables and file upload information are considered immutable, as they
-are calculated by PHP and cannot be re-calculated or derived within the same
-request. Cookies, query string arguments, and body parameters, however, are
-mutable to reflect the mutable state of their corresponding superglobals, and
-to allow for common practices such as body deserialization, cookie decryption,
-etc. If the original values are desired, they can be retrieved from the server
-parameters and/or request body.
-
-The server request provides one additional mutable property, "attributes", to
-allow consumers the ability to introspect, decompose, and match the request
-against application-specific rules (such as path matching, scheme matching,
-host matching, etc.). As such, the request can also provide messaging between
-multiple request consumers.
 
 From here forward, the namespace `Psr\Http\Message` will be omitted when
 referring to these interfaces.
@@ -70,14 +84,15 @@ retrieving the "FoO" header. Similarly, setting the "Foo" header will overwrite
 any previously set "foo" header.
 
 ```php
-$message->setHeader('foo', 'bar');
+$message = $message->withHeader('foo', 'bar');
+
 echo $message->getHeader('foo');
 // Outputs: bar
 
 echo $message->getHeader('FOO');
 // Outputs: bar
 
-$message->setHeader('fOO', 'baz');
+$message = $message->withHeader('fOO', 'baz');
 echo $message->getHeader('foo');
 // Outputs: baz
 ```
@@ -93,8 +108,9 @@ Use `getHeaderLines()` to retrieve an array of all the header values for a
 particular case-insensitive header by name.
 
 ```php
-$message->setHeader('foo', 'bar');
-$message->addHeader('foo', 'baz');
+$message = $message
+    ->setHeader('foo', 'bar')
+    ->addHeader('foo', 'baz');
 
 $header = $message->getHeader('foo');
 // $header contains: 'bar, baz'
@@ -108,7 +124,7 @@ Note: Not all header values can be concatenated using a comma (e.g.,
 `MessageInterface`-based classes SHOULD rely on the `getHeaderLines()` method
 for retrieving such multi-valued headers.
 
-### 1.2 Streams
+### 1.3 Streams
 
 HTTP messages consist of a start-line, headers, and a body. The body of an HTTP
 message can be very small or extremely large. Attempting to represent the body
@@ -131,10 +147,77 @@ collaborators to determine if a stream is capable of their requirements.
 Each stream instance will have various capabilities: it can be read-only,
 write-only, or read-write. It can also allow arbitrary random access (seeking
 forwards or backwards to any location), or only sequential access (for
-example in the case of a socket or pipe).
+example in the case of a socket, pipe, or callback-based stream).
 
 Finally, `StreamableInterface` defines a `__toString()` method to simplify
 retrieving or emitting the entire body contents at once.
+
+### 1.4 Request Targets and URIs
+
+Per RFC 7230, request messages contain a "request-target" as the second segment
+of the request line. The request target can be one of the following forms:
+
+- **origin-form**, which consists of the path, and, if present, the query
+  string; this is often referred to as a relative URL. Messages as transmitted
+  over TCP typically are of origin-form; scheme and authority data are usually
+  only present via CGI variables.
+- **absolute-form**, which consists of the scheme, authority
+  ("[user-info@]host[:port]", where items in brackets are optional), path (if
+  present), query string (if present), and fragment (if present). This is often
+  referred to as an absolute URI, and is the only form to specify a URI as
+  detailed in RFC 3986.
+- **authority-form**, which consists of the authority only. This is typically
+  used in CONNECT requests only, to establish a connection between an HTTP
+  client and a proxy server.
+- **asterisk-form**, which consists solely of the string '*', and which is used
+  with the OPTIONS method to determine the general capabilities of a web server.
+
+Since the goal of this proposal is to establish representations of HTTP
+messages, all four forms MUST be supported, even though only one represents a
+fully qualified URI.
+
+When working with fully qualified URIs, consumers will often need access to the
+various URI segments -- scheme, authority, user-info, host, port, path, query,
+and fragment -- and the ability to specify any specific segment. Since changing
+a segment is equivalent to creating a new URI, URI objects MUST be immutable.
+
+`UriTargetInterface` models HTTP and HTTPS URIs as specified in RFC 3986 (the
+primary use case), as well as any of the four request targets. The interface
+provides methods for testing which request target form is modeled, allowing
+consumers to query and branch based on that information. It also specifies a
+`__toString()` method for casting the modeled request target to the
+representation used (or to use) in the HTTP message.
+
+### 1.5 Server-side Requests
+
+`RequestInterface` provides the general representation of an HTTP request
+message. However, server-side requests need additional treatment, due to the
+nature of the server-side environment. Server-side processing needs to take into
+account Common Gateway Interface (CGI), and, more specifically, PHP's
+abstraction and extension of CGI via its Server APIs (SAPI). PHP has provided
+simplification around input marshaling via superglobals such as:
+
+- `$_COOKIE`, which deserializes and provides simplified access for HTTP
+  cookies.
+- `$_GET`, which deserializes and provides simplified access for query string
+  arguments.
+- `$_POST`, which deserializes and provides simplified access for urlencoded
+  parameters submitted via HTTP POST.
+- `$_FILES`, which provides serialized metadata around file uploads.
+- `$_SERVER`, which provides access to CGI/SAPI environment variables, which
+  commonly include the request method, the request scheme, the request URI, and
+  headers.
+
+`ServerRequestInterface` extends `RequestInterface` to provide an abstraction
+around these various superglobals. This practice helps reduce coupling to the
+superglobals by consumers, and encourages and promotes the ability to test
+request consumers.
+
+The server request provides one additional property, "attributes", to allow
+consumers the ability to introspect, decompose, and match the request against
+application-specific rules (such as path matching, scheme matching, host
+matching, etc.). As such, the server request can also provide messaging between
+multiple request consumers.
 
 2. Package
 ----------
@@ -157,13 +240,17 @@ namespace Psr\Http\Message;
  * from a server to a client. This interface defines the methods common to
  * each.
  *
+ * Messages are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return a new instance that contains the changed state.
+ *
  * @link http://www.ietf.org/rfc/rfc7230.txt
  * @link http://www.ietf.org/rfc/rfc7231.txt
  */
 interface MessageInterface
 {
     /**
-     * Gets the HTTP protocol version as a string.
+     * Retrieves the HTTP protocol version as a string.
      *
      * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
      *
@@ -172,18 +259,22 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
-     * Set the HTTP protocol version.
+     * Create a new instance with the specified HTTP protocol version.
      *
      * The version string MUST contain only the HTTP version number (e.g.,
      * "1.1", "1.0").
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new protocol version.
+     *
      * @param string $version HTTP protocol version
-     * @return void
+     * @return self
      */
-    public function setProtocolVersion($version);
+    public function withProtocolVersion($version);
 
     /**
-     * Gets all message headers.
+     * Retrieves all message headers.
      *
      * The keys represent the header name as it will be sent over the wire, and
      * each value is an array of strings associated with the header.
@@ -223,7 +314,8 @@ interface MessageInterface
      * a comma.
      *
      * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation.
+     * comma concatenation. For such headers, use getHeaderLines() instead
+     * and supply your own delimiter when concatenating.
      *
      * @param string $header Case-insensitive header name.
      * @return string
@@ -239,39 +331,55 @@ interface MessageInterface
     public function getHeaderLines($header);
 
     /**
-     * Sets a header, replacing any existing values of any headers with the
-     * same case-insensitive name.
+     * Create a new instance with the provided header, replacing any existing
+     * values of any headers with the same case-insensitive name.
      *
      * The header name is case-insensitive. The header values MUST be a string
      * or an array of strings.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new and/or updated header and value.
+     *
      * @param string $header Header name
      * @param string|string[] $value Header value(s).
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function setHeader($header, $value);
+    public function withHeader($header, $value);
 
     /**
-     * Appends a header value for the specified header.
+     * Creates a new instance, with the specified header appended with the
+     * given value.
      *
      * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list.
+     * value(s) will be appended to the existing list. If the header did not
+     * exist previously, it will be added.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new header and/or value.
      *
      * @param string $header Header name to add
      * @param string|string[] $value Header value(s).
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function addHeader($header, $value);
+    public function withAddedHeader($header, $value);
 
     /**
-     * Remove a specific header by case-insensitive name.
+     * Creates a new instance, without the specified header.
+     *
+     * Header resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that removes
+     * the named header.
      *
      * @param string $header HTTP header to remove
-     * @return void
+     * @return self
      */
-    public function removeHeader($header);
+    public function withoutHeader($header);
 
     /**
      * Gets the body of the message.
@@ -281,15 +389,19 @@ interface MessageInterface
     public function getBody();
 
     /**
-     * Sets the body of the message.
+     * Create a new instance, with the specified message body.
      *
      * The body MUST be a StreamableInterface object.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new body stream.
+     *
      * @param StreamableInterface $body Body.
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function setBody(StreamableInterface $body);
+    public function withBody(StreamableInterface $body);
 }
 ```
 
@@ -303,17 +415,18 @@ namespace Psr\Http\Message;
 /**
  * Representation of an outgoing, client-side request.
  *
- * Per the HTTP specification, this interface includes both accessors for
- * and mutators for the following:
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
  *
  * - Protocol version
  * - HTTP method
- * - URL
+ * - URI
  * - Headers
  * - Message body
  *
- * As the request CAN be built iteratively, the interface allows
- * mutability of all properties.
+ * Requests are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return a new instance that contains the changed state.
  */
 interface RequestInterface extends MessageInterface
 {
@@ -325,91 +438,45 @@ interface RequestInterface extends MessageInterface
     public function getMethod();
 
     /**
-     * Sets the HTTP method to be performed on the resource identified by the
-     * Request-URI.
+     * Create a new instance with the provided HTTP method.
      *
      * While HTTP method names are typically all uppercase characters, HTTP
      * method names are case-sensitive and thus implementations SHOULD NOT
      * modify the given string.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * changed request method.
+     *
      * @param string $method Case-insensitive method.
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */
-    public function setMethod($method);
+    public function withMethod($method);
 
     /**
-     * Retrieves the absolute URI.
+     * Retrieves the URI instance.
      *
-     * An absolute URI consists of minimally scheme and host, but can also
-     * contain:
-     *
-     * - authentication (user/pass) if provided
-     * - port (if non-standard)
-     * - path (if any)
-     * - query string (if present)
-     * - fragment (if present)
-     *
-     * If either of the scheme or host are not present, this method MUST return
-     * null.
+     * This method MUST return a UriTargetInterface instance.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string|null Returns the absolute URL as a string. The URL MUST
-     *     include the scheme and host; if the port is non-standard for the
-     *     scheme, the port MUST be included; authentication data MAY be
-     *     provided. If either host or scheme are missing, this method MUST
-     *     return null.
+     * @return UriTargetInterface Returns a UriTargetInterface instance
+     *     representing the URI of the request, if any.
      */
-    public function getAbsoluteUri();
+    public function getUri();
 
     /**
-     * Sets the absolute URI of the request.
+     * Create a new instance with the provided URI.
      *
-     * The absolute URI MUST be a string, and MUST include the scheme and host.
-     *
-     * If the port is non-standard for the scheme, the port MUST be provided.
-     *
-     * Authentication data MAY be provided.
-     *
-     * Path, query string, and fragment are optional.
-     *
-     * When setting the absolute URI, the url (see getUrl() and setUrl()) MUST
-     * be updated.
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new UriTargetInterface instance.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param string $uri Absolute request URI.
-     * @return void
-     * @throws \InvalidArgumentException If the URI is invalid.
+     * @param UriTargetInterface $uri New request URI to use.
+     * @return self
      */
-    public function setAbsoluteUri($uri);
-
-    /**
-     * Retrieves the request URL.
-     *
-     * The request URL is the path and query string ONLY.
-     *
-     * @link http://tools.ietf.org/html/rfc7230#section-5.3
-     * @return string Returns the URL as a string. The URL MUST be an
-     *     origin-form (path + query string), per RFC 7230 section 5.3
-     */
-    public function getUrl();
-
-    /**
-     * Sets the request URL.
-     *
-     * The URL MUST be a string. The URL SHOULD be an origin-form (path + query
-     * string) per RFC 7230 section 5.3; if other URL parts are present, the
-     * method MUST raise an exception OR remove those parts.
-     *
-     * When setting the URL, the absolute URI (see getAbsoluteUri() and
-     * setAbsoluteUri()) MUST be updated.
-     *
-     * @link http://tools.ietf.org/html/rfc7230#section-5.3
-     * @param string $url Request URL, with path and optionally query string.
-     * @return void
-     * @throws \InvalidArgumentException If the URL is invalid.
-     */
-    public function setUrl($url);
+    public function withUri(UriTargetInterface $uri);
 }
 ```
 
@@ -423,17 +490,17 @@ namespace Psr\Http\Message;
 /**
  * Representation of an incoming, server-side HTTP request.
  *
- * Per the HTTP specification, this interface includes accessors for
- * the following:
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
  *
  * - Protocol version
  * - HTTP method
- * - URL
+ * - URI
  * - Headers
  * - Message body
  *
  * Additionally, it encapsulates all data as it has arrived to the
- * application from the PHP environment, including:
+ * application from the CGI and/or PHP environment, including:
  *
  * - The values represented in $_SERVER.
  * - Any cookies provided (generally via $_COOKIE)
@@ -442,16 +509,21 @@ namespace Psr\Http\Message;
  * - Deserialized body parameters (generally from $_POST)
  *
  * $_SERVER and $_FILES values MUST be treated as immutable, as they represent
- * application state at the time of request. The other values SHOULD be
- * mutable, as they can be restored from $_SERVER, $_FILES, or the request
- * body, and may need treatment during the application (e.g., body parameters
- * may be deserialized based on content type).
+ * application state at the time of request; as such, no methods are provided
+ * to allow modification of those values. The other values provide such methods,
+ * as they can be restored from $_SERVER, $_FILES, or the request body, and may
+ * need treatment during the application (e.g., body parameters may be
+ * deserialized based on content type).
  *
  * Additionally, this interface recognizes the utility of introspecting a
  * request to derive and match additional parameters (e.g., via URI path
  * matching, decrypting cookie values, deserializing non-form-encoded body
  * content, matching authorization headers to users, etc). These parameters
- * are stored in an "attributes" property, which MUST be mutable.
+ * are stored in an "attributes" property.
+ *
+ * Requests are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return a new instance that contains the changed state.
  */
 interface ServerRequestInterface extends RequestInterface
 {
@@ -479,18 +551,20 @@ interface ServerRequestInterface extends RequestInterface
     public function getCookieParams();
 
     /**
-     * Set cookies.
-     *
-     * Set cookies sent by the client to the server.
+     * Create a new instance with the specified cookies.
      *
      * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
      * be compatible with the structure of $_COOKIE. Typically, this data will
      * be injected at instantiation.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated cookie values.
+     *
      * @param array $cookies Array of key/value pairs representing cookies.
-     * @return void
+     * @return self
      */
-    public function setCookieParams(array $cookies);
+    public function withCookieParams(array $cookies);
 
     /**
      * Retrieve query string arguments.
@@ -507,24 +581,28 @@ interface ServerRequestInterface extends RequestInterface
     public function getQueryParams();
 
     /**
-     * Set query string arguments.
+     * Create a new instance with the specified query string arguments.
      *
      * These values SHOULD remain immutable over the course of the incoming
      * request. They MAY be injected during instantiation, such as from PHP's
      * $_GET superglobal, or MAY be derived from some other value such as the
      * URI. In cases where the arguments are parsed from the URI, the data
-     * MUST be compatible with what PHP's `parse_str()` would return for
+     * MUST be compatible with what PHP's parse_str() would return for
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
      *
      * Setting query string arguments MUST NOT change the URL stored by the
      * request, nor the values in the server params.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated query string arguments.
+     *
      * @param array $query Array of query string arguments, typically from
      *     $_GET.
-     * @return void
+     * @return self
      */
-    public function setQueryParams(array $query);
+    public function withQueryParams(array $query);
 
     /**
      * Retrieve the upload file metadata.
@@ -551,7 +629,7 @@ interface ServerRequestInterface extends RequestInterface
     public function getBodyParams();
 
     /**
-     * Set parameters provided in the request body.
+     * Create a new instance with the specified body parameters.
      *
      * These MAY be injected during instantiation from PHP's $_POST
      * superglobal. The data IS NOT REQUIRED to come from $_POST, but MUST be
@@ -561,10 +639,14 @@ interface ServerRequestInterface extends RequestInterface
      * a JSON payload, this method could be used to inject the deserialized
      * parameters.
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated body parameters.
+     *
      * @param array $params The deserialized body parameters.
-     * @return void
+     * @return self
      */
-    public function setBodyParams(array $params);
+    public function withBodyParams(array $params);
 
     /**
      * Retrieve attributes derived from the request.
@@ -586,6 +668,9 @@ interface ServerRequestInterface extends RequestInterface
      * getAttributes(). If the attribute has not been previously set, returns
      * the default value as provided.
      *
+     * This method obviates the need for a hasAttribute() method, as it allows
+     * specifying a default value to return if the attribute is not found.
+     *
      * @see getAttributes()
      * @param string $attribute Attribute name.
      * @param mixed $default Default value to return if the attribute does not exist.
@@ -594,29 +679,38 @@ interface ServerRequestInterface extends RequestInterface
     public function getAttribute($attribute, $default = null);
 
     /**
-     * Set attributes derived from the request.
-     *
-     * This method allows setting request attributes, as described in
-     * getAttributes().
-     *
-     * @see getAttributes()
-     * @param array $attributes Attributes derived from the request.
-     * @return void
-     */
-    public function setAttributes(array $attributes);
-
-    /**
-     * Set a single derived request attribute.
+     * Create a new instance with the specified derived request attribute.
      *
      * This method allows setting a single derived request attribute as
      * described in getAttributes().
      *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated attribute.
+     *
      * @see getAttributes()
      * @param string $attribute The attribute name.
      * @param mixed $value The value of the attribute.
-     * @return void
+     * @return self
      */
-    public function setAttribute($attribute, $value);
+    public function withAttribute($attribute, $value);
+
+    /**
+     * Create a new instance that removes the specified derived request
+     * attribute.
+     *
+     * This method allows removing a single derived request attribute as
+     * described in getAttributes().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that removes
+     * the attribute.
+     *
+     * @see getAttributes()
+     * @param string $attribute The attribute name.
+     * @return self
+     */
+    public function withoutAttribute($attribute);
 }
 ```
 
@@ -630,16 +724,17 @@ namespace Psr\Http\Message;
 /**
  * Representation of an outgoing, server-side response.
  *
- * Per the HTTP specification, this interface includes both accessors for
- * and mutators for the following:
+ * Per the HTTP specification, this interface includes properties for
+ * each of the following:
  *
  * - Protocol version
  * - Status code and reason phrase
  * - Headers
  * - Message body
  *
- * As the response CAN be built iteratively, the interface allows
- * mutability of all properties.
+ * Responses are considered immutable; all methods that might change state MUST
+ * be implemented such that they retain the internal state of the current
+ * message and return a new instance that contains the changed state.
  */
 interface ResponseInterface extends MessageInterface
 {
@@ -654,11 +749,16 @@ interface ResponseInterface extends MessageInterface
     public function getStatusCode();
 
     /**
-     * Sets the status code, and optionally reason phrase,  of this response.
+     * Create a new instance with the specified status code, and optionally
+     * reason phrase, for the response.
      *
      * If no Reason-Phrase is specified, implementations MAY choose to default
      * to the RFC 7231 or IANA recommended reason phrase for the response's
      * Status-Code.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated status and reason phrase.
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
@@ -666,9 +766,10 @@ interface ResponseInterface extends MessageInterface
      * @param null|string $reasonPhrase The reason phrase to use with the
      *     provided status code; if none is provided, implementations MAY
      *     use the defaults as suggested in the HTTP specification.
+     * @return self
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function setStatus($code, $reasonPhrase = null);
+    public function withStatus($code, $reasonPhrase = null);
 
     /**
      * Gets the response Reason-Phrase, a short textual description of the Status-Code.
@@ -762,18 +863,29 @@ interface StreamableInterface
     /**
      * Seek to a position in the stream.
      *
-     * @link  http://www.php.net/manual/en/function.fseek.php
+     * @link http://www.php.net/manual/en/function.fseek.php
      * @param int $offset Stream offset
      * @param int $whence Specifies how the cursor position will be calculated
-     *                    based on the seek offset. Valid values are identical
-     *                    to the built-in PHP $whence values for `fseek()`.
-     *                    SEEK_SET: Set position equal to offset bytes
-     *                    SEEK_CUR: Set position to current location plus offset
-     *                    SEEK_END: Set position to end-of-stream plus offset
-     *
+     *     based on the seek offset. Valid values are identical to the built-in
+     *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
+     *     offset bytes SEEK_CUR: Set position to current location plus offset
+     *     SEEK_END: Set position to end-of-stream plus offset.
      * @return bool Returns TRUE on success or FALSE on failure.
      */
     public function seek($offset, $whence = SEEK_SET);
+
+    /**
+     * Seek to the beginning of the stream.
+     *
+     * If the stream is not seekable, this method will return FALSE, indicating
+     * failure; otherwise, it will perform a seek(0), and return the status of
+     * that operation.
+     *
+     * @see seek()
+     * @link http://www.php.net/manual/en/function.fseek.php
+     * @return bool Returns TRUE on success or FALSE on failure.
+     */
+    public function rewind();
 
     /**
      * Returns whether or not the stream is writable.
@@ -786,9 +898,8 @@ interface StreamableInterface
      * Write data to the stream.
      *
      * @param string $string The string that is to be written.
-     *
      * @return int|bool Returns the number of bytes written to the stream on
-     *                  success or FALSE on failure.
+     *     success or FALSE on failure.
      */
     public function write($string);
 
@@ -803,10 +914,10 @@ interface StreamableInterface
      * Read data from the stream.
      *
      * @param int $length Read up to $length bytes from the object and return
-     *                    them. Fewer than $length bytes may be returned if
-     *                    underlying stream call returns fewer bytes.
+     *     them. Fewer than $length bytes may be returned if underlying stream
+     *     call returns fewer bytes.
      * @return string|false Returns the data read from the stream, false if
-     *                      unable to read or if an error occurs.
+     *     unable to read or if an error occurs.
      */
     public function read($length);
 
@@ -826,10 +937,341 @@ interface StreamableInterface
      * @link http://php.net/manual/en/function.stream-get-meta-data.php
      * @param string $key Specific metadata to retrieve.
      * @return array|mixed|null Returns an associative array if no key is
-     *                          provided. Returns a specific key value if a key
-     *                          is provided and the value is found, or null if
-     *                          the key is not found.
+     *     provided. Returns a specific key value if a key is provided and the
+     *     value is found, or null if the key is not found.
      */
     public function getMetadata($key = null);
+}
+```
+
+### 3.5 `Psr\Http\Message\UriTargetInterface`
+
+```php
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing the request target, and typically a URI.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return a new instance that contains the
+ * changed state.
+ *
+ * Since this interface represents a request target per RFC 7230, the instance
+ * MAY represent an absolute URI OR one of the request targets that are not
+ * fully qualified URIs, including origin-form, authority-form, or
+ * asterisk-form. As such, test methods exist for determining what request
+ * target form is in use:
+ *
+ * - isAbsolute() tests if the target is in absolute-form (minimally scheme +
+ *   authority).
+ * - isOrigin() tests if the target is in origin-form (path + optional query
+ *   string only).
+ * - isAuthority() tests if the target contains the authority only.
+ * - isAsterisk() tests if the entirety of the target is '*'.
+ *
+ * These target forms are included, as they are valid forms for use with an
+ * HTTP request, and will appear without other URI segments available within
+ * the request line. This interface models the target as it appears in the
+ * incoming request line or as it will be emitted by a client.
+ *
+ * Typically, for all forms other than absolute-form, minimally the Host header
+ * will be also be present in the request message. For server-side requests,
+ * the scheme will typically be discoverable in the server parameters.
+ *
+ * @link http://tools.ietf.org/html/rfc3986 (the URI specification)
+ * @link http://tools.ietf.org/html/rfc7230#section-2.7 (URIs as used in the HTTP specification)
+ */
+interface UriTargetInterface
+{
+    /**
+     * Retrieve the URI scheme.
+     *
+     * Implementations SHOULD restrict values to "http", "https", or an empty
+     * string but MAY accommodate other schemes if required.
+     *
+     * If no scheme is present, this method MUST return an empty string.
+     *
+     * The string returned MUST omit the trailing "://" delimiter if present.
+     *
+     * @return string The scheme of the URI.
+     */
+    public function getScheme();
+
+    /**
+     * Retrieve the authority portion of the URI.
+     *
+     * The authority portion of the URI is:
+     *
+     * <pre>
+     * [user-info@]host[:port]
+     * </pre>
+     *
+     * If the port component is not set or is the standard port for the current
+     * scheme, it SHOULD NOT be included.
+     *
+     * This method MUST return an empty string if no authority information is
+     * present.
+     *
+     * @return string Authority portion of the URI, in "[user-info@]host[:port]"
+     *     format.
+     */
+    public function getAuthority();
+
+    /**
+     * Retrieve the user information portion of the URI, if present.
+     *
+     * If a user is present in the URI, this will return that value;
+     * additionally, if the password is also present, it will be appended to the
+     * user value, with a colon (":") separating the values.
+     *
+     * Implementations MUST NOT return the "@" suffix when returning this value.
+     *
+     * @return string User information portion of the URI, if present, in
+     *     "username[:password]" format.
+     */
+    public function getUserInfo();
+
+    /**
+     * Retrieve the host segment of the URI.
+     *
+     * This method MUST return a string; if no host segment is present, an
+     * empty string MUST be returned.
+     *
+     * @return string Host segment of the URI.
+     */
+    public function getHost();
+
+    /**
+     * Retrieve the port segment of the URI.
+     *
+     * If a port is present, and it is non-standard for the current scheme,
+     * this method MUST return it as an integer. If the port is the standard port
+     * used with the current scheme, this method SHOULD return null.
+     *
+     * If no port is present, and no scheme is present, this method MUST return
+     * a null value.
+     *
+     * If no port is present, but a scheme is present, this method MAY return
+     * the standard port for that scheme, but SHOULD return null.
+     *
+     * @return null|int The port for the URI.
+     */
+    public function getPort();
+
+    /**
+     * Retrieve the path segment of the URI.
+     *
+     * This method MUST return a string; if no path is present it MUST return
+     * an empty string.
+     *
+     * @return string The path segment of the URI.
+     */
+    public function getPath();
+
+    /**
+     * Retrieve the query string of the URI.
+     *
+     * This method MUST return a string; if no query string is present, it MUST
+     * return an empty string.
+     *
+     * The string returned MUST omit the leading "?" character.
+     *
+     * @return string The URI query string.
+     */
+    public function getQuery();
+
+    /**
+     * Retrieve the fragment segment of the URI.
+     *
+     * This method MUST return a string; if no fragment is present, it MUST
+     * return an empty string.
+     *
+     * The string returned MUST omit the leading "#" character.
+     *
+     * @return string The URI fragment.
+     */
+    public function getFragment();
+
+    /**
+     * Create a new instance with the specified scheme.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified scheme. If the scheme
+     * provided includes the "://" delimiter, it MUST be removed.
+     *
+     * Implementations SHOULD restrict values to "http", "https", or an empty
+     * string but MAY accommodate other schemes if required.
+     *
+     * An empty scheme is equivalent to removing the scheme.
+     *
+     * @param string $scheme The scheme to use with the new instance.
+     * @return self A new instance with the specified scheme.
+     * @throws \InvalidArgumentException for invalid or unsupported schemes.
+     */
+    public function withScheme($scheme);
+
+    /**
+     * Create a new instance with the specified user information.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified user information.
+     *
+     * Password is optional, but the user information MUST include the
+     * user; an empty string for the user is equivalent to removing user
+     * information.
+     *
+     * @param string $user User name to use for authority.
+     * @param null|string $password Password associated with $user.
+     * @return self A new instance with the specified user information.
+     */
+    public function withUserInfo($user, $password = null);
+
+    /**
+     * Create a new instance with the specified host.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified host.
+     *
+     * An empty host value is equivalent to removing the host.
+     *
+     * @param string $host Hostname to use with the new instance.
+     * @return self A new instance with the specified host.
+     * @throws \InvalidArgumentException for invalid hostnames.
+     */
+    public function withHost($host);
+
+    /**
+     * Create a new instance with the specified port.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified port.
+     *
+     * Implementations MUST raise an exception for ports outside the
+     * established TCP and UDP port ranges.
+     *
+     * A null value provided for the port is equivalent to removing the port
+     * information.
+     *
+     * @param null|int $port Port to use with the new instance; a null value
+     *     removes the port information.
+     * @return self A new instance with the specified port.
+     * @throws \InvalidArgumentException for invalid ports.
+     */
+    public function withPort($port);
+
+    /**
+     * Create a new instance with the specified path.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified path.
+     *
+     * The path MUST be prefixed with "/"; if not, the implementation MAY
+     * provide the prefix itself.
+     *
+     * An empty path value is equivalent to removing the path.
+     *
+     * @param string $path The path to use with the new instance.
+     * @return self A new instance with the specified path.
+     * @throws \InvalidArgumentException for invalid paths.
+     */
+    public function withPath($path);
+
+    /**
+     * Create a new instance with the specified query string.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified query string.
+     *
+     * If the query string is prefixed by "?", that character MUST be removed.
+     * Additionally, the query string SHOULD be parseable by parse_str() in
+     * order to be valid.
+     *
+     * An empty query string value is equivalent to removing the query string.
+     *
+     * @param string $query The query string to use with the new instance.
+     * @return self A new instance with the specified query string.
+     * @throws \InvalidArgumentException for invalid query strings.
+     */
+    public function withQuery($query);
+
+    /**
+     * Create a new instance with the specified URI fragment.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * a new instance that contains the specified URI fragment.
+     *
+     * If the fragment is prefixed by "#", that character MUST be removed.
+     *
+     * An empty fragment value is equivalent to removing the fragment.
+     *
+     * @param string $fragment The URI fragment to use with the new instance.
+     * @return self A new instance with the specified URI fragment.
+     */
+    public function withFragment($fragment);
+
+    /**
+     * Indicate whether the URI is in origin-form.
+     *
+     * Origin-form is a URI that includes only the path, and optionally the
+     * query string.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3.1
+     * @return bool
+     */
+    public function isOrigin();
+
+    /**
+     * Indicate whether the URI is absolute.
+     *
+     * An absolute URI contains minimally a non-empty scheme and non-empty
+     * authority.
+     *
+     * @see getAuthority()
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3.2
+     * @return bool
+     */
+    public function isAbsolute();
+
+    /**
+     * Indicate whether the URI is in authority form.
+     *
+     * An authority-form URI is an URI that contains ONLY the authority
+     * information.
+     *
+     * @see getAuthority()
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3.3
+     * @return bool
+     */
+    public function isAuthority();
+
+    /**
+     * Indicate whether the URI is an asterisk-form.
+     *
+     * An asterisk form URI will contain "*" as the path, and no other URI
+     * segments.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-5.3.4
+     * @return bool
+     */
+    public function isAsterisk();
+
+    /**
+     * Return the string representation of the URI.
+     *
+     * Concatenates the various segments of the URI, using the appropriate
+     * delimiters:
+     *
+     * - If a scheme is present, "://" MUST append the value.
+     * - If the authority information is present, that value will be
+     *   contatenated.
+     * - If a path is present, it MUST be prefixed by a "/" character.
+     * - If a query string is present, it MUST be prefixed by a "?" character.
+     * - If a URI fragment is present, it MUST be prefixed by a "#" character.
+     *
+     * @return string
+     */
+    public function __toString();
 }
 ```

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -339,50 +339,54 @@ interface RequestInterface extends MessageInterface
     public function setMethod($method);
 
     /**
-     * Retrieves the base request URL.
+     * Retrieves the absolute URI.
      *
-     * The base URL consists of:
+     * An absolute URI consists of minimally scheme and host, but can also
+     * contain:
      *
-     * - scheme
-     * - authentication (if any)
-     * - server name/host
+     * - authentication (user/pass) if provided
      * - port (if non-standard)
+     * - path (if any)
+     * - query string (if present)
+     * - fragment (if present)
      *
-     * This method is provided for convenience, particularly when considering
-     * server-side requests, where data such as the scheme and server name may
-     * need to be computed from more than one environmental variable.
+     * If either of the scheme or host are not present, this method MUST return
+     * null.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @return string Returns the base URL as a string. The URL MUST include
-     *     the scheme and host; if the port is non-standard for the scheme,
-     *     the port MUST be included; authentication data MAY be provided.
+     * @return string|null Returns the absolute URL as a string. The URL MUST
+     *     include the scheme and host; if the port is non-standard for the
+     *     scheme, the port MUST be included; authentication data MAY be
+     *     provided. If either host or scheme are missing, this method MUST
+     *     return null.
      */
-    public function getBaseUrl();
+    public function getAbsoluteUri();
 
     /**
-     * Sets the base request URL.
+     * Sets the absolute URI of the request.
      *
-     * The base URL MUST be a string, and MUST include the scheme and host.
+     * The absolute URI MUST be a string, and MUST include the scheme and host.
      *
      * If the port is non-standard for the scheme, the port MUST be provided.
      *
      * Authentication data MAY be provided.
      *
-     * If path, query string, or URL fragment are provided they SHOULD be
-     * stripped; optionally, an error MAY be raised in such situations.
+     * Path, query string, and fragment are optional.
+     *
+     * When setting the absolute URI, the url (see getUrl() and setUrl()) MUST
+     * be updated.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
-     * @param string $url Base request URL.
+     * @param string $uri Absolute request URI.
      * @return void
-     * @throws \InvalidArgumentException If the URL is invalid.
+     * @throws \InvalidArgumentException If the URI is invalid.
      */
-    public function setBaseUrl($url);
+    public function setAbsoluteUri($uri);
 
     /**
      * Retrieves the request URL.
      *
-     * The request URL is the same value as REQUEST_URI: the path and query
-     * string ONLY.
+     * The request URL is the path and query string ONLY.
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3
      * @return string Returns the URL as a string. The URL MUST be an
@@ -396,6 +400,9 @@ interface RequestInterface extends MessageInterface
      * The URL MUST be a string. The URL SHOULD be an origin-form (path + query
      * string) per RFC 7230 section 5.3; if other URL parts are present, the
      * method MUST raise an exception OR remove those parts.
+     *
+     * When setting the URL, the absolute URI (see getAbsoluteUri() and
+     * setAbsoluteUri()) MUST be updated.
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3
      * @param string $url Request URL, with path and optionally query string.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -490,6 +490,11 @@ interface ServerRequestInterface extends RequestInterface
      *
      * Retrieves the deserialized query string arguments, if any.
      *
+     * Note: the query params might not be in sync with the URL or server
+     * params. If you need to ensure you are only getting the original
+     * values, you may need to parse the composed URL or the `QUERY_STRING`
+     * composed in the server params.
+     *
      * @return array
      */
     public function getQueryParams();
@@ -504,6 +509,9 @@ interface ServerRequestInterface extends RequestInterface
      * MUST be compatible with what PHP's `parse_str()` would return for
      * purposes of how duplicate query parameters are handled, and how nested
      * sets are handled.
+     *
+     * Setting query string arguments MUST NOT change the URL stored by the
+     * request, nor the values in the server params.
      *
      * @param array $query Array of query string arguments, typically from
      *     $_GET.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -276,7 +276,7 @@ interface MessageInterface
     /**
      * Gets the body of the message.
      *
-     * @return StreamableInterface|null Returns the body, or null if not set.
+     * @return StreamableInterface Returns the body as a stream.
      */
     public function getBody();
 


### PR DESCRIPTION
This pull request obsoletes #400 and provides the following:

- Messages are now immutable. See the [mailing list discussion](https://groups.google.com/d/msg/php-fig/9gK8vX8iYZ8/5PZ9rx8UvXYJ) for the why and how. Primarily this means that setters were changed to mutator methods using the verbiage `with` and `without`, and now return a **new** instance that contains the requested updates.
- Addition of a new interface, `UriTargetInterface`. This interface models the request-target of a request message, including those formats that represent URIs per RFC 3986. `RequestInterface` now defines `getUri()` and `withUri(UriTargetInterface $uri)` instead of the `(get|set)Url()` equivalents from previous drafts.
- `setAttributes()` was removed. Per a comment from @Crell, this method suffered conceptually in the same way that `setHeaders()` and `addHeaders()` did. A new method, `withoutAttribute()` was added, however, to allow removing an attribute entirely.

I also spent a lot of time making sure the various docblocks fully described the interfaces and methods and the stipulations on behavior. I made similar updates to the proposal and metadata documents -- and particularly the latter, to ensure that the various design decisions have backing arguments.