### PR TITLE
Less obtrusive hugs

### DIFF
--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -20,7 +20,7 @@ This specification defines two interfaces, \Psr\Hug\Huggable and
 ### Huggable objects
 
 1. A Huggable object expresses affection and support for another object by invoking
-its hug() method, passing $this as the first parameter.
+its own hug() method, passing the other object as the first parameter. 
 
 2. An object whose hug() method is invoked MUST hug() the calling object back
 at least once.


### PR DESCRIPTION
It feels somehow better to go $this->hug($object) over $object->hug($this), could be because I see $this as the object wanting to hug, even though both are of course possible it seems nicer in the example and less obtrusive "give me a hug" vs "I give you a hug" <3