### PR TITLE
[PSR-7] Use `#`-prefixed headers instead of separator-style

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -1,8 +1,6 @@
-HTTP Message Meta Document
-==========================
+# HTTP Message Meta Document
 
-1. Summary
-----------
+## 1. Summary
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
 messages as described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
@@ -30,8 +28,7 @@ In PHP, HTTP messages are used in two contexts:
 This proposal presents an API for fully describing all parts of the various
 HTTP messages within PHP.
 
-2. HTTP Messages in PHP
------------------------
+## 2. HTTP Messages in PHP
 
 PHP does not have built-in support for HTTP messages.
 
@@ -78,8 +75,7 @@ application processing is complete. Special care needs to be paid to ensure
 that error reporting and other actions that send content to the output buffer
 do not flush the output buffer.
 
-3. Why Bother?
---------------
+## 3. Why Bother?
 
 HTTP messages are used in a wide number of PHP projects -- both clients and
 servers. In each case, we observe one or more of the following patterns or
@@ -140,8 +136,7 @@ current interfaces utilized by existing PHP libraries. This proposal is aimed
 at interoperability between PHP packages for the purpose of describing HTTP
 messages.
 
-4. Scope
---------
+## 4. Scope
 
 ### 4.1 Goals
 
@@ -166,8 +161,7 @@ messages.
   there will be a certain amount of invention needed to describe HTTP message
   interfaces in PHP.
 
-5. Design Decisions
--------------------
+## 5. Design Decisions
 
 ### Message design
 
@@ -505,8 +499,7 @@ Examples of this practice already exist in libraries such as
 has functionality for casting the value to a string, these objects can be
 used to populate the headers of an HTTP message.
 
-6. People
----------
+## 6. People
 
 ### 6.1 Editor(s)
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1,5 +1,4 @@
-HTTP message interfaces
-=======================
+# HTTP message interfaces
 
 This document describes common interfaces for representing HTTP messages as
 described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
@@ -59,8 +58,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 - [RFC 7231](http://tools.ietf.org/html/rfc7231)
 
 
-1. Specification
-----------------
+## 1. Specification
 
 ### 1.1 Messages
 
@@ -286,14 +284,12 @@ application-specific rules (such as path matching, scheme matching, host
 matching, etc.). As such, the server request can also provide messaging between
 multiple request consumers.
 
-2. Package
-----------
+## 2. Package
 
 The interfaces and classes described are provided as part of the
 [psr/http-message](https://packagist.org/packages/psr/http-message) package.
 
-3. Interfaces
--------------
+## 3. Interfaces
 
 ### 3.1 `Psr\Http\Message\MessageInterface`
 


### PR DESCRIPTION
Per #453, using separator-style headers (those with `===` and `---` filled lines
following the header) can cause rendering issues if the header starts with a
`{number}.` prefix. All other proposals use `#`-prefixed headers, likely to
address this very issue, so this patch alters headers to do the same both for
consistency and to correct rendering issues.

Fixes #453