### PR TITLE
One-line short descriptions in method docblocks

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -550,8 +550,7 @@ interface MessageInterface
     public function getHeader($name);
 
     /**
-     * Retrieves the line for a single header, with the header values as a
-     * comma-separated string.
+     * Retrieves a comma-concatenated string of the values for a single header.
      *
      * This method returns all of the header values of the given
      * case-insensitive header name as a string concatenated together using
@@ -572,8 +571,7 @@ interface MessageInterface
     public function getHeaderLine($name);
 
     /**
-     * Return an instance with the provided header, replacing any existing
-     * values of any headers with the same case-insensitive name.
+     * Return an instance with the provided value replacing the specified header.
      *
      * While header names are case-insensitive, the casing of the header will
      * be preserved by this function, and returned from getHeaders().
@@ -590,8 +588,7 @@ interface MessageInterface
     public function withHeader($name, $value);
 
     /**
-     * Return an instance with the specified header appended with the
-     * given value.
+     * Return an instance with the specified header appended with the given value.
      *
      * Existing values for the specified header will be maintained. The new
      * value(s) will be appended to the existing list. If the header did not
@@ -1029,8 +1026,7 @@ interface ServerRequestInterface extends RequestInterface
     public function withAttribute($name, $value);
 
     /**
-     * Return an instance that removes the specified derived request
-     * attribute.
+     * Return an instance that removes the specified derived request attribute.
      *
      * This method allows removing a single derived request attribute as
      * described in getAttributes().
@@ -1082,8 +1078,7 @@ interface ResponseInterface extends MessageInterface
     public function getStatusCode();
 
     /**
-     * Return an instance with the specified status code, and optionally
-     * reason phrase, for the response.
+     * Return an instance with the specified status code and, optionally, reason phrase.
      *
      * If no reason phrase is specified, implementations MAY choose to default
      * to the RFC 7231 or IANA recommended reason phrase for the response's
@@ -1096,17 +1091,16 @@ interface ResponseInterface extends MessageInterface
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @param int $code The 3-digit integer result code to set.
-     * @param null|string $reasonPhrase The reason phrase to use with the
+     * @param string $reasonPhrase The reason phrase to use with the
      *     provided status code; if none is provided, implementations MAY
      *     use the defaults as suggested in the HTTP specification.
      * @return self
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus($code, $reasonPhrase = null);
+    public function withStatus($code, $reasonPhrase = '');
 
     /**
-     * Gets the response reason phrase, a short textual description of the
-     * status code.
+     * Gets the response reason phrase associated with the status code.
      *
      * Because a reason phrase is not a required element in a response
      * status line, the reason phrase value MAY be null. Implementations MAY
@@ -1116,7 +1110,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string|null Reason phrase, or null if unknown.
+     * @return string Reason phrase; must return an empty string if none present.
      */
     public function getReasonPhrase();
 }
@@ -1171,7 +1165,7 @@ interface StreamInterface
     public function detach();
 
     /**
-     * Get the size of the stream if known
+     * Get the size of the stream if known.
      *
      * @return int|null Returns the size in bytes if known, or null if unknown.
      */

--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -550,7 +550,7 @@ interface MessageInterface
     public function getHeader($name);
 
     /**
-     * Retrieves a comma-concatenated string of the values for a single header.
+     * Retrieves a comma-separated string of the values for a single header.
      *
      * This method returns all of the header values of the given
      * case-insensitive header name as a string concatenated together using


### PR DESCRIPTION
Per @Crell in the ML, this patch modifies the short-description lines of a number of methods that were wrapping to a second line, shortening them to fit on a single line.

Additionally, a small number of signature changes were made for consistency:

- `withStatus()` sets the default value of `$reasonPhrase` to a string.
- `getReasonPhrase()` now only returns a string; if no value is present, an empty string is returned.