### PR TITLE
[PSR-7] Replace null with empty string

### DIFF
--- a/proposed/http-message.md
+++ b/proposed/http-message.md
@@ -1240,14 +1240,14 @@ interface ResponseInterface extends MessageInterface
      * Gets the response reason phrase associated with the status code.
      *
      * Because a reason phrase is not a required element in a response
-     * status line, the reason phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * status code.
+     * status line, the reason phrase value MAY be an empty string.
+     * Implementations MAY choose to return the default RFC 7231 recommended
+     * reason phrase (or those listed in the IANA HTTP Status Code Registry) for
+     * the response's status code.
      *
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string Reason phrase; must return an empty string if none present.
+     * @return string Reason phrase; MUST return an empty string if none present.
      */
     public function getReasonPhrase();
 }


### PR DESCRIPTION
The return value MUST be an empty string, but the description said it could be null.
Also 'must' wasn't uppercase.

I know psr-7 is in Voting stage, but I guess this is just a forgotten textual change.