### PR TITLE
[PSR-7] Use exceptions for error handling in streams

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1029,6 +1029,10 @@ interface StreamableInterface
      *
      * Warning: This could attempt to load a large amount of data into memory.
      *
+     * This method MUST NOT raise an exception in order to conform with PHP's 
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string
      */
     public function __toString();
@@ -1059,7 +1063,8 @@ interface StreamableInterface
     /**
      * Returns the current position of the file read/write pointer
      *
-     * @return int|bool Position of the file pointer or false on error.
+     * @return int Position of the file pointer
+     * @throws \RuntimeException on error.
      */
     public function tell();
 
@@ -1088,6 +1093,7 @@ interface StreamableInterface
      *     offset bytes SEEK_CUR: Set position to current location plus offset
      *     SEEK_END: Set position to end-of-stream plus offset.
      * @return bool Returns TRUE on success or FALSE on failure.
+     * @throws \RuntimeException on failure.
      */
     public function seek($offset, $whence = SEEK_SET);
 
@@ -1100,7 +1106,8 @@ interface StreamableInterface
      *
      * @see seek()
      * @link http://www.php.net/manual/en/function.fseek.php
-     * @return bool Returns TRUE on success or FALSE on failure.
+     * @return bool Returns TRUE on success.
+     * @throws \RuntimeException on failure.
      */
     public function rewind();
 
@@ -1116,7 +1123,8 @@ interface StreamableInterface
      *
      * @param string $string The string that is to be written.
      * @return int|bool Returns the number of bytes written to the stream on
-     *     success or FALSE on failure.
+     *     success.
+     * @throws \RuntimeException on failure.
      */
     public function write($string);
 
@@ -1133,8 +1141,8 @@ interface StreamableInterface
      * @param int $length Read up to $length bytes from the object and return
      *     them. Fewer than $length bytes may be returned if underlying stream
      *     call returns fewer bytes.
-     * @return string|false Returns the data read from the stream, false if
-     *     unable to read or if an error occurs.
+     * @return string Returns the data read from the stream
+     * @throws \RuntimeException if unable to read or if an error occurs.
      */
     public function read($length);
 
@@ -1142,6 +1150,8 @@ interface StreamableInterface
      * Returns the remaining contents in a string
      *
      * @return string
+     * @throws \RuntimeException if unable to read or an error occurs while 
+     *     reading.
      */
     public function getContents();
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1140,8 +1140,9 @@ interface StreamableInterface
      * @param int $length Read up to $length bytes from the object and return
      *     them. Fewer than $length bytes may be returned if underlying stream
      *     call returns fewer bytes.
-     * @return string Returns the data read from the stream
-     * @throws \RuntimeException if unable to read or if an error occurs.
+     * @return string|null Returns the data read from the stream, or null if no bytes
+         are available and the stream is in non-blocking mode.
+     * @throws \RuntimeException if an error occurs.
      */
     public function read($length);
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1138,7 +1138,7 @@ interface StreamableInterface
      *     them. Fewer than $length bytes may be returned if underlying stream
      *     call returns fewer bytes.
      * @return string|null Returns the data read from the stream, or null if no bytes
-         are available and the stream is in non-blocking mode.
+     *     are available and the stream is in non-blocking mode.
      * @throws \RuntimeException if an error occurs.
      */
     public function read($length);

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1122,8 +1122,7 @@ interface StreamableInterface
      * Write data to the stream.
      *
      * @param string $string The string that is to be written.
-     * @return int|bool Returns the number of bytes written to the stream on
-     *     success.
+     * @return int Returns the number of bytes written to the stream.
      * @throws \RuntimeException on failure.
      */
     public function write($string);

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1092,7 +1092,6 @@ interface StreamableInterface
      *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
      *     offset bytes SEEK_CUR: Set position to current location plus offset
      *     SEEK_END: Set position to end-of-stream plus offset.
-     * @return bool Returns TRUE on success or FALSE on failure.
      * @throws \RuntimeException on failure.
      */
     public function seek($offset, $whence = SEEK_SET);
@@ -1100,13 +1099,11 @@ interface StreamableInterface
     /**
      * Seek to the beginning of the stream.
      *
-     * If the stream is not seekable, this method will return FALSE, indicating
-     * failure; otherwise, it will perform a seek(0), and return the status of
-     * that operation.
+     * If the stream is not seekable, this method will raise an exception;
+     * otherwise, it will perform a seek(0).
      *
      * @see seek()
      * @link http://www.php.net/manual/en/function.fseek.php
-     * @return bool Returns TRUE on success.
      * @throws \RuntimeException on failure.
      */
     public function rewind();


### PR DESCRIPTION
Per discussion:

- https://groups.google.com/d/msgid/php-fig/d5a9b044-1862-4333-bb67-645de997078c%40googlegroups.com

@ircmaxell indicates that raising exceptions is acceptable for StreamWrapper implementations, making it acceptable within this domain.

This patch modifies `StreamableInterface` methods that were following PHP stream error handling conventions (i.e., multiple return values, using int/bool returns to indicate errors) to instead raise `RuntimeException` instances.