### PR TITLE
[PSR-7] Scheme delimiters clarification

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -631,26 +631,3 @@ used to populate the headers of an HTTP message.
 * Evert Pot
 * Phil Sturgeon
 * Chris Wilkinson
-
-## 7. Votes
-
-## 8. Errata
-
-### 8.1 Scheme Delimiters
-
-Per [RFC 3986 section 3](https://tools.ietf.org/html/rfc3986#section-3), `:` is
-considered a closing delimiter for a scheme, and `//` is considered an
-opening delimeter for the URI authority.
-
-In the specification as accepted, `Psr\Http\Message\UriInterface` indicates that
-the methods `withScheme()` and `getScheme()` should ignore a trailing `://`
-delimiter for purposes of consistency. (No similar stipulation is placed on the
-authority, as authority is not treated as a single segment, but rather as its
-own individual segments (`user-info`, `host`, and `port`)).
-
-The `://` delimiter was called out specifically, as schemes are widely either
-presented as the bare-word (e.g., `http`, `https`) or with that delimiter (e.g.,
-`http://`, `https://`), which is the combination of the scheme closing delimiter
-and the authority opening delimiter. However, implementations of the methods
-MUST also strip a closing `:` delimiter when presented without the opening `//`
-delimiter.

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -631,3 +631,26 @@ used to populate the headers of an HTTP message.
 * Evert Pot
 * Phil Sturgeon
 * Chris Wilkinson
+
+## 7. Votes
+
+## 8. Errata
+
+### 8.1 Scheme Delimiters
+
+Per [RFC 3986 section 3](https://tools.ietf.org/html/rfc3986#section-3), `:` is
+considered a closing delimiter for a scheme, and `//` is considered an
+opening delimeter for the URI authority.
+
+In the specification as accepted, `Psr\Http\Message\UriInterface` indicates that
+the methods `withScheme()` and `getScheme()` should ignore a trailing `://`
+delimiter for purposes of consistency. (No similar stipulation is placed on the
+authority, as authority is not treated as a single segment, but rather as its
+own individual segments (`user-info`, `host`, and `port`)).
+
+The `://` delimiter was called out specifically, as schemes are widely either
+presented as the bare-word (e.g., `http`, `https`) or with that delimiter (e.g.,
+`http://`, `https://`), which is the combination of the scheme closing delimiter
+and the authority opening delimiter. However, implementations of the methods
+MUST also strip a closing `:` delimiter when presented without the opening `//`
+delimiter.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -520,7 +520,7 @@ interface RequestInterface extends MessageInterface
      *
      * This method acts exactly like MessageInterface::getHeaders(), with one
      * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host segment of the composed URI, if
+     * method MUST attempt to pull the host component of the composed URI, if
      * present.
      *
      * @see MessageInterface::getHeaders()
@@ -537,7 +537,7 @@ interface RequestInterface extends MessageInterface
      * This method acts exactly like MessageInterface::getHeader(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
@@ -555,7 +555,7 @@ interface RequestInterface extends MessageInterface
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
@@ -1208,17 +1208,17 @@ interface UriInterface
     public function getUserInfo();
 
     /**
-     * Retrieve the host segment of the URI.
+     * Retrieve the host component of the URI.
      *
-     * This method MUST return a string; if no host segment is present, an
+     * This method MUST return a string; if no host component is present, an
      * empty string MUST be returned.
      *
-     * @return string Host segment of the URI.
+     * @return string Host component of the URI.
      */
     public function getHost();
 
     /**
-     * Retrieve the port segment of the URI.
+     * Retrieve the port component of the URI.
      *
      * If a port is present, and it is non-standard for the current scheme,
      * this method MUST return it as an integer. If the port is the standard port
@@ -1257,7 +1257,7 @@ interface UriInterface
     public function getQuery();
 
     /**
-     * Retrieve the fragment segment of the URI.
+     * Retrieve the fragment component of the URI.
      *
      * This method MUST return a string; if no fragment is present, it MUST
      * return an empty string.
@@ -1391,7 +1391,7 @@ interface UriInterface
     /**
      * Return the string representation of the URI.
      *
-     * Concatenates the various segments of the URI, using the appropriate
+     * Concatenates the various components of the URI, using the appropriate
      * delimiters:
      *
      * - If a scheme is present, "://" MUST append the value.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1163,10 +1163,10 @@ interface UriInterface
      *
      * If no scheme is present, this method MUST return an empty string.
      *
-     * The string returned MUST omit the trailing "://" delimiter if present.
+     * The string MUST omit the closing scheme delimiter (":") or the
+     * combination of the closing scheme delimiter and the opening authority
+     * delimiter ("://"), if present.
      *
-     * @see https://github.com/php-fig/fig-standards/blob/proposed/http-message-meta.md#81-scheme-delimiters
-     *     which indicates ":" delimiters must also be omitted.
      * @return string The scheme of the URI.
      */
     public function getScheme();
@@ -1270,16 +1270,16 @@ interface UriInterface
      * Return an instance with the specified scheme.
      *
      * This method MUST retain the state of the current instance, and return
-     * an instance that contains the specified scheme. If the scheme
-     * provided includes the "://" delimiter, it MUST be removed.
+     * a new instance that contains the specified scheme. If the scheme
+     * provided includes either the closing scheme delimiter (":") or the
+     * combination of the closing scheme delimiter and the opening authority
+     * delimiter ("://"), these strings should be removed.
      *
      * Implementations SHOULD restrict values to "http", "https", or an empty
      * string but MAY accommodate other schemes if required.
      *
      * An empty scheme is equivalent to removing the scheme.
      *
-     * @see https://github.com/php-fig/fig-standards/blob/proposed/http-message-meta.md#81-scheme-delimiters
-     *     which indicates ":" delimiters must also be omitted.
      * @param string $scheme The scheme to use with the new instance.
      * @return self A new instance with the specified scheme.
      * @throws \InvalidArgumentException for invalid or unsupported schemes.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1271,8 +1271,8 @@ interface UriInterface
     /**
      * Return an instance with the specified scheme.
      *
-     * This method MUST retain the state of the current instance, and return a
-     * new instance that contains the specified scheme.
+     * This method MUST retain the state of the current instance, and return an
+     * instance that contains the specified scheme.
      *
      * Implementations MUST support an empty scheme AND the schemes "http" and
      * "https", but MAY accept other schemes if required.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1165,6 +1165,8 @@ interface UriInterface
      *
      * The string returned MUST omit the trailing "://" delimiter if present.
      *
+     * @see https://github.com/php-fig/fig-standards/blob/proposed/http-message-meta.md#81-scheme-delimiters
+     *     which indicates ":" delimiters must also be omitted.
      * @return string The scheme of the URI.
      */
     public function getScheme();
@@ -1276,6 +1278,8 @@ interface UriInterface
      *
      * An empty scheme is equivalent to removing the scheme.
      *
+     * @see https://github.com/php-fig/fig-standards/blob/proposed/http-message-meta.md#81-scheme-delimiters
+     *     which indicates ":" delimiters must also be omitted.
      * @param string $scheme The scheme to use with the new instance.
      * @return self A new instance with the specified scheme.
      * @throws \InvalidArgumentException for invalid or unsupported schemes.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1161,12 +1161,14 @@ interface UriInterface
      * Implementations SHOULD restrict values to "http", "https", or an empty
      * string but MAY accommodate other schemes if required.
      *
+     * The string MUST omit the closing scheme delimiter (":"), if present.
+     *
+     * If non-empty, the value MUST be normalized to lowercase, per RFC 3986
+     * Section 3.1.
+     *
      * If no scheme is present, this method MUST return an empty string.
      *
-     * The string MUST omit the closing scheme delimiter (":") or the
-     * combination of the closing scheme delimiter and the opening authority
-     * delimiter ("://"), if present.
-     *
+     * @see https://tools.ietf.org/html/rfc3986#section-3.1
      * @return string The scheme of the URI.
      */
     public function getScheme();
@@ -1269,14 +1271,11 @@ interface UriInterface
     /**
      * Return an instance with the specified scheme.
      *
-     * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified scheme. If the scheme
-     * provided includes either the closing scheme delimiter (":") or the
-     * combination of the closing scheme delimiter and the opening authority
-     * delimiter ("://"), these strings should be removed.
+     * This method MUST retain the state of the current instance, and return a
+     * new instance that contains the specified scheme.
      *
      * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accommodate other schemes if required.
+     * string but MAY accept other schemes if required.
      *
      * An empty scheme is equivalent to removing the scheme.
      *

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1361,9 +1361,7 @@ interface UriInterface
      * This method MUST retain the state of the current instance, and return
      * an instance that contains the specified query string.
      *
-     * If the query string is prefixed by "?", that character MUST be removed.
-     * Additionally, the query string SHOULD be parseable by parse_str() in
-     * order to be valid.
+     * The query string SHOULD be parseable by parse_str() in order to be valid.
      *
      * The implementation MUST percent-encode reserved characters as
      * specified in RFC 3986, Section 2, but MUST NOT double-encode any
@@ -1382,8 +1380,6 @@ interface UriInterface
      *
      * This method MUST retain the state of the current instance, and return
      * an instance that contains the specified URI fragment.
-     *
-     * If the fragment is prefixed by "#", that character MUST be removed.
      *
      * An empty fragment value is equivalent to removing the fragment.
      *

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1274,8 +1274,8 @@ interface UriInterface
      * This method MUST retain the state of the current instance, and return a
      * new instance that contains the specified scheme.
      *
-     * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accept other schemes if required.
+     * Implementations MUST support an empty scheme AND the schemes "http" and
+     * "https", but MAY accept other schemes if required.
      *
      * An empty scheme is equivalent to removing the scheme.
      *


### PR DESCRIPTION
A [discussion on the mailing list](https://groups.google.com/d/msgid/php-fig/db3d5421-30a5-4135-9f9e-fe432f03d719%40googlegroups.com?utm_medium=email&utm_source=footer) raised the point that `:` is the actual scheme delimiter. In reviewing [RFC 3986 section 3](https://tools.ietf.org/html/rfc3986#section-3), I noted that `:` is the end delimiter for a scheme, and `//` is the opening delimiter for the authority. Since the `UriInterface` does not allow setting the authority in a single go, the only time the `//` delimiter will likely be used is as part of the scheme, making the current wording valid. However, the wording should also note that a trailing `:` delimiter MUST be removed as well.

This patch updates the `UriInterface`'s `withScheme()` and `getScheme()` methods to clarify that either the `:` or `://`, when present, MUST be removed.