### PR TITLE
Remove the reason phrase

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1088,7 +1088,7 @@ namespace Psr\Http\Message;
  * each of the following:
  *
  * - Protocol version
- * - Status code and reason phrase
+ * - Status code
  * - Headers
  * - Message body
  *
@@ -1109,43 +1109,19 @@ interface ResponseInterface extends MessageInterface
     public function getStatusCode();
 
     /**
-     * Return an instance with the specified status code, and optionally
-     * reason phrase, for the response.
-     *
-     * If no reason phrase is specified, implementations MAY choose to default
-     * to the RFC 7231 or IANA recommended reason phrase for the response's
-     * status code.
+     * Return an instance with the specified status code for the response.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return an instance that has the
-     * updated status and reason phrase.
+     * updated status.
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @param int $code The 3-digit integer result code to set.
-     * @param null|string $reasonPhrase The reason phrase to use with the
-     *     provided status code; if none is provided, implementations MAY
-     *     use the defaults as suggested in the HTTP specification.
      * @return self
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus($code, $reasonPhrase = null);
-
-    /**
-     * Gets the response reason phrase, a short textual description of the
-     * status code.
-     *
-     * Because a reason phrase is not a required element in a response
-     * status line, the reason phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * status code.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string|null Reason phrase, or null if unknown.
-     */
-    public function getReasonPhrase();
+    public function withStatus($code);
 }
 ```
 


### PR DESCRIPTION
The reason phrase is totally optional in HTTP 1.1 and should not be relied on. Moreover, it was removed from HTTP 2 altogether. So, I think it makes sense to not add it to PSR-7.