### PR TITLE
[PSR-7] Fixed a typo in an example

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -230,7 +230,7 @@ For example, a user may want to make an asterisk-form request to a server:
 ```php
 $request = $request
     ->withMethod('OPTIONS')
-    ->withRequestForm('*')
+    ->withRequestTarget('*')
     ->withUri(new Uri('https://example.org/'));
 ```
 


### PR DESCRIPTION
`s/withRequestForm/withRequestTarget/`; thanks to @webmozart for reporting the issue.