### PR TITLE
[PSR-7] Added language to withPath() regarding percent encoding

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1287,6 +1287,10 @@ interface UriInterface
      * Additionally, the query string SHOULD be parseable by parse_str() in
      * order to be valid.
      *
+     * The implementation MUST percent encode reserved characters as
+     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
+     * characters.
+     *
      * An empty query string value is equivalent to removing the query string.
      *
      * @param string $query The query string to use with the new instance.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1265,7 +1265,7 @@ interface UriInterface
      * The path MUST be prefixed with "/"; if not, the implementation MAY
      * provide the prefix itself.
      *
-     * The implementation MUST percent encode reserved characters as
+     * The implementation MUST percent-encode reserved characters as
      * specified in RFC 3986, Section 2, but MUST NOT double-encode any
      * characters.
      *
@@ -1287,7 +1287,7 @@ interface UriInterface
      * Additionally, the query string SHOULD be parseable by parse_str() in
      * order to be valid.
      *
-     * The implementation MUST percent encode reserved characters as
+     * The implementation MUST percent-encode reserved characters as
      * specified in RFC 3986, Section 2, but MUST NOT double-encode any
      * characters.
      *

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1265,6 +1265,10 @@ interface UriInterface
      * The path MUST be prefixed with "/"; if not, the implementation MAY
      * provide the prefix itself.
      *
+     * The implementation MUST percent encode reserved characters as
+     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
+     * characters.
+     *
      * An empty path value is equivalent to removing the path.
      *
      * @param string $path The path to use with the new instance.


### PR DESCRIPTION
Per RFC 3986, section2, reserved characters MUST be percent encoded; however,
the implementation MUST NOT double-encode.

See the relevant discussion on the mailing list for more details:

- https://groups.google.com/d/msgid/php-fig/d5102d77-dab0-48cd-8e79-2999128ed948%40googlegroups.com