### PR TITLE
[PSR-7] Detail Host header sources

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -501,12 +501,30 @@ namespace Psr\Http\Message;
 interface RequestInterface extends MessageInterface
 {
     /**
+     * Extends MessageInterface::getHeaders() to provide request-specific
+     * behavior.
+     *
+     * Retrieves all message headers.
+     *
+     * This method acts exactly like MessageInterface::getHeaders(), with one
+     * behavioral change: if the Host header has not been previously set, the
+     * method MUST attempt to pull the host segment of the composed URI, if
+     * present.
+     *
+     * @see MessageInterface::getHeaders()
+     * @see UriInterface::getHost()
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings.
+     */
+    public function getHeaders();
+
+    /**
      * Extends MessageInterface::getHeader() to provide request-specific
      * behavior.
      *
      * This method acts exactly like MessageInterface::getHeader(), with
      * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method SHOULD attempt to pull the host
+     * not been previously set, the method MUST attempt to pull the host
      * segment of the composed URI, if present.
      *
      * @see MessageInterface::getHeader()
@@ -515,6 +533,24 @@ interface RequestInterface extends MessageInterface
      * @return string
      */
     public function getHeader($name);
+
+    /**
+     * Extends MessageInterface::getHeaderLines() to provide request-specific
+     * behavior.
+     *
+     * Retrieves a header by the given case-insensitive name as an array of strings.
+     *
+     * This method acts exactly like MessageInterface::getHeaderLines(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method MUST attempt to pull the host
+     * segment of the composed URI, if present.
+     *
+     * @see MessageInterface::getHeaderLines()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string[]
+     */
+    public function getHeaderLines($name);
 
     /**
      * Retrieves the message's request target.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -135,6 +135,17 @@ Note: Not all header values can be concatenated using a comma (e.g.,
 `MessageInterface`-based classes SHOULD rely on the `getHeaderLines()` method
 for retrieving such multi-valued headers.
 
+##### Host header
+
+In requests, the Host header typically mirrors the host segment of the URI, as
+well as the host used when establishing the TCP connection. However, the HTTP
+specification allows the Host header to differ from each of the two.
+
+The `RequestInterface` overrides the `MessageInterface::getHeader()` method to
+indicate that if no Host header is present, but a host segment is present in the
+composed `UriInterface`, the value from the URI should be used. If a Host header
+is explicitly provided to the request instance, that value will be preferred.
+
 ### 1.3 Streams
 
 HTTP messages consist of a start-line, headers, and a body. The body of an HTTP
@@ -489,6 +500,22 @@ namespace Psr\Http\Message;
  */
 interface RequestInterface extends MessageInterface
 {
+    /**
+     * Extends MessageInterface::getHeader() to provide request-specific
+     * behavior.
+     *
+     * This method acts exactly like MessageInterface::getHeader(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method SHOULD attempt to pull the host
+     * segment of the composed URI, if present.
+     *
+     * @see MessageInterface::getHeader()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string
+     */
+    public function getHeader($name);
+
     /**
      * Retrieves the message's request target.
      *


### PR DESCRIPTION
Per [the mailing
list](https://groups.google.com/forum/#!msg/php-fig/yZGMFW_fWEk/uuZlhmtIN_8J),
this patch details that the Host header should be pulled from the composed
`UriInterface`'s host segment if:

- no value is present for the Host header, AND
- the composed URI has a host segment.