### PR TITLE
[WIP] split of security reporting from PSR-9

### DIFF
--- a/proposed/security-reporting-process-meta.md
+++ b/proposed/security-reporting-process-meta.md
@@ -1,0 +1,89 @@
+Security Disclosure Meta Document
+=================================
+
+1. Summary
+----------
+
+Unfortunately with all software development, security vulnerabilities are a
+fact of life that need to be addressed. It is important that when security
+vulnerabilities are found that researchers have an easy channel to the
+projects in question allowing them to disclose the issue to a controlled
+group of people.
+
+
+2. Why Bother?
+--------------
+
+As of right now, there isn't really a common standard for most parts of this
+process. There isn't a standard where researchers can find out about the
+process for handling security issues for any given project. There is also
+no standard that explains to researchers what they can expect to happen if
+they report a vulnerability.
+
+3. Scope
+--------
+
+## 3.1 Goals
+
+* A defined process for how vulnerabilities are reported, how these get fixed
+  and finally disclosed to the public
+
+## 3.2 Non-Goals
+
+* Methods for reducing security vulnerabilities
+* Publication of security issues and fixes
+
+4. Approaches
+-------------
+
+Currently the most viable approach seems to be defining a base line workflow
+for how security vulnerabilities go from discovery to fixing to public
+disclosure. Inspiration could be drawn from [1].
+
+For further reference here is a list of security disclosure processes in
+various PHP and non-PHP projects:
+
+* http://symfony.com/doc/current/contributing/code/security.html
+* http://framework.zend.com/security/
+* http://www.yiiframework.com/security/
+* https://www.drupal.org/security
+* http://codex.wordpress.org/FAQ_Security
+* http://www.sugarcrm.com/page/sugarcrm-security-policy/en
+* http://typo3.org/teams/security/
+* http://cakephp.org/development
+* http://www.concrete5.org/developers/security/
+* http://developer.joomla.org/security.html
+* http://wiki.horde.org/SecurityManagement
+* http://www.revive-adserver.com/support/bugs/
+* http://magento.com/security
+* http://www.apache.org/security/committers.html
+* https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/
+* http://www.openbsd.org/security.html
+
+A summary of the differences and similarities can be found here:
+https://groups.google.com/d/msg/php-fig-psr-9-discussion/puGV_X0bj_M/Jr_IAS40StsJ
+
+5. People
+---------
+
+### 5.1 Editor
+
+* Lukas Kahwe Smith
+
+### 5.2 Sponsors
+
+* Larry Garfield (Drupal)
+* Korvin Szanto (concrete5)
+
+### 5.3 Coordinator
+
+* Korvin Szanto (concrete5)
+
+6. Votes
+--------
+
+
+7. Relevant Links
+-----------------
+
+[1]: http://symfony.com/doc/current/contributing/code/security.html

--- a/proposed/security-reporting-process.md
+++ b/proposed/security-reporting-process.md
@@ -1,0 +1,54 @@
+## Introduction
+
+Unfortunately with all software development, security vulnerabilities are a
+fact of life that need to be addressed. It is important that when security
+vulnerabilities are found that researchers have an easy channel to the
+projects in question allowing them to disclose the issue to a controlled
+group of people.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119][].
+
+[RFC 2119]: http://tools.ietf.org/html/rfc2119
+
+## Goal
+
+The goal of this PSR is to give researchers, project leads, upstream project
+leads and end user a defined and structured process for disclosing security
+vulnerabilities.
+
+## Security Disclosure Process Discovery
+
+Every project MUST provide a link to its security disclosure process in
+an obvious place. Ideally this should be on the main domain of the given
+project. This MAY be a sub-domain in case it is a sub-project of a larger
+initiative. The link MAY use the custom link relation
+``php-disclosure-process``, ie. for example
+``<link rel="php-disclosure-process" href="http://example.org/security"/>``.
+
+Projects SHOULD ideally make the location prominent itself
+by either creating a dedicated sub-domain like ``http://security.example.org``
+or by making it a top level directory like ``http://example.org/security``.
+Alternatively projects MAY also simply reference this document, ie. PSR-9.
+
+Note that projects MAY not have a dedicated domain. For example a project
+hosted on Github, Bitbucket or other service should still ensure that the
+process is referenced on the landing page, ie. for example
+http://github.com/example/somelib should ensure that the default branch
+has a README file which references the procedures used so that it is
+automatically displayed.
+
+If necessary projects MAY have different disclosure process
+for different major version number. In this case one URL SHOULD be provided
+for each major version. In the case a major version is no longer receiving
+security fixes, instead of an URL a project MAY opt to instead simply
+note that the version is no longer receiving security fixes.
+
+## Security Disclosure Process
+
+Every project MUST provide an email address in their security disclosure
+process description. If not specified otherwise, this email address is
+``security@[project domain]``. Projects SHALL NOT use contact forms.
+
+...?


### PR DESCRIPTION
as discussed on the list we decided it would make more sense to split the security disclosure (https://github.com/php-fig/fig-standards/pull/393/files) aspect from the security reporting aspect.