### PR TITLE
Updated the translations of psr-3 to match the current spec

### DIFF
--- a/accepted/es/PSR-3-interfaz-de-logger.md
+++ b/accepted/es/PSR-3-interfaz-de-logger.md
@@ -104,112 +104,120 @@ implementación se proveen como parte del paquete [psr/log](https://packagist.or
 namespace Psr\Log;
 
 /**
- * Describe una instancia de logger
- * 
- * El mensaje DEBE ser una cadena o un objecto que implemente __toString().
+ * Describes a logger instance.
  *
- * El mensaje PUEDE contener marcadores con el formato: {foo} donde foo
- * será reemplazado por el valor de la clave "foo" en el array de contexto.
+ * The message MUST be a string or object implementing __toString().
  *
- * El array de contexto puede contener cualquier dato arbitrario de datos, la
- * única suposición que pueden hacer las implementaciones es si se provee
- * una instancia de `Exception` para producir una pila de trazas, ésta TIENE QUE
- * estar en la clave "exception".
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
  *
- * Revise https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
- * para obtener la especificación completa de esta interfaz.
+ * The context array can contain arbitrary data. The only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
  */
 interface LoggerInterface
 {
     /**
-     * El sistema no está disponible.
+     * System is unusable.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function emergency($message, array $context = array());
 
     /**
-     * Debe actuarse de manera inmediata.
+     * Action must be taken immediately.
      *
-     * Ejemplo: Sitio web caído, base de datos no disponible, etc. Esto debería
-     * mandar un SMS de alerta y despertarle.
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function alert($message, array $context = array());
 
     /**
-     * Condiciones críticas.
+     * Critical conditions.
      *
-     * Ejemplo: Componente de la aplicación no disponible, excepción inesperada.
+     * Example: Application component unavailable, unexpected exception.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function critical($message, array $context = array());
 
     /**
-     * Errores en tiempo de ejecución que no requieren de una acción inmediata
-     * pero que deberían ser imprimidas en el log y monitoreadas.
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function error($message, array $context = array());
 
     /**
-     * Evento excepcional pero que no implica error sino adevertencia.
+     * Exceptional occurrences that are not errors.
      *
-     * Ejemplo: Uso de APIs obsoletas, mal uso de un API, cosas indeseables que
-     * no son necesariamente un error.
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function warning($message, array $context = array());
 
     /**
-     * Eventos normales pero significantes.
+     * Normal but significant events.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function notice($message, array $context = array());
 
     /**
-     * Evento interesante.
+     * Interesting events.
      *
-     * Ejemplo: Acceso de usuarios, SQL logs.
+     * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function info($message, array $context = array());
 
     /**
-     * Información detallada de debug.
+     * Detailed debug information.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function debug($message, array $context = array());
 
     /**
-     * Imprime un log con nivel arbitrario.
+     * Logs with an arbitrary level.
      *
-     * @param mixed $level
+     * @param mixed  $level
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function log($level, $message, array $context = array());
@@ -225,14 +233,15 @@ interface LoggerInterface
 namespace Psr\Log;
 
 /**
- * Describe un objecto que soporta loggers.
+ * Describes a logger-aware instance.
  */
 interface LoggerAwareInterface
 {
     /**
-     * Define una instancia de log en el objeto
+     * Sets a logger instance on the object.
      *
      * @param LoggerInterface $logger
+     *
      * @return null
      */
     public function setLogger(LoggerInterface $logger);
@@ -248,20 +257,21 @@ interface LoggerAwareInterface
 namespace Psr\Log;
 
 /**
- * Describe los niveles de log
+ * Describes log levels.
  */
 class LogLevel
 {
     const EMERGENCY = 'emergency';
-    const ALERT     = 'alert';
-    const CRITICAL  = 'critical';
-    const ERROR     = 'error';
-    const WARNING   = 'warning';
-    const NOTICE    = 'notice';
-    const INFO      = 'info';
-    const DEBUG     = 'debug';
+    const ALERT = 'alert';
+    const CRITICAL = 'critical';
+    const ERROR = 'error';
+    const WARNING = 'warning';
+    const NOTICE = 'notice';
+    const INFO = 'info';
+    const DEBUG = 'debug';
 }
 ```
+
 Notas
 --------
 

--- a/accepted/fr/PSR-3-logger-interface.md
+++ b/accepted/fr/PSR-3-logger-interface.md
@@ -154,113 +154,120 @@ pertinents et une suite de tests pour vérifier votre mise en œuvre fournies pa
 namespace Psr\Log;
 
 /**
- * Décrit une instance logger
+ * Describes a logger instance.
  *
- * Le message DOIT être une chaîne ou un objet qui implémente __ toString ().
+ * The message MUST be a string or object implementing __toString().
  *
- * Le message PEUT contenir des marqueurs à la forme: {foo} où foo
- * sera remplacé par les données de contexte à clé "foo".
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
  *
- * Le tableau de contexte peut contenir des données arbitraires, la seule
- * hypothèse qui peut être faite par des réalisateurs, c'est que si une instance
- * de Exception est donné pour produire une trace de la pile, il DOIT être dans
- * une clé nommée "exception".
+ * The context array can contain arbitrary data. The only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
  *
- * Voir https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
- * pour la spécification d'interface complète.
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
  */
 interface LoggerInterface
 {
     /**
-     * Le système est inutilisable.
+     * System is unusable.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function emergency($message, array $context = array());
 
     /**
-     * Des mesures doivent être prises immédiatement.
-     *
-     * Exemple: Tout le site est hors service, la base de données est
-     * indisponible, etc. Cela devrait déclencher des alertes par SMS et vous
-     * réveiller.
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function alert($message, array $context = array());
 
     /**
-     * Conditions critiques.
-     *
-     * Exemple: Composant d'application indisponible, exception inattendue.
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function critical($message, array $context = array());
 
     /**
-     * Erreurs d'exécution qui ne nécessitent pas une action immédiate mais doit
-     * normalement être journalisée et contrôlée.
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function error($message, array $context = array());
 
     /**
-     * Événements exceptionnels qui ne sont pas des erreurs.
-     *
-     * Exemple: Utilisation des API obsolètes, mauvaise utilisation d'une API,
-     * indésirables élements qui ne sont pas nécessairement mauvais.
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function warning($message, array $context = array());
 
     /**
-     * Événements normaux mais significatifs.
+     * Normal but significant events.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function notice($message, array $context = array());
 
     /**
-     * Événements intéressants.
+     * Interesting events.
      *
-     * Exemple: Connexion utilisateur, journaux SQL.
+     * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function info($message, array $context = array());
 
     /**
-     * Informations détaillées de débogage.
+     * Detailed debug information.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function debug($message, array $context = array());
 
     /**
-     * Logs avec un niveau arbitraire.
+     * Logs with an arbitrary level.
      *
-     * @param mixed $level
+     * @param mixed  $level
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function log($level, $message, array $context = array());
@@ -276,14 +283,15 @@ interface LoggerInterface
 namespace Psr\Log;
 
 /**
- * Décrit une instance logger-aware
+ * Describes a logger-aware instance.
  */
 interface LoggerAwareInterface
 {
     /**
-     * Définit une instance logger sur l'objet
+     * Sets a logger instance on the object.
      *
      * @param LoggerInterface $logger
+     *
      * @return null
      */
     public function setLogger(LoggerInterface $logger);
@@ -299,17 +307,17 @@ interface LoggerAwareInterface
 namespace Psr\Log;
 
 /**
- * Décrit les niveaux de journalisation
+ * Describes log levels.
  */
 class LogLevel
 {
     const EMERGENCY = 'emergency';
-    const ALERT     = 'alert';
-    const CRITICAL  = 'critical';
-    const ERROR     = 'error';
-    const WARNING   = 'warning';
-    const NOTICE    = 'notice';
-    const INFO      = 'info';
-    const DEBUG     = 'debug';
+    const ALERT = 'alert';
+    const CRITICAL = 'critical';
+    const ERROR = 'error';
+    const WARNING = 'warning';
+    const NOTICE = 'notice';
+    const INFO = 'info';
+    const DEBUG = 'debug';
 }
 ```

--- a/accepted/sl/PSR-3-logger-interface.md
+++ b/accepted/sl/PSR-3-logger-interface.md
@@ -145,14 +145,14 @@ paketa [psr/log](https://packagist.org/packages/psr/log).
 namespace Psr\Log;
 
 /**
- * Describes a logger instance
+ * Describes a logger instance.
  *
  * The message MUST be a string or object implementing __toString().
  *
  * The message MAY contain placeholders in the form: {foo} where foo
  * will be replaced by the context data in key "foo".
  *
- * The context array can contain arbitrary data, the only assumption that
+ * The context array can contain arbitrary data. The only assumption that
  * can be made by implementors is that if an Exception instance is given
  * to produce a stack trace, it MUST be in a key named "exception".
  *
@@ -165,7 +165,8 @@ interface LoggerInterface
      * System is unusable.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function emergency($message, array $context = array());
@@ -177,7 +178,8 @@ interface LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function alert($message, array $context = array());
@@ -188,7 +190,8 @@ interface LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function critical($message, array $context = array());
@@ -198,7 +201,8 @@ interface LoggerInterface
      * be logged and monitored.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function error($message, array $context = array());
@@ -210,7 +214,8 @@ interface LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function warning($message, array $context = array());
@@ -219,7 +224,8 @@ interface LoggerInterface
      * Normal but significant events.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function notice($message, array $context = array());
@@ -230,7 +236,8 @@ interface LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function info($message, array $context = array());
@@ -239,7 +246,8 @@ interface LoggerInterface
      * Detailed debug information.
      *
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function debug($message, array $context = array());
@@ -247,9 +255,10 @@ interface LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed $level
+     * @param mixed  $level
      * @param string $message
-     * @param array $context
+     * @param array  $context
+     *
      * @return null
      */
     public function log($level, $message, array $context = array());
@@ -265,14 +274,15 @@ interface LoggerInterface
 namespace Psr\Log;
 
 /**
- * Describes a logger-aware instance
+ * Describes a logger-aware instance.
  */
 interface LoggerAwareInterface
 {
     /**
-     * Sets a logger instance on the object
+     * Sets a logger instance on the object.
      *
      * @param LoggerInterface $logger
+     *
      * @return null
      */
     public function setLogger(LoggerInterface $logger);
@@ -288,17 +298,17 @@ interface LoggerAwareInterface
 namespace Psr\Log;
 
 /**
- * Describes log levels
+ * Describes log levels.
  */
 class LogLevel
 {
     const EMERGENCY = 'emergency';
-    const ALERT     = 'alert';
-    const CRITICAL  = 'critical';
-    const ERROR     = 'error';
-    const WARNING   = 'warning';
-    const NOTICE    = 'notice';
-    const INFO      = 'info';
-    const DEBUG     = 'debug';
+    const ALERT = 'alert';
+    const CRITICAL = 'critical';
+    const ERROR = 'error';
+    const WARNING = 'warning';
+    const NOTICE = 'notice';
+    const INFO = 'info';
+    const DEBUG = 'debug';
 }
 ```


### PR DESCRIPTION
Based on the fact that #474 gets merged, then the translations need updating.

Also, I have no idea why the code samples where translated as they should exactly match the implementation we provide, which is in English. We do not provide non-english psr log packages.

The translations where also inconstant because the code in accepted/sl/PSR-3-logger-interface.md wasn't actually translated.