### PR TITLE
[PSR-7] Always return a string from read()

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1138,8 +1138,8 @@ interface StreamableInterface
      * @param int $length Read up to $length bytes from the object and return
      *     them. Fewer than $length bytes may be returned if underlying stream
      *     call returns fewer bytes.
-     * @return string|null Returns the data read from the stream, or null if no bytes
-     *     are available and the stream is in non-blocking mode.
+     * @return string Returns the data read from the stream, or an empty string
+     *     if no bytes are available.
      * @throws \RuntimeException if an error occurs.
      */
     public function read($length);


### PR DESCRIPTION
Per notes on #504 post-merge, `read()` should return an empty string if no bytes
are available, and not null.