### PR TITLE
fix #325 - README-pt_BR.md

### DIFF
--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -1,0 +1,54 @@
+Grupo de Interoperabilidade entre Frameworks PHP
+================================================
+
+A ideia por trás do grupo é falar sobre pontos em comum entre os projetos
+representados e encontrar maneiras de trabalharmos juntos. Nosso público-alvo
+somos nós mesmos, apesar de estarmos conscientes de que o restante da
+comunidade PHP está nos observando. Se outras pessoas quiserem adotar o que
+estamos fazendo serão bem vindas, mesmo que esse não seja o objetivo do
+grupo.
+
+
+Proposta de uma Recomendação de Padrão
+--------------------------------------
+
+Para propor uma recomendação de padrão (PSR - PHP Standards Recommendation,
+em inglês):
+
+- faça o fork, crie um branch, faça o checkout desse branch, adicione a PSR na
+  pasta `proposed/`, faça o push do branch para o Github e envie um pull
+  request; ou,
+
+- crie uma issue para iniciar a discussão no Github; ou,
+
+- inicie uma conversa na [lista de discussão][].
+
+[lista de discussão]: http://groups.google.com/group/php-fig/
+
+
+Solicitação de Associação
+-------------------------
+
+Você **não** precisa ser um membro votante para participar de uma discussão na
+[lista][lista de discussão].
+
+Para se tornar um membro votante, você precisa enviar um email para a
+[lista de discussão][].
+
+- O assunto da mensagem deve ser: `Membership Request: {$your_name} ({$project_name})`
+
+- O corpo da mensagem deve conter seu nome, o nome (e o link) do projeto
+  que você representa, e outros detalhes que achar relevantes.
+
+- Os membros atuais votarão em sua solicitação.
+
+Não misture várias solicitações de associação em uma única mensagem; por
+favor, uma solicitação por mensagem/thread.
+
+
+Membros Votantes
+----------------
+
+A lista atual de membros votantes está disponível na [página do projeto][].
+
+[página do projeto]: http://www.php-fig.org/


### PR DESCRIPTION
[pt_BR] Create README-pt_BR.md, starting with original EN
[pt_BR] Translate README into Brazilian Portuguese
[pt_BR] Enhance translation of README-pt_BR (thanks @andreia!)

List of notes:
- https://github.com/php-fig/fig-standards/pull/325#discussion-diff-27341117
- https://github.com/php-fig/fig-standards/pull/325#discussion-diff-27341162
- https://github.com/php-fig/fig-standards/pull/325#discussion-diff-27341482
- https://github.com/php-fig/fig-standards/pull/325#issuecomment-88280023

Signed-off-by: Rogerio Prado de Jesus <rogeriopradoj@gmail.com>