### PR TITLE
Change page title to an H1

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-## Index of PHP Standard Recommendations
+# PHP Standard Recommendations
 
 According to the [PSR Workflow Bylaw](https://github.com/php-fig/fig-standards/blob/master/bylaws/004-psr-workflow.md) each PSR has a status as it is being worked on. Once a proposal has passed the Entrance Vote it will be listed here as "Draft". 
 


### PR DESCRIPTION
All other pages titles start with an H1, so to make things easier with the website this page should probably be an H1 as well. Further, I don't really think "Index of" is necessary.