### PR TITLE
Path "component" instead of "segment"

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1231,12 +1231,12 @@ interface UriInterface
     public function getPort();
 
     /**
-     * Retrieve the path segment of the URI.
+     * Retrieve the path component of the URI.
      *
      * This method MUST return a string; if no path is present it MUST return
      * the string "/".
      *
-     * @return string The path segment of the URI.
+     * @return string The path component of the URI.
      */
     public function getPath();
 


### PR DESCRIPTION
A path segment is something different, it's only one part between two slashes. But the path component is the full path. See RFC 3986

Btw, the rest of PSR-7 also speaks about "segments", e.g. host segment. But these are also named host component in RFC 3986. I don't see why we should diverge from the standard here...