### PR TITLE
[PSR-7] Additional upload files functionality

### DIFF
--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -606,7 +606,7 @@ represented by `$_FILES`. This data is useful in several cases:
   - https://github.com/siriusphp/upload
 - As a canonical source of file upload information that cannot be mutated.
 
-`getUploadedParams()` exists to fix a known issue with how PHP structures the
+`getUploadedFiles()` exists to fix a known issue with how PHP structures the
 `$_FILES` superglobal when array notation (e.g., `files[0]`, `files[1]`, and so
 on) is used to name file uploads. It can be _derived_ from the return value of
 `getFileParams()`, but presents a structure that is more user friendly, as you

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -655,6 +655,8 @@ used to populate the headers of an HTTP message.
 * Michael Dowling
 * Larry Garfield
 * Evert Pot
-- Tobias Schultze
+* Tobias Schultze
+* Bernhard Schussek
+* Anton Serdyuk
 * Phil Sturgeon
 * Chris Wilkinson

--- a/proposed/http-message-meta.md
+++ b/proposed/http-message-meta.md
@@ -594,6 +594,32 @@ specific, and the results of detection can be easily injected into objects that
 need it, and/or calculated as needed using utility functions and/or classes from
 the `RequestInterface` instance itself.
 
+### Why are both getFileParams() and getUploadedFiles() present?
+
+`getFileParams()` exists to provide the raw file upload data, typically as
+represented by `$_FILES`. This data is useful in several cases:
+
+- A number of existing libraries exist that already can process the `$_FILES`
+  array; having a method that returns that raw value allows them to interoperate
+  with this specification.
+  - https://github.com/codeguy/Upload
+  - https://github.com/siriusphp/upload
+- As a canonical source of file upload information that cannot be mutated.
+
+`getUploadedParams()` exists to fix a known issue with how PHP structures the
+`$_FILES` superglobal when array notation (e.g., `files[0]`, `files[1]`, and so
+on) is used to name file uploads. It can be _derived_ from the return value of
+`getFileParams()`, but presents a structure that is more user friendly, as you
+can access the various uploads using the same tree structure in which the files
+were submitted.
+
+### Why does getUploadedFiles() return objects instead of arrays?
+
+`getUploadedFiles()` returns a tree of `Psr\Http\Message\UploadedFileInterface`
+instances. This is done primarily to simplify specification: instead of
+requiring paragraphs of implementation specification for an array, we can
+specify an interface.
+
 ### What about "special" header values?
 
 A number of header values contain unique representation requirements which can

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1639,6 +1639,16 @@ interface UploadedFileInterface
     public function getTemporaryPath();
     
     /**
+     * Retrieve the file size.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array, OR the value returned by filesize().
+     *
+     * @return int|null The file size in bytes or null if none was provided.
+     */
+    public function getSize();
+    
+    /**
      * Retrieve the error associated with the uploaded file.
      *
      * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
@@ -1668,21 +1678,6 @@ interface UploadedFileInterface
      *     was provided.
      */
     public function getClientFilename();
-    
-    /**
-     * Retrieve the size sent by the client.
-     *
-     * Do not trust the value returned by this method. A client could send
-     * a wrong or malicious size with the intention to corrupt or hack your
-     * application.
-     *
-     * Implementations SHOULD return the value stored in the "size" key of
-     * the file in the $_FILES array.
-     *
-     * @return int|null The size sent by the client in bytes or null if none
-     *     was provided.
-     */
-    public function getClientSize();
     
     /**
      * Retrieve the mime type sent by the client.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -816,11 +816,6 @@ interface ServerRequestInterface extends RequestInterface
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
-     * The implementation SHOULD ensure that is_uploaded_file() returns true for
-     * the paths of the uploaded files. However, this recommendation MAY be
-     * ignored in special cases, for example when using temporary files as
-     * uploaded files during testing.
-     *
      * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
     public function getUploadedFiles();
@@ -1531,6 +1526,12 @@ interface UploadedFileInterface
      *
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
+     *
+     * The implementation MUST guarantee that the file pointed to by the path
+     * can safely be used by the calling code. More precisely, the
+     * implementation MUST ensure that is_uploaded_file() returns true for
+     * the path if the path was provided through the $_FILES array or a
+     * similar mechanism.
      *
      * @return string The absolute path to the uploaded file.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1527,6 +1527,9 @@ interface UploadedFileInterface
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
      *
+     * Implementations MUST guarantee that is_uploaded_file() returns true
+     * for the returned path.
+     *
      * @return string The absolute path to the uploaded file.
      */
     public function getPath();

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1611,6 +1611,14 @@ namespace Psr\Http\Message;
  * might change state MUST be implemented such that they retain the internal
  * state of the current instance and return an instance that contains the
  * changed state.
+ *
+ * When used in an SAPI environment where $_FILES is populated, files referenced
+ * by instances SHOULD be moved using is_uploaded_file() and
+ * move_uploaded_file() to ensure permissions and upload status are verified
+ * correctly.
+ *
+ * @see http://php.net/is_uploaded_file
+ * @see http://php.net/move_uploaded_file
  */
 interface UploadedFileInterface
 {

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1615,22 +1615,20 @@ namespace Psr\Http\Message;
 interface UploadedFileInterface
 {
     /**
-     * Retrieve the path to the uploaded file.
+     * Retrieve the (temporary) path to the uploaded file.
      *
-     * This method MUST return an absolute file path.
+     * This method MUST return an absolute file path; the path is assumed
+     * to be temporary, per the typical PHP upload mechisms.
      *
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
      *
      * The implementation MUST guarantee that the file pointed to by the path
-     * can safely be used by the calling code. More precisely, the
-     * implementation MUST ensure that is_uploaded_file() returns true for
-     * the path if the path was provided through the $_FILES array or a
-     * similar mechanism.
+     * can safely be used by the calling code.
      *
      * @return string The absolute path to the uploaded file.
      */
-    public function getPath();
+    public function getTemporaryPath();
     
     /**
      * Retrieve the error associated with the uploaded file.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -396,7 +396,7 @@ operations will work regardless of environment. In particular:
 - `move($path)` is provided as a safe and recommended alternative to calling
   `move_uploaded_file()` directly on the temporary upload file. Implementations
   will detect the correct operation to use based on environment.
-- `getStream()` will return a `StreamableInterface` instance. In non-SAPI
+- `getStream()` will return a `StreamInterface` instance. In non-SAPI
   environments, one proposed possibility is to parse individual upload files
   into `php://temp` streams instead of directly to files; in such cases, no
   upload file is present. `getStream()` is therefore guaranteed to work
@@ -406,7 +406,6 @@ As examples:
 
 ```
 // Move a file to an upload directory
-$uuid = create_a_uuid();
 $filename = sprintf(
     '%s.%s',
     create_uuid(),
@@ -415,7 +414,9 @@ $filename = sprintf(
 $file0->move(DATA_DIR . '/' . $filename);
 
 // Stream a file to Amazon S3.
-// Assume $s3wrapper is a PHP stream that will write to S3.
+// Assume $s3wrapper is a PHP stream that will write to S3, and that
+// Psr7StreamWrapper is a class that will decorate a StreamInterface as a PHP
+// StreamWrapper.
 $stream = new Psr7StreamWrapper($file1->getStream());
 stream_copy_to_stream($stream, $s3wrapper);
 ```
@@ -1647,7 +1648,7 @@ interface UploadedFileInterface
     /**
      * Retrieve a stream representing the uploaded file.
      *
-     * This method MUST return a StreamableInterface instance, representing the
+     * This method MUST return a StreamInterface instance, representing the
      * uploaded file. The purpose of this method is to allow utilizing native PHP
      * stream functionality to manipulate the file upload, such as
      * stream_copy_to_stream() (though the result will need to be decorated in a
@@ -1656,7 +1657,7 @@ interface UploadedFileInterface
      * If the move() method has been called previously, this method MUST raise
      * an exception.
      *
-     * @return StreamableInterface Stream representation of the uploaded file.
+     * @return StreamInterface Stream representation of the uploaded file.
      * @throws \RuntimeException in cases when no stream is available or can be
      *     created.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -816,6 +816,11 @@ interface ServerRequestInterface extends RequestInterface
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
+     * The implementation SHOULD ensure that is_uploaded_file() returns true for
+     * the paths of the uploaded files. However, this recommendation MAY be
+     * ignored in special cases, for example when using temporary files as
+     * uploaded files during testing.
+     *
      * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
     public function getUploadedFiles();
@@ -1526,9 +1531,6 @@ interface UploadedFileInterface
      *
      * Implementations SHOULD return the value stored in the "tmp_name" key
      * of the file in the $_FILES array.
-     *
-     * Implementations MUST guarantee that is_uploaded_file() returns true
-     * for the returned path.
      *
      * @return string The absolute path to the uploaded file.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -807,18 +807,32 @@ interface ServerRequestInterface extends RequestInterface
     public function withQueryParams(array $query);
 
     /**
-     * Retrieve the upload file metadata.
+     * Retrieve the uploaded files.
      *
-     * This method MUST return file upload metadata in the same structure
+     * This method MUST return the file upload metadata in the same structure
      * as PHP's $_FILES superglobal.
      *
      * These values MUST remain immutable over the course of the incoming
      * request. They SHOULD be injected during instantiation, such as from PHP's
      * $_FILES superglobal, but MAY be derived from other sources.
      *
-     * @return array Upload file(s) metadata, if any.
+     * @return UploadedFileInterface[] The uploaded file(s), if any.
      */
-    public function getFileParams();
+    public function getUploadedFiles();
+
+    /**
+     * Create a new instance with the specified uploaded files.
+     *
+     * These MAY be injected during instantiation.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * updated body parameters.
+     *
+     * @param UploadedFileInterface[] $uploadedFiles The uploaded files.
+     * @return self
+     */
+    public function withUploadedFiles(array $uploadedFiles);
 
     /**
      * Retrieve any parameters provided in the request body.
@@ -1486,5 +1500,95 @@ interface UriInterface
      * @return string
      */
     public function __toString();
+}
+```
+
+### 3.6 `Psr\Http\Message\UploadedFileInterface`
+
+```php
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a file uploaded through an HTTP request.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return a new instance that contains the
+ * changed state.
+ */
+interface UploadedFileInterface
+{
+    /**
+     * Retrieve the path to the uploaded file.
+     *
+     * This method MUST return an absolute file path.
+     *
+     * Implementations SHOULD return the value stored in the "tmp_name" key
+     * of the file in the $_FILES array.
+     *
+     * @return string The absolute path to the uploaded file.
+     */
+    public function getPath();
+    
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
+     *
+     * If the file was uploaded successfully, this method MUST return
+     * UPLOAD_ERR_OK.
+     *
+     * Implementations SHOULD return the value stored in the "error" key of
+     * the file in the $_FILES array.
+     *
+     * @return int One of the UPLOAD_ERR_XXX constants.
+     */
+    public function getError();
+    
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious filename with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "name" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename();
+    
+    /**
+     * Retrieve the size sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a wrong or malicious size with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array.
+     *
+     * @return int|null The size sent by the client in bytes or null if none
+     *     was provided.
+     */
+    public function getClientSize();
+    
+    /**
+     * Retrieve the mime type sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious mime type with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "type" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The mime type sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientMimeType();
 }
 ```


### PR DESCRIPTION
This pull request is based on (and incorporates commits from) #492.

In addition to the changes there, it presents the following:

- Clarifications to the `UploadedFileInterface` and `ServerRequestInterface`, including re-addition of `getFileParams()` as a canonical, non-mutable source for upload file data.
- Addition of section 1.6 to the specification, describing "Uploaded files".
- Addition of two "design decision" sections to the metadocument:
 - "Why are both getFileParams() and getUploadedFiles() present?"
 - "Why does getUploadedFiles() return objects instead of arrays?"