### PR TITLE
[PSR-7] Return "/" from UriInterface::getPath()

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1222,7 +1222,7 @@ interface UriInterface
      * Retrieve the path segment of the URI.
      *
      * This method MUST return a string; if no path is present it MUST return
-     * an empty string.
+     * the string "/".
      *
      * @return string The path segment of the URI.
      */


### PR DESCRIPTION
Per discussion on #426, RFC 3986 declares an empty path and the path "/" as
equivalent. For consistency, the interface should return "/" for either case.