### PR TITLE
Alternative way to address consistency issues mentioned in #491 and #493

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -386,7 +386,7 @@ interface MessageInterface
      * Retrieves a header by the given case-insensitive name as an array of
      * strings.
      *
-     * If the header did not appear in the message, this method should return an
+     * If the header did not appear in the message, this method MUST return an
      * empty array.
      *
      * @param string $name Case-insensitive header field name.
@@ -405,7 +405,7 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeader() instead
      * and supply your own delimiter when concatenating.
      *
-     * If the header did not appear in the message, this method should return
+     * If the header did not appear in the message, this method MUST return
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
@@ -414,7 +414,8 @@ interface MessageInterface
     public function getHeaderLine($name);
 
     /**
-     * Retrieves all message headers.
+     * Retrieves all message headers as an array of header names and string
+     * values.
      *
      * The keys represent the header name as it will be sent over the wire, and
      * each value is a string of the header values concatenated together using
@@ -566,7 +567,9 @@ interface RequestInterface extends MessageInterface
      * Extends MessageInterface::getHeaderLines() to provide request-specific
      * behavior.
      *
-     * Retrieves a header by the given case-insensitive name as a string.
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
      *
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
@@ -584,7 +587,8 @@ interface RequestInterface extends MessageInterface
      * Extends MessageInterface::getHeaderLines() to provide request-specific
      * behavior.
      *
-     * Retrieves all message headers.
+     * Retrieves all message headers as an array of header names and string
+     * values.
      *
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header has not been previously set,

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -383,6 +383,18 @@ interface MessageInterface
     public function hasHeader($name);
 
     /**
+     * Retrieves a header by the given case-insensitive name as an array of
+     * strings.
+     *
+     * If the header did not appear in the message, this method should return an
+     * empty array.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string[]
+     */
+    public function getHeader($name);
+
+    /**
      * Retrieve a header by the given case-insensitive name, as a string.
      *
      * This method returns all of the header values of the given
@@ -390,7 +402,7 @@ interface MessageInterface
      * a comma.
      *
      * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeaderLines() instead
+     * comma concatenation. For such headers, use getHeader() instead
      * and supply your own delimiter when concatenating.
      *
      * If the header did not appear in the message, this method should return
@@ -399,18 +411,22 @@ interface MessageInterface
      * @param string $name Case-insensitive header field name.
      * @return string|null
      */
-    public function getHeader($name);
+    public function getHeaderLine($name);
 
     /**
-     * Retrieves a header by the given case-insensitive name as an array of strings.
+     * Retrieves all message headers.
      *
-     * If the header did not appear in the message, this method should return an
-     * empty array.
+     * The keys represent the header name as it will be sent over the wire, and
+     * each value is a string of the header values concatenated together using
+     * a comma.
      *
-     * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * While header names are not case-sensitive, getHeaderLines() will preserve
+     * the exact case in which headers were originally specified.
+     *
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be a string.
      */
-    public function getHeaderLines($name);
+    public function getHeaderLines();
 
     /**
      * Return an instance with the provided header, replacing any existing
@@ -542,7 +558,7 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string
+     * @return string[]
      */
     public function getHeader($name);
 
@@ -550,7 +566,7 @@ interface RequestInterface extends MessageInterface
      * Extends MessageInterface::getHeaderLines() to provide request-specific
      * behavior.
      *
-     * Retrieves a header by the given case-insensitive name as an array of strings.
+     * Retrieves a header by the given case-insensitive name as a string.
      *
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
@@ -560,9 +576,27 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * @return string
      */
-    public function getHeaderLines($name);
+    public function getHeaderLine($name);
+
+    /**
+     * Extends MessageInterface::getHeaderLines() to provide request-specific
+     * behavior.
+     *
+     * Retrieves all message headers.
+     *
+     * This method acts exactly like MessageInterface::getHeaderLines(), with
+     * one behavioral change: if the Host header has not been previously set,
+     * the method MUST attempt to pull the host segment of the composed URI, if
+     * present.
+     *
+     * @see MessageInterface::getHeaderLines()
+     * @see UriInterface::getHost()
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be a string.
+     */
+    public function getHeaderLines();
 
     /**
      * Retrieves the message's request target.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -386,7 +386,7 @@ interface MessageInterface
      * Retrieves a header by the given case-insensitive name as an array of
      * strings.
      *
-     * If the header did not appear in the message, this method MUST return an
+     * If the header does not appear in the message, this method MUST return an
      * empty array.
      *
      * @param string $name Case-insensitive header field name.
@@ -405,7 +405,7 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeader() instead
      * and supply your own delimiter when concatenating.
      *
-     * If the header did not appear in the message, this method MUST return
+     * If the header does not appear in the message, this method MUST return
      * a null value.
      *
      * @param string $name Case-insensitive header field name.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -390,7 +390,7 @@ interface MessageInterface
      * empty array.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string[] An array of discrete string values for the given header.
+     * @return string[] An array of string values for the given header.
      *    If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
@@ -411,7 +411,7 @@ interface MessageInterface
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|null A string of discrete header values concatenated
+     * @return string|null A string of header values concatenated
      *    together using a comma. If the header does not appear in the message,
      *    this method MUST return a null value.
      */
@@ -547,7 +547,7 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string[] An array of discrete string values for the given header.
+     * @return string[] An array of string values for the given header.
      *    If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
@@ -569,7 +569,7 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string|null A string of discrete header values concatenated
+     * @return string|null A string of header values concatenated
      *    together using a comma. If the header does not appear in the message,
      *    this method MUST return a null value.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -414,22 +414,6 @@ interface MessageInterface
     public function getHeaderLine($name);
 
     /**
-     * Retrieves all message headers as an array of header names and string
-     * values.
-     *
-     * The keys represent the header name as it will be sent over the wire, and
-     * each value is a string of the header values concatenated together using
-     * a comma.
-     *
-     * While header names are not case-sensitive, getHeaderLines() will preserve
-     * the exact case in which headers were originally specified.
-     *
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be a string.
-     */
-    public function getHeaderLines();
-
-    /**
      * Return an instance with the provided header, replacing any existing
      * values of any headers with the same case-insensitive name.
      *
@@ -582,25 +566,6 @@ interface RequestInterface extends MessageInterface
      * @return string
      */
     public function getHeaderLine($name);
-
-    /**
-     * Extends MessageInterface::getHeaderLines() to provide request-specific
-     * behavior.
-     *
-     * Retrieves all message headers as an array of header names and string
-     * values.
-     *
-     * This method acts exactly like MessageInterface::getHeaderLines(), with
-     * one behavioral change: if the Host header has not been previously set,
-     * the method MUST attempt to pull the host segment of the composed URI, if
-     * present.
-     *
-     * @see MessageInterface::getHeaderLines()
-     * @see UriInterface::getHost()
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be a string.
-     */
-    public function getHeaderLines();
 
     /**
      * Retrieves the message's request target.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -391,6 +391,8 @@ interface MessageInterface
      *
      * @param string $name Case-insensitive header field name.
      * @return string[] An array of discrete string values for the given header.
+     *    If the header does not appear in the message, this method MUST
+     *    return an empty array.
      */
     public function getHeader($name);
 
@@ -409,7 +411,9 @@ interface MessageInterface
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|null
+     * @return string|null A string of discrete header values concatenated
+     *    together using a comma. If the header does not appear in the message,
+     *    this method MUST return a null value.
      */
     public function getHeaderLine($name);
 
@@ -544,6 +548,8 @@ interface RequestInterface extends MessageInterface
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
      * @return string[] An array of discrete string values for the given header.
+     *    If the header does not appear in the message, this method MUST
+     *    return an empty array.
      */
     public function getHeader($name);
 
@@ -563,7 +569,9 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string
+     * @return string|null A string of discrete header values concatenated
+     *    together using a comma. If the header does not appear in the message,
+     *    this method MUST return a null value.
      */
     public function getHeaderLine($name);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -390,8 +390,8 @@ interface MessageInterface
      * empty array.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values for the given header.
-     *    If the header does not appear in the message, this method MUST
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
     public function getHeader($name);
@@ -411,9 +411,9 @@ interface MessageInterface
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|null A string of header values concatenated
-     *    together using a comma. If the header does not appear in the message,
-     *    this method MUST return a null value.
+     * @return string|null A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return a null value.
      */
     public function getHeaderLine($name);
 
@@ -547,8 +547,8 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values for the given header.
-     *    If the header does not appear in the message, this method MUST
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
     public function getHeader($name);
@@ -569,9 +569,9 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeaderLines()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string|null A string of header values concatenated
-     *    together using a comma. If the header does not appear in the message,
-     *    this method MUST return a null value.
+     * @return string|null A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return a null value.
      */
     public function getHeaderLine($name);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -390,7 +390,7 @@ interface MessageInterface
      * empty array.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * @return string[] An array of discrete string values for the given header.
      */
     public function getHeader($name);
 
@@ -543,7 +543,7 @@ interface RequestInterface extends MessageInterface
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * @return string[] An array of discrete string values for the given header.
      */
     public function getHeader($name);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -87,14 +87,14 @@ any previously set `foo` header value.
 ```php
 $message = $message->withHeader('foo', 'bar');
 
-echo $message->getHeader('foo');
+echo $message->getHeaderLine('foo');
 // Outputs: bar
 
-echo $message->getHeader('FOO');
+echo $message->getHeaderLine('FOO');
 // Outputs: bar
 
 $message = $message->withHeader('fOO', 'baz');
-echo $message->getHeader('foo');
+echo $message->getHeaderLine('foo');
 // Outputs: baz
 ```
 
@@ -111,9 +111,9 @@ request or response.
 In order to accommodate headers with multiple values yet still provide the
 convenience of working with headers as strings, headers can be retrieved from
 an instance of a `MessageInterface` as an array or a string. Use the
-`getHeader()` method to retrieve a header value as a string containing all
+`getHeaderLine()` method to retrieve a header value as a string containing all
 header values of a case-insensitive header by name concatenated with a comma.
-Use `getHeaderLines()` to retrieve an array of all the header values for a
+Use `getHeader()` to retrieve an array of all the header values for a
 particular case-insensitive header by name.
 
 ```php
@@ -121,16 +121,16 @@ $message = $message
     ->withHeader('foo', 'bar')
     ->withAddedHeader('foo', 'baz');
 
-$header = $message->getHeader('foo');
+$header = $message->getHeaderLine('foo');
 // $header contains: 'bar, baz'
 
-$header = $message->getHeaderLines('foo');
+$header = $message->getHeader('foo');
 // ['bar', 'baz']
 ```
 
 Note: Not all header values can be concatenated using a comma (e.g.,
 `Set-Cookie`). When working with such headers, consumers of
-`MessageInterface`-based classes SHOULD rely on the `getHeaderLines()` method
+`MessageInterface`-based classes SHOULD rely on the `getHeader()` method
 for retrieving such multi-valued headers.
 
 ##### Host header
@@ -139,10 +139,12 @@ In requests, the Host header typically mirrors the host segment of the URI, as
 well as the host used when establishing the TCP connection. However, the HTTP
 specification allows the Host header to differ from each of the two.
 
-The `RequestInterface` overrides the `MessageInterface::getHeader()` method to
-indicate that if no Host header is present, but a host segment is present in the
-composed `UriInterface`, the value from the URI should be used. If a Host header
-is explicitly provided to the request instance, that value will be preferred.
+The `RequestInterface` overrides the `MessageInterface::getHeader()`,
+`MessageInterface::getHeaders()`, and `MessageInterface::getHeaderLine()`
+methods to indicate that if no Host header is present, but a host segment is
+present in the composed `UriInterface`, the value from the URI should be used.
+If a Host header is explicitly provided to the request instance, that value will
+be preferred.
 
 ### 1.3 Streams
 


### PR DESCRIPTION
Another variant of PR #491 and #493 with specific return types.

This PR suggests the following changes:

- `getHeader($name)` takes the place of the current `getHeaderLines($name)` and returns an array of strings (even with only one).
- `getHeaders()` is unchanged and returns an array with arrays of strings for values.
- `getHeaderLine($name)` takes the place of the current `getHeader($name)` and returns a (concatenated) string.
- `getHeaderLines()` returns an array with strings as values.

This provides a predictable interface where the user can know the return type in advance and won't need to test whether the method returned a string or array.

It also adds consistency where both:

```
$message->getHeaders()[$k] === $message->getHeader($k)
```

And

```
$message->getHeaderLines()[$k] === $message->getHeaderLine($k)
```
