### PR TITLE
[PSR-7] fix delimiters for scheme/authority and edge cases with path

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1613,14 +1613,17 @@ interface UriInterface
      * Section 4.1. The method concatenates the various components of the URI,
      * using the appropriate delimiters:
      *
-     * - If a scheme is present, "://" MUST append the value.
-     * - If the authority information is present, that value will be
-     *   concatenated.
-     * - If the path is rootless and the authority information is present, the
-     *   path MUST be prefixed by a "/" character. Otherwise, the path can be
-     *   concatenated without additional delimiters.
-     * - If a query string is present, it MUST be prefixed by a "?" character.
-     * - If a URI fragment is present, it MUST be prefixed by a "#" character.
+     * - If a scheme is present, it MUST be suffixed by ":".
+     * - If an authority is present, it MUST be prefixed by "//".
+     * - The path can be concatenated without delimiters. But there are two
+     *   cases where the path has to be adjusted to make the URI reference
+     *   valid as PHP does not allow to throw an exception in __toString():
+     *     - If the path is rootless and an authority is present, the path MUST
+     *       be prefixed by "/".
+     *     - If the path is starting with more than one "/" and no authority is
+     *       present, the starting slashes MUST be reduced to one.
+     * - If a query is present, it MUST be prefixed by "?".
+     * - If a fragment is present, it MUST be prefixed by "#".
      *
      * @see http://tools.ietf.org/html/rfc3986#section-4.1
      * @return string


### PR DESCRIPTION
1. the "//" delimiter belongs to the authority and not scheme which is important for `mailto:tobias@example.org` for example where the email is the path
2. I found another edge cases for the path that need to be adjusted. Ideally we would throw an exception because the given values are invalid for a URI but we cannot do that in __toString unfortunately
   - `$request->withScheme('http')->withHost('')->withPath('//path')->__toString()` CANNOT return `http://path` because it would change the path to the host if you `parse_url` that back. See RFC 3986:
  
    > When
   authority is not present, the path cannot begin with two slash
   characters ("//").  These restrictions result in five different ABNF
   rules for a path (Section 3.3), only one of which will match any
   given URI reference.
  
    So we change it to `http:/path` which is the best guess we can do.

The other edge case was already specified, e.g. `$request->withScheme('http')->withHost('example.org')->withPath('rootless/sub')->__toString()` CANNOT return `http://example.orgrootless/sub`, so we change it to `http://example.org/rootless/sub`