### PR TITLE
Add Beau Simensen as the new PSR-6 sponsor.

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Unless a PSR is marked as "Accepted" it is subject to change. Draft can change d
 | A      | 3   | [Logger Interface][psr3]       | Jordi Boggiano          | _N/A_          | _N/A_          |
 | A      | 4   | [Autoloading Standard][psr4]   | Paul M. Jones           | Phil Sturgeon  | Larry Garfield |
 | D      | 5   | [PHPDoc Standard][psr5]        | Mike van Riel           | Phil Sturgeon  | Donald Gilbert |
-| R      | 6   | [Caching Interface][psr6]      | Larry Garfield          | Pádraic Brady  | John Mertic    |
+| R      | 6   | [Caching Interface][psr6]      | Larry Garfield          | Pádraic Brady  | Beau Simensen  |
 | D      | 7   | [HTTP Message Interface][psr7] | Matthew Weier O'Phinney | Beau Simensen  | Paul Jones     |
 | D      | 8   | [Huggable Interface][psr8]     | Larry Garfield          | Cal Evans      | Paul Jones     |
 | D      | 9   | [Security Disclosure][psr9]    | Lukas Kahwe Smith       | Korvin Szanto  | Larry Garfield |

--- a/proposed/cache-meta.md
+++ b/proposed/cache-meta.md
@@ -285,8 +285,8 @@ do so.
 
 ### 5.2 Sponsors
 
-* Pádraic Brady (Coordinator)
-* John Mertic
+* Pádraic Brady, Zend Framework (Coordinator)
+* Beau Simensen, Sculpin
 
 ### 5.3 Contributors
 


### PR DESCRIPTION
Since John Mertic is no longer a voting representative.