### PR TITLE
Making withUri() and Host header modifications more explicit

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -654,7 +654,17 @@ interface RequestInterface extends MessageInterface
     public function getUri();
 
     /**
-     * Return an instance with the provided URI.
+     * Returns an instance with the provided URI.
+     *
+     * This method will update the Host header of the returned request by
+     * default if the URI contains a host component. If the URI does not
+     * contain a host component, any pre-existing Host header will be carried
+     * over to the returned request.
+     *
+     * You can disable modifying the Host header of the request by setting
+     * `$overrideHost` to false. Note that when `$overrideHost` is set to
+     * false, the returned request will not update the Host header of the
+     * message-- even if the message contains no Host header.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the
@@ -662,9 +672,10 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
+     * @param bool $overrideHost Set to false to not change the Host header.
      * @return self
      */
-    public function withUri(UriInterface $uri);
+    public function withUri(UriInterface $uri, $overrideHost = true);
 }
 ```
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -664,7 +664,7 @@ interface RequestInterface extends MessageInterface
      * You can opt-in to preserving the original state of the Host header by
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
      * `true`, the returned request will not update the Host header of the
-     * returned message-- even if the message contains no Host header. This
+     * returned message -- even if the message contains no Host header. This
      * means that a call to `getHeader('Host')` on the original request MUST
      * equal the return value of a call to `getHeader('Host')` on the returned
      * request.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -661,10 +661,13 @@ interface RequestInterface extends MessageInterface
      * contain a host component, any pre-existing Host header will be carried
      * over to the returned request.
      *
-     * You can disable modifying the Host header of the request by setting
-     * `$overrideHost` to false. Note that when `$overrideHost` is set to
-     * false, the returned request will not update the Host header of the
-     * message-- even if the message contains no Host header.
+     * You can opt-in to preserving the original state of the Host header by
+     * setting `$preserveHost` to `true`. When `$preserveHost` is set to
+     * `true`, the returned request will not update the Host header of the
+     * returned message-- even if the message contains no Host header. This
+     * means that a call to `getHeader('Host')` on the original request MUST
+     * equal the return value of a call to `getHeader('Host')` on the returned
+     * request.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the
@@ -672,10 +675,10 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
-     * @param bool $overrideHost Set to false to not change the Host header.
+     * @param bool $preserveHost Preserve the original state of the Host header.
      * @return self
      */
-    public function withUri(UriInterface $uri, $overrideHost = true);
+    public function withUri(UriInterface $uri, $preserveHost = false);
 }
 ```
 


### PR DESCRIPTION
This PR updates the `witUri` method of a request to be more explicit about its relationship to the Host header, and updates this method to perform the expected behavior of assuming the host component of the provided URI by default.

Associating a URI with a request is an abstraction on top of an HTTP message. This abstraction isn't technically required to represent an HTTP message, but it is provided in PSR-7 as a convenience for clients and servers to know more about the transport of the message (destination or source) and to more easily slice up things in the URI (path, query, etc).

One of the components of the URI is the host, and an HTTP request also has a Host header. When calling `withRequest()` with a URI that contains a host component the HTTP request should be updated to use the host component of the URI by default, however, there should be a way to opt out of this transformation if desired. Updating the Host header by default reflects the most common usage of an HTTP message: you typically want to send a request to the same destination as the URI you provided, and diverging from this path is atypical.

This change also simplifies the current behavior of only overriding the Host header in the request if a Host header was not explicitly set. This change removes that concept entirely. For example, all of the "softHost" stuff from Guzzle's PSR7 package would be removed and this method would be greatly simplified (and easier to use IMO): https://github.com/guzzle/psr7/blob/master/src/Request.php#L136

@weierophinney @evert 