### PR TITLE
HTTP: Alternative way to address consistency issues mentioned in #491

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -398,15 +398,6 @@ interface MessageInterface
     public function getHeader($name);
 
     /**
-     * Retrieves all header lines as array of strings.
-     *
-     * If there are no headers, this method should return an empty array.
-     *
-     * @return string[]
-     */
-    public function getHeaderLines();
-
-    /**
      * Retrieves the line for a single header, with the header values as a
      * comma-separated string.
      *
@@ -550,21 +541,6 @@ interface RequestInterface extends MessageInterface
      * @return array|null
      */
     public function getHeader($name);
-
-    /**
-     * Extends MessageInterface::getHeaderLines() to provide request-specific
-     * behavior.
-     *
-     * This method acts exactly like MessageInterface::getHeaderLines(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeaderLines()
-     * @see UriInterface::getHost()
-     * @return string[]
-     */
-    public function getHeaderLines();
 
     /**
      * Extends MessageInterface::getHeaderLines() to provide request-specific

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -350,16 +350,16 @@ interface MessageInterface
      * Retrieves all message header values.
      *
      * The keys represent the header name as it will be sent over the wire, and
-     * each value is the string, or array of strings, associated with the header.
+     * each value array of strings associated with the header.
      *
      *     // Represent the headers as a string
      *     foreach ($message->getHeaders() as $name => $values) {
-     *         echo $name . ": " . implode(", ", (array) $values);
+     *         echo $name . ": " . implode(", ", $values);
      *     }
      *
      *     // Emit headers iteratively:
      *     foreach ($message->getHeaders() as $name => $values) {
-     *         foreach ((array) $values as $value) {
+     *         foreach ($values as $value) {
      *             header(sprintf('%s: %s', $name, $value), false);
      *         }
      *     }
@@ -368,8 +368,8 @@ interface MessageInterface
      * exact case in which headers were originally specified.
      *
      * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST the value(s) for that
-     *     header.
+     *     key MUST be a header name, and each value MUST be the array of values
+     *     for that header.
      */
     public function getHeaders();
 
@@ -386,14 +386,14 @@ interface MessageInterface
     /**
      * Retrieves a message header value by the given case-insensitive name.
      *
-     * This method returns all of the header values of the given
+     * This method returns an array of all the header values of the given
      * case-insensitive header name.
      *
      * If the header did not appear in the message, this method should return
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|array|null
+     * @return array|null
      */
     public function getHeader($name);
 
@@ -530,8 +530,8 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaders()
      * @see UriInterface::getHost()
      * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST the value(s) for that
-     *     header.
+     *     key MUST be a header name, and each value MUST the array of values
+     *     for that header.
      */
     public function getHeaders();
 
@@ -547,7 +547,7 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string|array|null
+     * @return array|null
      */
     public function getHeader($name);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -350,7 +350,7 @@ interface MessageInterface
      * Retrieves all message header values.
      *
      * The keys represent the header name as it will be sent over the wire, and
-     * each value array of strings associated with the header.
+     * each value is an array of strings associated with the header.
      *
      *     // Represent the headers as a string
      *     foreach ($message->getHeaders() as $name => $values) {

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -347,19 +347,19 @@ interface MessageInterface
     public function withProtocolVersion($version);
 
     /**
-     * Retrieves all message headers.
+     * Retrieves all message header values.
      *
      * The keys represent the header name as it will be sent over the wire, and
-     * each value is an array of strings associated with the header.
+     * each value is the string, or array of strings, associated with the header.
      *
      *     // Represent the headers as a string
      *     foreach ($message->getHeaders() as $name => $values) {
-     *         echo $name . ": " . implode(", ", $values);
+     *         echo $name . ": " . implode(", ", (array) $values);
      *     }
      *
      *     // Emit headers iteratively:
      *     foreach ($message->getHeaders() as $name => $values) {
-     *         foreach ($values as $value) {
+     *         foreach ((array) $values as $value) {
      *             header(sprintf('%s: %s', $name, $value), false);
      *         }
      *     }
@@ -368,7 +368,8 @@ interface MessageInterface
      * exact case in which headers were originally specified.
      *
      * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
+     *     key MUST be a header name, and each value MUST the value(s) for that
+     *     header.
      */
     public function getHeaders();
 
@@ -383,34 +384,39 @@ interface MessageInterface
     public function hasHeader($name);
 
     /**
-     * Retrieve a header by the given case-insensitive name, as a string.
+     * Retrieves a message header value by the given case-insensitive name.
      *
      * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
-     *
-     * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeaderLines() instead
-     * and supply your own delimiter when concatenating.
+     * case-insensitive header name.
      *
      * If the header did not appear in the message, this method should return
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|null
+     * @return string|array|null
      */
     public function getHeader($name);
 
     /**
-     * Retrieves a header by the given case-insensitive name as an array of strings.
+     * Retrieves all header lines as array of strings.
      *
-     * If the header did not appear in the message, this method should return an
-     * empty array.
+     * If there are no headers, this method should return an empty array.
      *
-     * @param string $name Case-insensitive header field name.
      * @return string[]
      */
-    public function getHeaderLines($name);
+    public function getHeaderLines();
+
+    /**
+     * Retrieves the line for a single header, with the header values as a
+     * comma-separated string.
+     *
+     * If the header does not appear in the message, this method should return
+     * a null value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string|null
+     */
+    public function getHeaderLine($name);
 
     /**
      * Create a new instance with the provided header, replacing any existing
@@ -516,8 +522,6 @@ interface RequestInterface extends MessageInterface
      * Extends MessageInterface::getHeaders() to provide request-specific
      * behavior.
      *
-     * Retrieves all message headers.
-     *
      * This method acts exactly like MessageInterface::getHeaders(), with one
      * behavioral change: if the Host header has not been previously set, the
      * method MUST attempt to pull the host segment of the composed URI, if
@@ -526,7 +530,8 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaders()
      * @see UriInterface::getHost()
      * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
+     *     key MUST be a header name, and each value MUST the value(s) for that
+     *     header.
      */
     public function getHeaders();
 
@@ -542,15 +547,13 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string
+     * @return string|array|null
      */
     public function getHeader($name);
 
     /**
      * Extends MessageInterface::getHeaderLines() to provide request-specific
      * behavior.
-     *
-     * Retrieves a header by the given case-insensitive name as an array of strings.
      *
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
@@ -559,10 +562,25 @@ interface RequestInterface extends MessageInterface
      *
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
      * @return string[]
      */
-    public function getHeaderLines($name);
+    public function getHeaderLines();
+
+    /**
+     * Extends MessageInterface::getHeaderLines() to provide request-specific
+     * behavior.
+     *
+     * This method acts exactly like MessageInterface::getHeaderLines(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method MUST attempt to pull the host
+     * segment of the composed URI, if present.
+     *
+     * @see MessageInterface::getHeaderLine()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string|null
+     */
+    public function getHeaderLine($name);
 
     /**
      * Retrieves the message's request target.


### PR DESCRIPTION
This PR suggests the following changes:

- `getHeader($name)` returns the header values as set by the user; it does not return a concatenated string.

- `getHeaders()` is now essentially the equivalent of calling `getHeader()` for every header in the message; it does not return an array of header line strings.

- `getHeaderLine($name)` is a new method that takes the place of the old `getHeader()`, where the return value is expected to be an entire header line with the values concatenated into a comma-separated string.

- `getHeaderLines()` has been removed.

This PR has no equivalent for the old `getHeaderLines($name)` behavior that would return an array of multiple lines for a single header, each with a separate value for that header. The user can mimic that behavior with something like:

    $lines = [];
    foreach ($message->getHeader($name) as $values) {
        foreach ($values as $value) {
            $lines[] = "{$name}: {$value}";
        }
    }

Finally, this further enforces the idea that `getHeader()` or `getHeaders()` should always return an array for the header values themselves.

I think this is both more flexible and more consistent than the previous version, and addresses both my own gripes and those expressed in #491.