### PR TITLE
Added UploadedFileInterface

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -785,6 +785,11 @@ interface ServerRequestInterface extends RequestInterface
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
+     * The implementation SHOULD ensure that is_uploaded_file() returns true for
+     * the paths of the uploaded files. However, this recommendation MAY be
+     * ignored in special cases, for example when using temporary files as
+     * uploaded files during testing.
+     *
      * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
     public function getUploadedFiles();
@@ -1445,9 +1450,6 @@ interface UploadedFileInterface
      *
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
-     *
-     * Implementations MUST guarantee that is_uploaded_file() returns true
-     * for the returned path.
      *
      * @return string The absolute path to the uploaded file.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -785,11 +785,6 @@ interface ServerRequestInterface extends RequestInterface
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
-     * The implementation SHOULD ensure that is_uploaded_file() returns true for
-     * the paths of the uploaded files. However, this recommendation MAY be
-     * ignored in special cases, for example when using temporary files as
-     * uploaded files during testing.
-     *
      * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
     public function getUploadedFiles();
@@ -1450,6 +1445,12 @@ interface UploadedFileInterface
      *
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
+     *
+     * The implementation MUST guarantee that the file pointed to by the path
+     * can safely be used by the calling code. More precisely, the
+     * implementation MUST ensure that is_uploaded_file() returns true for
+     * the path if the path was provided through the $_FILES array or a
+     * similar mechanism.
      *
      * @return string The absolute path to the uploaded file.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1446,6 +1446,9 @@ interface UploadedFileInterface
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
      *
+     * Implementations MUST guarantee that is_uploaded_file() returns true
+     * for the returned path.
+     *
      * @return string The absolute path to the uploaded file.
      */
     public function getPath();

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -776,18 +776,32 @@ interface ServerRequestInterface extends RequestInterface
     public function withQueryParams(array $query);
 
     /**
-     * Retrieve the upload file metadata.
+     * Retrieve the uploaded files.
      *
-     * This method MUST return file upload metadata in the same structure
+     * This method MUST return the file upload metadata in the same structure
      * as PHP's $_FILES superglobal.
      *
      * These values MUST remain immutable over the course of the incoming
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
-     * @return array Upload file(s) metadata, if any.
+     * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
-    public function getFileParams();
+    public function getUploadedFiles();
+
+    /**
+     * Create a new instance with the specified uploaded files.
+     *
+     * These MAY be injected during instantiation.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated body parameters.
+     *
+     * @param UploadedFileInterface[] $uploadedFiles The uploaded files.
+     * @return self
+     */
+    public function withUploadedFiles(array $uploadedFiles);
 
     /**
      * Retrieve any parameters provided in the request body.
@@ -1405,5 +1419,95 @@ interface UriInterface
      * @return string
      */
     public function __toString();
+}
+```
+
+### 3.6 `Psr\Http\Message\UploadedFileInterface`
+
+```php
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a file uploaded through an HTTP request.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return a new instance that contains the
+ * changed state.
+ */
+interface UploadedFileInterface
+{
+    /**
+     * Retrieve the path to the uploaded file.
+     *
+     * This method MUST return an absolute file path.
+     *
+     * Implementations SHOULD return the value stored in the "tmp_name" key
+     * of the file in the $_FILES array.
+     *
+     * @return string The absolute path to the uploaded file.
+     */
+    public function getPath();
+    
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
+     *
+     * If the file was uploaded successfully, this method MUST return
+     * UPLOAD_ERR_OK.
+     *
+     * Implementations SHOULD return the value stored in the "error" key of
+     * the file in the $_FILES array.
+     *
+     * @return int One of the UPLOAD_ERR_XXX constants.
+     */
+    public function getError();
+    
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious filename with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "name" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename();
+    
+    /**
+     * Retrieve the size sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a wrong or malicious size with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array.
+     *
+     * @return int|null The size sent by the client in bytes or null if none
+     *     was provided.
+     */
+    public function getClientSize();
+    
+    /**
+     * Retrieve the mime type sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious mime type with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "type" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The mime type sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientMimeType();
 }
 ```


### PR DESCRIPTION
The structure of PHP's $_FILES array is inconsistent with the structure of $_POST when the names of the form fields contain array keys.

For example, when submitting the text inputs "text[0]" and "text[1]", the contents of $_POST are:

```
array(1) { 
    ["text"]=>array(2) { 
        [0]=>string(5)"text0" 
        [1]=>string(5)"text1" 
    } 
} 
```

However, when submitting the file inputs "file[0]" and "file[1]", the contents of $_FILES are:

```
array(1) { 
    ["file"]=>array(2) { 
        ["name"]=>array(2) { 
            [0]=>string(9)"file0.txt" 
            [1]=>string(9)"file1.txt" 
        } 
        ["type"]=>array(2) { 
            [0]=>string(10)"text/plain" 
            [1]=>string(10)"text/html" 
        } 
    } 
} 
```

While you can read `$_POST['text'][1]` to access the contents of the field "text[1]", you *cannot* read `$_FILES['file'][1]` to access the contents of the field "file[1]", which is a quite big usability issue in practice. Symfony, for example, rearranges the contents of the $_FILES array for that sake.

I think PSR-7 should fix this issue. Otherwise every user of the PSR interfaces must fix this themselves, which isn't exactly interoperable.

I see two approaches to fix this:

* Describe this issue and the precise rules for rearranging the array in the PSR. This is verbose and prone to mistakes, which is why I don't like it very much.
* Enforce implementations to return `UploadedFileInterface` objects "in the same structure" as the $_FILES array (same wording as in getQueryParams()). This solution is concise and leaves little room for interpretation. The correct result in the above case would be:

```
array(1) { 
    ["file"]=>array(2) { 
        [0]=>object(UploadedFileInterface)
        [1]=>object(UploadedFileInterface)
    } 
} 
```

Hence it is possible to read `$message->getUploadedFiles()['file'][1]` to access all data related to the field "file[1]".