### PR TITLE
Changed "case-insensitive" to "case-sensitive" in RequestInterface::with...

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -866,7 +866,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * changed request method.
      *
-     * @param string $method Case-insensitive method.
+     * @param string $method Case-sensitive method.
      * @return self
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */


### PR DESCRIPTION
Looks a like a typo since the longer part of the description makes a point to describe methods as case-sensitive.