### PR TITLE
 Document return values for non-existant headers

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -376,8 +376,10 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeaderLines() instead
      * and supply your own delimiter when concatenating.
      *
+     * If the header did not exist, this method should return a null value.
+     *
      * @param string $name Case-insensitive header field name.
-     * @return string
+     * @return string|null
      */
     public function getHeader($name);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -376,7 +376,8 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeaderLines() instead
      * and supply your own delimiter when concatenating.
      *
-     * If the header did not exist, this method should return a null value.
+     * If the header did not appear in the message, this method should return
+     * a null value.
      *
      * @param string $name Case-insensitive header field name.
      * @return string|null
@@ -385,6 +386,9 @@ interface MessageInterface
 
     /**
      * Retrieves a header by the given case-insensitive name as an array of strings.
+     *
+     * If the header did not appear in the message, this method should return an
+     * empty array.
      *
      * @param string $name Case-insensitive header field name.
      * @return string[]


### PR DESCRIPTION
Allow `getHeader()` to return `null` if the header did not exist.

@weierophinney does this make sense? I noticed that phly/http returns an empty string, but there's a difference between an empty header, and no header at all.