### PR TITLE
Reverse order of PSR Index by Status

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,26 +6,6 @@ Unless a PSR is marked as "Accepted" it is subject to change. Draft can change d
 
 ## Index by Status
 
-### Draft
-
-| Num | Title                          | Editor                  |  Coordinator   | Sponsor        |
-|:---:|--------------------------------|-------------------------|----------------|----------------|
-| 5   | [PHPDoc Standard][psr5]        | Mike van Riel           | Phil Sturgeon  | Donald Gilbert |
-| 8   | [Huggable Interface][psr8]     | Larry Garfield          | Cal Evans      | Paul Jones     |
-| 9   | [Security Disclosure][psr9]    | Lukas Kahwe Smith       | Korvin Szanto  | Larry Garfield |
-| 10  | [Security Advisories][psr10]   | Lukas Kahwe Smith       | Larry Garfield | Korvin Szanto  |
-
-### Review
-
-| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
-|:---:|--------------------------------|-------------------------|---------------|-------------|
-| 6   | [Caching Interface][psr6]      | Larry Garfield          | Pádraic Brady | John Mertic |
-
-### Voting
-
-| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
-|:---:|--------------------------------|-------------------------|---------------|-------------|
-
 ### Accepted
 
 | Num | Title                          | Editor                  |  Coordinator  | Sponsor        |
@@ -36,6 +16,26 @@ Unless a PSR is marked as "Accepted" it is subject to change. Draft can change d
 | 3   | [Logger Interface][psr3]       | Jordi Boggiano          | _N/A_         | _N/A_          |
 | 4   | [Autoloading Standard][psr4]   | Paul M. Jones           | Phil Sturgeon | Larry Garfield |
 | 7   | [HTTP Message Interface][psr7] | Matthew Weier O'Phinney | Beau Simensen | Paul Jones     |
+
+### Voting
+
+| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
+|:---:|--------------------------------|-------------------------|---------------|-------------|
+
+### Review
+
+| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
+|:---:|--------------------------------|-------------------------|---------------|-------------|
+| 6   | [Caching Interface][psr6]      | Larry Garfield          | Pádraic Brady | John Mertic |
+
+### Draft
+
+| Num | Title                          | Editor                  |  Coordinator   | Sponsor        |
+|:---:|--------------------------------|-------------------------|----------------|----------------|
+| 5   | [PHPDoc Standard][psr5]        | Mike van Riel           | Phil Sturgeon  | Donald Gilbert |
+| 8   | [Huggable Interface][psr8]     | Larry Garfield          | Cal Evans      | Paul Jones     |
+| 9   | [Security Disclosure][psr9]    | Lukas Kahwe Smith       | Korvin Szanto  | Larry Garfield |
+| 10  | [Security Advisories][psr10]   | Lukas Kahwe Smith       | Larry Garfield | Korvin Szanto  |
 
 ## Numerical Index
 


### PR DESCRIPTION
I'd like to propose reversing the order of the Index by Status section.

The PHP-FIG works hard to create and approve these PSRs, so I feel the Accepted ones should be presented front-and-center, not buried half-way down the page.  I also think most visitors interested in implementing these PSRs would expect them to be displayed prominently, instead of seeing the incomplete works first.  This change is analogous to PSRs becoming "promoted" to a "higher" status.

I doubt that this change would negatively-impact those who are (or wish to become) more-involved in FIG.  These visitors will likely be familiar with the process and statuses, and will therefore know to scroll past the Accepted PSRs to locate those being worked on.

TL;DR: I think this change makes the index slightly more community-friendly.