### PR TITLE
[PSR-7] Changed verbiage of $header and $attribute arguments

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -71,7 +71,7 @@ and `$_POST`, respectively), providing a layer of convenience for web developers
 On the response side of the equation, PHP was originally developed as a
 templating language, and allows intermixing HTML and PHP; any HTML portions of
 a file are immediately flushed to the output buffer. Modern applications and
-frameworks, however, eschew this practice, as it can lead to issues with
+frameworks eschew this practice, as it can lead to issues with
 regards to emitting a status line and/or response headers; they tend to
 aggregate all headers and content, and emit them at once when all other
 application processing is complete. Special care needs to be paid to ensure
@@ -161,8 +161,8 @@ messages.
   frameworks to change their interfaces to conform. It is strictly meant for
   interoperability.
 * While everyone's perception of what is and is not an implementation detail
-  varies, this proposal should not impose implementation details. However,
-  because RFCs 7230, 7231, and 3986 do not force any particular implementation,
+  varies, this proposal should not impose implementation details. As
+  RFCs 7230, 7231, and 3986 do not force any particular implementation,
   there will be a certain amount of invention needed to describe HTTP message
   interfaces in PHP.
 
@@ -202,14 +202,14 @@ times in a give request -- and which would require parsing the URI in order to
 determine (e.g., via `parse_url()`). Modeling URIs as value objects allows
 parsing once only, and simplifies access to individual segments. It also
 provides convenience in client applications by allowing users to create new
-instances of a base URI instance with just the segments that change (e.g.,
+instances of a base URI instance with only the segments that change (e.g.,
 updating the path only).
 
 ### Why does the request interface have methods for dealing with the request-target AND compose a URI?
 
 RFC 7230 details the request line as containing a "request-target". Of the four
 forms of request-target, only one is a URI compliant with RFC 3986; the most
-common form used, however, is origin-form, which represents the URI without the
+common form used is origin-form, which represents the URI without the
 scheme or authority information. Moreover, since all forms are valid for
 purposes of requests, the proposal must accommodate each.
 
@@ -237,7 +237,7 @@ This is the very definition of a value object. The practice by which changes
 result in a new instance is termed [immutability](http://en.wikipedia.org/wiki/Immutable_object),
 and is a feature designed to ensure the integrity of a given value.
 
-However, the proposal also recognizes that most clients and server-side
+The proposal also recognizes that most clients and server-side
 applications will need to be able to easily update message aspects, and, as
 such, provides interface methods that will create new message instances with
 the updates. These are generally prefixed with the verbiage `with` or
@@ -386,7 +386,7 @@ correlations with the request and response messages described in
 implementing value objects that correspond to the specific HTTP message types
 they model.
 
-For server-side applications, however, there are other considerations for
+For server-side applications there are other considerations for
 incoming requests:
 
 - Access to server parameters (potentially derived from the request, but also

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -41,8 +41,8 @@ This is the response body
 
 The first line is the "status line", and contains, in order, the HTTP protocol
 version, the HTTP status code, and a "reason phrase," a human-readable
-description of the status code. Just like the request message, this is then
-followed by one or more HTTP headers, and empty line, and the message body.
+description of the status code. Like the request message, this is then
+followed by one or more HTTP headers, an empty line, and the message body.
 
 The interfaces described in this document are abstractions around HTTP messages
 and the elements composing them.
@@ -78,13 +78,13 @@ referring to these interfaces.
 
 #### 1.2 HTTP Headers
 
-##### Case-insensitive header names
+##### Case-insensitive header field names
 
-HTTP messages include case-insensitive header names. Headers are retrieved by name from
-classes implementing the `MessageInterface` interface in a case-insensitive
-manner. For example, retrieving the "foo" header will return the same result as
-retrieving the "FoO" header. Similarly, setting the "Foo" header will overwrite
-any previously set "foo" header.
+HTTP messages include case-insensitive header field names. Headers are retrieved
+by name from classes implementing the `MessageInterface` in a case-insensitive
+manner. For example, retrieving the `foo` header will return the same result as
+retrieving the `FoO` header. Similarly, setting the `Foo` header will overwrite
+any previously set `foo` header value.
 
 ```php
 $message = $message->withHeader('foo', 'bar');
@@ -112,7 +112,7 @@ request or response.
 
 In order to accommodate headers with multiple values yet still provide the
 convenience of working with headers as strings, headers can be retrieved from
-an instance of a ``MessageInterface`` as an array or string. Use the
+an instance of a `MessageInterface` as an array or a string. Use the
 `getHeader()` method to retrieve a header value as a string containing all
 header values of a case-insensitive header by name concatenated with a comma.
 Use `getHeaderLines()` to retrieve an array of all the header values for a
@@ -181,7 +181,7 @@ of the request line. The request target can be one of the following forms:
 - **authority-form**, which consists of the authority only. This is typically
   used in CONNECT requests only, to establish a connection between an HTTP
   client and a proxy server.
-- **asterisk-form**, which consists solely of the string '*', and which is used
+- **asterisk-form**, which consists solely of the string `*`, and which is used
   with the OPTIONS method to determine the general capabilities of a web server.
 
 Aside from these request-targets, there is often an 'effective URL' which is
@@ -357,12 +357,12 @@ interface MessageInterface
     /**
      * Checks if a header exists by the given case-insensitive name.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return bool Returns true if any header names match the given header
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($header);
+    public function hasHeader($name);
 
     /**
      * Retrieve a header by the given case-insensitive name, as a string.
@@ -375,18 +375,18 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeaderLines() instead
      * and supply your own delimiter when concatenating.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return string
      */
-    public function getHeader($header);
+    public function getHeader($name);
 
     /**
      * Retrieves a header by the given case-insensitive name as an array of strings.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return string[]
      */
-    public function getHeaderLines($header);
+    public function getHeaderLines($name);
 
     /**
      * Create a new instance with the provided header, replacing any existing
@@ -399,12 +399,12 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that has the
      * new and/or updated header and value.
      *
-     * @param string $header Header name
+     * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($header, $value);
+    public function withHeader($name, $value);
 
     /**
      * Creates a new instance, with the specified header appended with the
@@ -418,12 +418,12 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that has the
      * new header and/or value.
      *
-     * @param string $header Header name to add
+     * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($header, $value);
+    public function withAddedHeader($name, $value);
 
     /**
      * Creates a new instance, without the specified header.
@@ -434,10 +434,10 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that removes
      * the named header.
      *
-     * @param string $header HTTP header to remove
+     * @param string $name Case-insensitive header field name to remove.
      * @return self
      */
-    public function withoutHeader($header);
+    public function withoutHeader($name);
 
     /**
      * Gets the body of the message.
@@ -767,11 +767,11 @@ interface ServerRequestInterface extends RequestInterface
      * specifying a default value to return if the attribute is not found.
      *
      * @see getAttributes()
-     * @param string $attribute Attribute name.
+     * @param string $name The attribute name.
      * @param mixed $default Default value to return if the attribute does not exist.
      * @return mixed
      */
-    public function getAttribute($attribute, $default = null);
+    public function getAttribute($name, $default = null);
 
     /**
      * Create a new instance with the specified derived request attribute.
@@ -784,11 +784,11 @@ interface ServerRequestInterface extends RequestInterface
      * updated attribute.
      *
      * @see getAttributes()
-     * @param string $attribute The attribute name.
+     * @param string $name The attribute name.
      * @param mixed $value The value of the attribute.
      * @return self
      */
-    public function withAttribute($attribute, $value);
+    public function withAttribute($name, $value);
 
     /**
      * Create a new instance that removes the specified derived request
@@ -802,10 +802,10 @@ interface ServerRequestInterface extends RequestInterface
      * the attribute.
      *
      * @see getAttributes()
-     * @param string $attribute The attribute name.
+     * @param string $name The attribute name.
      * @return self
      */
-    public function withoutAttribute($attribute);
+    public function withoutAttribute($name);
 }
 ```
 
@@ -1298,7 +1298,7 @@ interface UriInterface
      *
      * - If a scheme is present, "://" MUST append the value.
      * - If the authority information is present, that value will be
-     *   contatenated.
+     *   concatenated.
      * - If a path is present, it MUST be prefixed by a "/" character.
      * - If a query string is present, it MUST be prefixed by a "?" character.
      * - If a URI fragment is present, it MUST be prefixed by a "#" character.


### PR DESCRIPTION
Changed the verbiage of header and attribute related method arguments
to `$name` instead of `$header` or `$attribute` to improve on readability as
otherwise the arguments might be seen as objects (e.g. `$header` could be
misinterpreted as needing a specific implementation like `AuthHeader`
instead of being a header field name string).

See https://github.com/php-fig/fig-standards/issues/410 and respective PR.

Removed a few `however`/`just` instances in the meta-message text as those
words should probably be avoided in technical documentation (like easy, simply
clearly etc.). Hope this doesn't make this PR fail.