### PR TITLE
[PSR-7] single quotes are used in code examples

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -643,7 +643,7 @@ interface MessageInterface
      *
      *     // Represent the headers as a string
      *     foreach ($message->getHeaders() as $name => $values) {
-     *         echo $name . ": " . implode(", ", $values);
+     *         echo $name . ': ' . implode(', ', $values);
      *     }
      *
      *     // Emit headers iteratively:


### PR DESCRIPTION
PSR-7 uses single quotes in code examples everywhere else, like 6 lines below this change.