### PR TITLE
Add more flexibility to headers

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -387,7 +387,7 @@ interface MessageInterface
      *
      * This method returns all of the header values of the given
      * case-insensitive header name as a string concatenated together using
-     * a comma.
+     * a specified seperator.
      *
      * NOTE: Not all header values may be appropriately represented using
      * comma concatenation. For such headers, use getHeaderLines() instead
@@ -399,7 +399,7 @@ interface MessageInterface
      * @param string $name Case-insensitive header field name.
      * @return string|null
      */
-    public function getHeader($name);
+    public function getHeader($name, $seperator = ',');
 
     /**
      * Retrieves a header by the given case-insensitive name as an array of strings.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -387,7 +387,7 @@ interface MessageInterface
      *
      * This method returns all of the header values of the given
      * case-insensitive header name as a string concatenated together using
-     * a specified seperator.
+     * a specified separator.
      *
      * NOTE: Not all header values may be appropriately represented using
      * comma concatenation. For such headers, use getHeaderLines() instead
@@ -399,7 +399,7 @@ interface MessageInterface
      * @param string $name Case-insensitive header field name.
      * @return string|null
      */
-    public function getHeader($name, $seperator = ',');
+    public function getHeader($name, $separator = ',');
 
     /**
      * Retrieves a header by the given case-insensitive name as an array of strings.


### PR DESCRIPTION
Would like to see an optional separator as sometimes I don't want to use commas. Kind of nit-picking... but would be nice.