### PR TITLE
Update description for RequestInterface::withUri().

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -676,64 +676,6 @@ namespace Psr\Http\Message;
 interface RequestInterface extends MessageInterface
 {
     /**
-     * Extends MessageInterface::getHeaders() to provide request-specific
-     * behavior.
-     *
-     * Retrieves all message headers.
-     *
-     * This method acts exactly like MessageInterface::getHeaders(), with one
-     * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host component of the composed URI, if
-     * present.
-     *
-     * @see MessageInterface::getHeaders()
-     * @see UriInterface::getHost()
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
-     */
-    public function getHeaders();
-
-    /**
-     * Extends MessageInterface::getHeader() to provide request-specific
-     * behavior.
-     *
-     * This method acts exactly like MessageInterface::getHeader(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * component of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeader()
-     * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values as provided for the given
-     *    header. If the header does not appear in the message, this method MUST
-     *    return an empty array.
-     */
-    public function getHeader($name);
-
-    /**
-     * Extends MessageInterface::getHeaderLine() to provide request-specific
-     * behavior.
-     *
-     * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
-     *
-     * This method acts exactly like MessageInterface::getHeaderLine(), with
-     * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method MUST attempt to pull the host
-     * component of the composed URI, if present.
-     *
-     * @see MessageInterface::getHeaderLine()
-     * @see UriInterface::getHost()
-     * @param string $name Case-insensitive header field name.
-     * @return string|null A string of values as provided for the given header
-     *    concatenated together using a comma. If the header does not appear in
-     *    the message, this method MUST return a null value.
-     */
-    public function getHeaderLine($name);
-
-    /**
      * Retrieves the message's request target.
      *
      * Retrieves the message's request-target either as it will appear (for

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -781,18 +781,15 @@ interface RequestInterface extends MessageInterface
     /**
      * Returns an instance with the provided URI.
      *
-     * This method will update the Host header of the returned request by
+     * This method MUST update the Host header of the returned request by
      * default if the URI contains a host component. If the URI does not
-     * contain a host component, any pre-existing Host header will be carried
+     * contain a host component, any pre-existing Host header MUST be carried
      * over to the returned request.
      *
      * You can opt-in to preserving the original state of the Host header by
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
-     * `true`, the returned request will not update the Host header of the
-     * returned message -- even if the message contains no Host header. This
-     * means that a call to `getHeader('Host')` on the original request MUST
-     * equal the return value of a call to `getHeader('Host')` on the returned
-     * request.
+     * `true`, the returned request MUST NOT update the Host header of the
+     * returned message -- even if the message contains no Host header.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -669,6 +669,9 @@ namespace Psr\Http\Message;
  * - Headers
  * - Message body
  *
+ * During construction, implementations MUST attempt to set the Host header from
+ * a provided URI if no Host header is provided as well.
+ * 
  * Requests are considered immutable; all methods that might change state MUST
  * be implemented such that they retain the internal state of the current
  * message and return an instance that contains the changed state.

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -815,11 +815,16 @@ interface RequestInterface extends MessageInterface
      *
      * You can opt-in to preserving the original state of the Host header by
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
-     * `true`, the returned request MUST NOT update the Host header of the
-     * returned message -- unless the original messages contains no Host header.
-     * This means that a call to `getHeader('Host')` on the original request
-     * MUST equal the return value of a call to `getHeader('Host')` on the
-     * returned request.
+     * `true`, this method interacts with the Host header in the following ways:
+     *
+     * - If the the Host header is missing or empty, and the new URI contains 
+     *   a host component, this method MUST update the Host header in the returned 
+     *   request.
+     * - If the Host header is missing or empty, and the new URI does not contain a
+     *   host component, this method MUST NOT update the Host header in the returned
+     *   request.
+     * - If a Host header is present and non-empty, this method MUST NOT update
+     *   the Host header in the returned request.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -146,6 +146,27 @@ present in the composed `UriInterface`, the value from the URI should be used.
 If a Host header is explicitly provided to the request instance, that value will
 be preferred.
 
+`RequestInterface::withUri()` also interacts with the Host header. By default,
+this method replaces the returned request's Host header with a Host header
+matching the host component of the passed `UriInterface`.
+
+You can opt-in to preserving the original state of the Host header by passing
+`true` for the second (`$preserveHost`) argument. When this argument is set to
+`true`, the returned request will not update the Host header of the returned
+message -- unless the message contains no Host header.
+
+This table illustrates what `getHeaderLine('Host')` will return for a request
+returned by `withUri()` with the `$preserveHost` argument set to `true` for
+various initial requests and URIs.
+
+Request Host header | Request host component | URI host component | Result
+--------------------|------------------------|--------------------|--------
+''                  | ''                     | ''                 | ''
+''                  | foo.com                | ''                 | foo.com
+''                  | foo.com                | bar.com            | foo.com
+foo.com             | ''                     | bar.com            | foo.com
+foo.com             | bar.com                | baz.com            | foo.com
+
 ### 1.3 Streams
 
 HTTP messages consist of a start-line, headers, and a body. The body of an HTTP
@@ -789,7 +810,10 @@ interface RequestInterface extends MessageInterface
      * You can opt-in to preserving the original state of the Host header by
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
      * `true`, the returned request MUST NOT update the Host header of the
-     * returned message -- even if the message contains no Host header.
+     * returned message -- unless the original messages contains no Host header.
+     * This means that a call to `getHeader('Host')` on the original request
+     * MUST equal the return value of a call to `getHeader('Host')` on the
+     * returned request.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -135,25 +135,21 @@ for retrieving such multi-valued headers.
 
 ##### Host header
 
-In requests, the Host header typically mirrors the host segment of the URI, as
+In requests, the `Host` header typically mirrors the host segment of the URI, as
 well as the host used when establishing the TCP connection. However, the HTTP
-specification allows the Host header to differ from each of the two.
+specification allows the `Host` header to differ from each of the two.
 
-The `RequestInterface` overrides the `MessageInterface::getHeader()`,
-`MessageInterface::getHeaders()`, and `MessageInterface::getHeaderLine()`
-methods to indicate that if no Host header is present, but a host segment is
-present in the composed `UriInterface`, the value from the URI should be used.
-If a Host header is explicitly provided to the request instance, that value will
-be preferred.
+During construction, implementations MUST attempt to set the `Host` header from
+a provided URI if no `Host` header is provided as well.
 
-`RequestInterface::withUri()` also interacts with the Host header. By default,
-this method replaces the returned request's Host header with a Host header
-matching the host component of the passed `UriInterface`.
+`RequestInterface::withUri()` will, by default, replace the returned request's
+`Host` header with a `Host` header matching the host component of the passed
+`UriInterface`.
 
-You can opt-in to preserving the original state of the Host header by passing
+You can opt-in to preserving the original state of the `Host` header by passing
 `true` for the second (`$preserveHost`) argument. When this argument is set to
-`true`, the returned request will not update the Host header of the returned
-message -- unless the message contains no Host header.
+`true`, the returned request will not update the `Host` header of the returned
+message -- unless the message contains no `Host` header.
 
 This table illustrates what `getHeaderLine('Host')` will return for a request
 returned by `withUri()` with the `$preserveHost` argument set to `true` for

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -159,13 +159,19 @@ This table illustrates what `getHeaderLine('Host')` will return for a request
 returned by `withUri()` with the `$preserveHost` argument set to `true` for
 various initial requests and URIs.
 
-Request Host header | Request host component | URI host component | Result
---------------------|------------------------|--------------------|--------
-''                  | ''                     | ''                 | ''
-''                  | foo.com                | ''                 | foo.com
-''                  | foo.com                | bar.com            | foo.com
-foo.com             | ''                     | bar.com            | foo.com
-foo.com             | bar.com                | baz.com            | foo.com
+Request Host header<sup>[1](#rhh)</sup> | Request host component<sup>[2](#rhc)</sup> | URI host component<sup>[3](#uhc)</sup> | Result
+----------------------------------------|--------------------------------------------|----------------------------------------|--------
+''                                      | ''                                         | ''                                     | ''
+''                                      | foo.com                                    | ''                                     | foo.com
+''                                      | foo.com                                    | bar.com                                | foo.com
+foo.com                                 | ''                                         | bar.com                                | foo.com
+foo.com                                 | bar.com                                    | baz.com                                | foo.com
+
+- <sup id="rhh">1</sup> `Host` header value prior to operation.
+- <sup id="rhc">2</sup> Host component of the URI composed in the request prior
+  to the operation.
+- <sup id="uhc">3</sup> Host component of the URI being injected via
+  `withUri()`.
 
 ### 1.3 Streams
 

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -140,7 +140,7 @@ well as the host used when establishing the TCP connection. However, the HTTP
 specification allows the `Host` header to differ from each of the two.
 
 During construction, implementations MUST attempt to set the `Host` header from
-a provided URI if no `Host` header is provided as well.
+a provided URI if no `Host` header is provided.
 
 `RequestInterface::withUri()` will, by default, replace the returned request's
 `Host` header with a `Host` header matching the host component of the passed
@@ -666,7 +666,7 @@ namespace Psr\Http\Message;
  * - Message body
  *
  * During construction, implementations MUST attempt to set the Host header from
- * a provided URI if no Host header is provided as well.
+ * a provided URI if no Host header is provided.
  * 
  * Requests are considered immutable; all methods that might change state MUST
  * be implemented such that they retain the internal state of the current


### PR DESCRIPTION
This PR updates the description for `RequestInterface::withUri()`. The new description uses "MUST" in place of "will" and removes a line from the description that was inconsistent with `Message::getHeaders()`, `getHeader()`, and `getHeaderLines()` when the original request did not include an explicitly set `Host` header.

Specifically, the problematic section is:

> You can opt-in to preserving the original state of the Host header by setting $preserveHost to true. When $preserveHost is set to true, the returned request will not update the Host header of the returned message -- even if the message contains no Host header. **This means that a call to getHeader('Host') on the original request MUST equal the return value of a call to getHeader('Host') on the returned request.**

Here's an example:

```php
// $request1 has no explictily set Host header.
$request1->getHeader('Host'); // [] Not set, so empty array

$request2 = $request1->withUri(new Uri('http://localhost/'), true);
$request2->getHeader('Host'); // ['localhost'] Read from the URI

$request3 = $request2->withUri(new Uri('http://someotherhost/'), true);
$request3->getHeader('Host'); // ['someotherhost'] Read from the URI
```

I think we can drop this last sentence and avoid the inconsistency. With the stronger language ("MUST" in place of "will", etc.), the description should be clear enough.

Alternatively, we could replace the last sentence with a  a more explicit explanation, but they end up being really wordy and convoluted. Something like: 

> You can opt-in to preserving the original state of the Host header by setting $preserveHost to true. When $preserveHost is set to true, the returned request will not update the Host header of the returned message -- even if the message contains no Host header. **If a request has an explicitly set Host header, a call to getHeader('Host') on that request MUST equal the return value of a call to getHeader('Host') on the request returned by withUri() with $preserveHost set to true.**