### PR TITLE
[PSR-7] Removed verbiage "if any" from `getUri()`

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -774,7 +774,7 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @return UriInterface Returns a UriInterface instance
-     *     representing the URI of the request, if any.
+     *     representing the URI of the request.
      */
     public function getUri();
 


### PR DESCRIPTION
Per a point made [on the mailing list](https://groups.google.com/d/msgid/php-fig/8f3c71aa-bbfb-4178-9806-8d740425ef0e%40googlegroups.com), this patch removes the phrase "if any" from `RequestInterface::getUri()` to remove any confusion about whether or not it should return a `UriInterface` instance.