### PR TITLE
[PSR-7] Adding cookies MUST NOT update headers or server params

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -884,6 +884,9 @@ interface ServerRequestInterface extends RequestInterface
      * be compatible with the structure of $_COOKIE. Typically, this data will
      * be injected at instantiation.
      *
+     * This method MUST NOT update the related Cookie header of the request
+     * instance, nor related values in the server params.
+     *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the
      * updated cookie values.


### PR DESCRIPTION
Per discussion with @simensen, added verbiage to indicate that setting cookie parameters MUST NOT update headers or server params. This mirrors language that already exists in `withQueryParams()` (which specifies implementations MUST NOT update the URI instance based on the changes).