### PR TITLE
Use "status code" and "reason phrase" consistently.

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -956,9 +956,9 @@ namespace Psr\Http\Message;
 interface ResponseInterface extends MessageInterface
 {
     /**
-     * Gets the response Status-Code.
+     * Gets the response status code.
      *
-     * The Status-Code is a 3-digit integer result code of the server's attempt
+     * The status code is a 3-digit integer result code of the server's attempt
      * to understand and satisfy the request.
      *
      * @return int Status code.
@@ -969,9 +969,9 @@ interface ResponseInterface extends MessageInterface
      * Return an instance with the specified status code, and optionally
      * reason phrase, for the response.
      *
-     * If no Reason-Phrase is specified, implementations MAY choose to default
+     * If no reason phrase is specified, implementations MAY choose to default
      * to the RFC 7231 or IANA recommended reason phrase for the response's
-     * Status-Code.
+     * status code.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the
@@ -989,13 +989,14 @@ interface ResponseInterface extends MessageInterface
     public function withStatus($code, $reasonPhrase = null);
 
     /**
-     * Gets the response Reason-Phrase, a short textual description of the Status-Code.
+     * Gets the response reason phrase, a short textual description of the
+     * status code.
      *
-     * Because a Reason-Phrase is not a required element in a response
-     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
      * choose to return the default RFC 7231 recommended reason phrase (or those
      * listed in the IANA HTTP Status Code Registry) for the response's
-     * Status-Code.
+     * status code.
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml


### PR DESCRIPTION
This PR uses "status code" and "reason phrase" consistently throughout the text and docblocks.

I can see a reason to use "Status-Code" and "Reason-Phrase" instead as the RFCs use this style (although only in text, not in the section headers). However, since we don't use "Header-Field", "Field-Name", and "Field-Value" when referring to headers, it seems to odd to use the hyphenated and capped style for "Status-Code" and "Reason-Phrase".