### PR TITLE
Remove RequestInterface::getHeaders, getHeader, and getHeaderLine

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -649,64 +649,6 @@ namespace Psr\Http\Message;
 interface RequestInterface extends MessageInterface
 {
     /**
-     * Extends MessageInterface::getHeaders() to provide request-specific
-     * behavior.
-     *
-     * Retrieves all message headers.
-     *
-     * This method acts exactly like MessageInterface::getHeaders(), with one
-     * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host component of the composed URI, if
-     * present.
-     *
-     * @see MessageInterface::getHeaders()
-     * @see UriInterface::getHost()
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
-     */
-    public function getHeaders();
-
-    /**
-     * Extends MessageInterface::getHeader() to provide request-specific
-     * behavior.
-     *
-     * This method acts exactly like MessageInterface::getHeader(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * component of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeader()
-     * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values as provided for the given
-     *    header. If the header does not appear in the message, this method MUST
-     *    return an empty array.
-     */
-    public function getHeader($name);
-
-    /**
-     * Extends MessageInterface::getHeaderLines() to provide request-specific
-     * behavior.
-     *
-     * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
-     *
-     * This method acts exactly like MessageInterface::getHeaderLines(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * component of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeaderLine()
-     * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
-     * @return string|null A string of values as provided for the given header
-     *    concatenated together using a comma. If the header does not appear in
-     *    the message, this method MUST return a null value.
-     */
-    public function getHeaderLine($name);
-
-    /**
      * Retrieves the message's request target.
      *
      * Retrieves the message's request-target either as it will appear (for


### PR DESCRIPTION
The new behavior in `RequestInterface::withUri()` from PR #500 makes the overrides
in `Request::getHeaders()`, `getHeader()`, `getHeaderLine()` unecessary and incompatible with the description for `withUri()`.

Specifically, the problematic section is:

> You can opt-in to preserving the original state of the Host header by
> setting `$preserveHost` to `true`. When `$preserveHost` is set to
> `true`, the returned request will not update the Host header of the
> returned message -- even if the message contains no Host header. This
> means that a call to `getHeader('Host')` on the original request MUST
> equal the return value of a call to `getHeader('Host')` on the returned
> request.

Here's an example:

```php
// $request1 has no explictily set Host header.
$request1->getHeader('Host'); // [] Not set, so empty array

$request2 = $request1->withUri(new Uri('http://localhost/'), true);
$request2->getHeader('Host'); // ['localhost'] Read from the URI

$request3 = $request2->withUri(new Uri('http://someotherhost/'), true);
$request3->getHeader('Host'); // ['someotherhost'] Read from the URI
```
