### PR TITLE
[PSR-7] TCP abbreviation should be uppercase

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -241,7 +241,7 @@ OPTIONS * HTTP/1.1
 ```
 
 But the HTTP client will be able to use the effective URL (from `getUri()`),
-to determine the protocol, hostname and tcp port.
+to determine the protocol, hostname and TCP port.
 
 A HTTP client MUST ignore the values of `Uri::getPath()` and `Uri::getQuery()`,
 and instead use the value returned by `getRequestTarget()`, which defaults


### PR DESCRIPTION
This is very minor change. `tcp` in text was changed to `TCP` since it's an abbreviation.