### PR TITLE
[PSR-7] Clarification of path, query, and fragment encoding

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -631,3 +631,38 @@ used to populate the headers of an HTTP message.
 * Evert Pot
 * Phil Sturgeon
 * Chris Wilkinson
+
+## 7. Votes
+
+## 8. Errata
+
+### 8.1 URI Encoding
+
+Each of `Psr\Http\Message\UriInterface`'s `*Path()`, `*Query()`, and
+`*Fragment()` methods reference [RFC 3986 Section
+2](https://tools.ietf.org/html/rfc3986#section-2) with regards to how the
+specific segment should be encoded.
+
+RFC 3986 Section 2 lists a number of reserved characters, and the `UriInterface`
+methods indicate that reserved characters MUST be escaped. However, RFC 3986
+also notes:
+
+> A URI is composed from a limited set of characters consisting of digits,
+> letters, and a few graphic symbols.  A reserved subset of those characters may
+> be used to delimit syntax components within a URI while the remaining
+> characters, including both the unreserved set and those reserved characters
+> not acting as delimiters, define each component's identifying data.
+
+In other words, the reserved characters noted in Section 2 are a *general* set,
+and that the list may differ from component to component within the URI;
+developers must refer to the appropriate section for the component they are
+encoding to determine the appropriate list.
+
+The primary confusion arising is whether or not the `/` character MUST be
+encoded. RFC 3986 indicates in [Section 3.3](https://tools.ietf.org/html/rfc3986#section-3.3)
+that `/` is considered a data character for the path component (and,
+specifically, a delimiter between elements of the path component); as such,
+it does not need to be escaped. If a `/` is required but is not intended as a
+delimiter within the path, it MAY be percent-escaped (i.e., `%2F`) *prior* to
+passing it to `withPath()`; `withPath()` MUST then preserve the encoding as
+presented.

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -631,38 +631,3 @@ used to populate the headers of an HTTP message.
 * Evert Pot
 * Phil Sturgeon
 * Chris Wilkinson
-
-## 7. Votes
-
-## 8. Errata
-
-### 8.1 URI Encoding
-
-Each of `Psr\Http\Message\UriInterface`'s `*Path()`, `*Query()`, and
-`*Fragment()` methods reference [RFC 3986 Section
-2](https://tools.ietf.org/html/rfc3986#section-2) with regards to how the
-specific segment should be encoded.
-
-RFC 3986 Section 2 lists a number of reserved characters, and the `UriInterface`
-methods indicate that reserved characters MUST be escaped. However, RFC 3986
-also notes:
-
-> A URI is composed from a limited set of characters consisting of digits,
-> letters, and a few graphic symbols.  A reserved subset of those characters may
-> be used to delimit syntax components within a URI while the remaining
-> characters, including both the unreserved set and those reserved characters
-> not acting as delimiters, define each component's identifying data.
-
-In other words, the reserved characters noted in Section 2 are a *general* set,
-and that the list may differ from component to component within the URI;
-developers must refer to the appropriate section for the component they are
-encoding to determine the appropriate list.
-
-The primary confusion arising is whether or not the `/` character MUST be
-encoded. RFC 3986 indicates in [Section 3.3](https://tools.ietf.org/html/rfc3986#section-3.3)
-that `/` is considered a data character for the path component (and,
-specifically, a delimiter between elements of the path component); as such,
-it does not need to be escaped. If a `/` is required but is not intended as a
-delimiter within the path, it MAY be percent-escaped (i.e., `%2F`) *prior* to
-passing it to `withPath()`; `withPath()` MUST then preserve the encoding as
-presented.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -531,7 +531,7 @@ interface RequestInterface extends MessageInterface
      *
      * This method acts exactly like MessageInterface::getHeaders(), with one
      * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host segment of the composed URI, if
+     * method MUST attempt to pull the host component of the composed URI, if
      * present.
      *
      * @see MessageInterface::getHeaders()
@@ -548,7 +548,7 @@ interface RequestInterface extends MessageInterface
      * This method acts exactly like MessageInterface::getHeader(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
@@ -570,7 +570,7 @@ interface RequestInterface extends MessageInterface
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
      * @see MessageInterface::getHeaderLine()
      * @see UriInterface::getHost()
@@ -1221,17 +1221,17 @@ interface UriInterface
     public function getUserInfo();
 
     /**
-     * Retrieve the host segment of the URI.
+     * Retrieve the host component of the URI.
      *
-     * This method MUST return a string; if no host segment is present, an
+     * This method MUST return a string; if no host component is present, an
      * empty string MUST be returned.
      *
-     * @return string Host segment of the URI.
+     * @return string Host component of the URI.
      */
     public function getHost();
 
     /**
-     * Retrieve the port segment of the URI.
+     * Retrieve the port component of the URI.
      *
      * If a port is present, and it is non-standard for the current scheme,
      * this method MUST return it as an integer. If the port is the standard port
@@ -1268,7 +1268,7 @@ interface UriInterface
      *
      * @see https://tools.ietf.org/html/rfc3986#section-2
      * @see https://tools.ietf.org/html/rfc3986#section-3.3
-     * @return string The path segment of the URI.
+     * @return string The path component of the URI.
      */
     public function getPath();
 
@@ -1295,7 +1295,7 @@ interface UriInterface
     public function getQuery();
 
     /**
-     * Retrieve the fragment segment of the URI.
+     * Retrieve the fragment component of the URI.
      *
      * This method MUST return a string; if no fragment is present, it MUST
      * return an empty string.
@@ -1432,7 +1432,7 @@ interface UriInterface
     /**
      * Return the string representation of the URI.
      *
-     * Concatenates the various segments of the URI, using the appropriate
+     * Concatenates the various components of the URI, using the appropriate
      * delimiters:
      *
      * - If a scheme is present, "://" MUST append the value.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1306,9 +1306,6 @@ interface UriInterface
      * any characters. To determine what characters to encode, please refer to
      * RFC 3986, Sections 2 and 3.5.
      *
-     * As an example, if the fragment should include a hash symbol ("#"), that
-     * value MUST be encoded (e.g., "%23") when passed to the instance.
-     *
      * @see https://tools.ietf.org/html/rfc3986#section-2
      * @see https://tools.ietf.org/html/rfc3986#section-3.5
      * @return string The URI fragment.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1262,8 +1262,8 @@ interface UriInterface
      * double-encode any characters. To determine what characters to encode,
      * please refer to RFC 3986, Sections 2 and 3.3.
      *
-     * If the value should include a slash ("/") not intended as delimeter
-     * between path segments, that value MUST be encode (e.g., "%2F") when
+     * If the value should include a slash ("/") not intended as delimiter
+     * between path segments, that value MUST be encoded (e.g., "%2F") when
      * passed to the instance.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-2

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1262,9 +1262,9 @@ interface UriInterface
      * double-encode any characters. To determine what characters to encode,
      * please refer to RFC 3986, Sections 2 and 3.3.
      *
-     * If the value should include a slash ("/") not intended as delimiter
-     * between path segments, that value MUST be encoded (e.g., "%2F") when
-     * passed to the instance.
+     * As an example, if the value should include a slash ("/") not intended as
+     * delimiter between path segments, that value MUST be encoded (e.g., "%2F")
+     * when passed to the instance.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-2
      * @see https://tools.ietf.org/html/rfc3986#section-3.3
@@ -1284,6 +1284,10 @@ interface UriInterface
      * any characters. To determine what characters to encode, please refer to
      * RFC 3986, Sections 2 and 3.4.
      *
+     * As an example, if a value in a key/value pair of the query string should
+     * include an ampersand ("&") not intended as a delimiter between values,
+     * that value MUST be encoded (e.g., "%26") when passed to the instance.
+     *
      * @see https://tools.ietf.org/html/rfc3986#section-2
      * @see https://tools.ietf.org/html/rfc3986#section-3.4
      * @return string The URI query string.
@@ -1301,6 +1305,9 @@ interface UriInterface
      * The value returned MUST be percent-encoded, but MUST NOT double-encode
      * any characters. To determine what characters to encode, please refer to
      * RFC 3986, Sections 2 and 3.5.
+     *
+     * As an example, if the fragment should include a hash symbol ("#"), that
+     * value MUST be encoded (e.g., "%23") when passed to the instance.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-2
      * @see https://tools.ietf.org/html/rfc3986#section-3.5

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1258,7 +1258,17 @@ interface UriInterface
      * the front controller, this difference becomes significant. It's the task
      * of the user to handle both "" and "/".
      *
-     * @return string The path component of the URI.
+     * The value returned MUST be returned in percent-encoded form, but MUST NOT
+     * double-encode any characters. To determine what characters to encode,
+     * please refer to RFC 3986, Sections 2 and 3.3.
+     *
+     * If the value should include a slash ("/") not intended as delimeter
+     * between path segments, that value MUST be encode (e.g., "%2F") when
+     * passed to the instance.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.3
+     * @return string The path segment of the URI.
      */
     public function getPath();
 
@@ -1270,6 +1280,12 @@ interface UriInterface
      *
      * The string returned MUST omit the leading "?" character.
      *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.4.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.4
      * @return string The URI query string.
      */
     public function getQuery();
@@ -1282,6 +1298,12 @@ interface UriInterface
      *
      * The string returned MUST omit the leading "#" character.
      *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.5.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.5
      * @return string The URI fragment.
      */
     public function getFragment();
@@ -1362,10 +1384,6 @@ interface UriInterface
      * The path MUST be prefixed with "/"; if not, the implementation MAY
      * provide the prefix itself.
      *
-     * The implementation MUST percent-encode reserved characters as
-     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
-     * characters.
-     *
      * An empty path value is equivalent to removing the path.
      *
      * @param string $path The path to use with the new instance.
@@ -1383,10 +1401,6 @@ interface UriInterface
      * If the query string is prefixed by "?", that character MUST be removed.
      * Additionally, the query string SHOULD be parseable by parse_str() in
      * order to be valid.
-     *
-     * The implementation MUST percent-encode reserved characters as
-     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
-     * characters.
      *
      * An empty query string value is equivalent to removing the query string.
      *


### PR DESCRIPTION
Comments on #479 and #449 indicate uncertainty about how to encode the path, particularly the `/` character; additionally, if references to encoding are made in other methods, these should be addressed.

This patch:

- Removes references to encoding from the `withPath()`, `withQuery()`, and `withFragment()` methods.
- Adds verbiage on encoding to the `getPath()`, `getQuery()`, and `getFragment()` methods, indicating they MUST be percent-encoded, but MUST NOT be double-encoded.
- Adds references to RFC 3986 Section 2 and the relevant component-specific section in each of the `getPath()`, `getQuery()` and `getFragment()` methods as the canonical source for determining what should and should not be encoded.
- Adds verbiage to `getPath()` specifically around encoding of the `/` character.