### PR TITLE
Remove empty path normalization to support base path use-case

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1233,8 +1233,13 @@ interface UriInterface
     /**
      * Retrieve the path segment of the URI.
      *
-     * This method MUST return a string; if no path is present it MUST return
-     * the string "/".
+     * This method MUST return a string.
+     *
+     * Normally, the empty path "" and absolute path "/" are considered equal as
+     * defined in RFC 7230 Section 2.7.3. But this method MUST NOT automatically
+     * do this normalization because in contexts with a trimmed base path, e.g.
+     * the front controller, this difference becomes significant. It's the task
+     * of the user to handle both "" and "/".
      *
      * @return string The path segment of the URI.
      */


### PR DESCRIPTION
This is to fix https://groups.google.com/forum/#!topic/php-fig/TswE4FD0SyM
It basically reverts #460 and clarifies things.

Also since we do not apply other normalization of the path as well (e.g. dot segment resolving), I think this is consistent.