### PR TITLE
Reverse order of PSR Index by Status

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,27 +6,6 @@ Unless a PSR is marked as "Accepted" it is subject to change. Draft can change d
 
 ## Index by Status
 
-### Draft
-
-| Num | Title                          | Editor(s)                      |  Coordinator   | Sponsor         |
-|:---:|--------------------------------|--------------------------------|----------------|-----------------|
-| 5   | [PHPDoc Standard][psr5]        | Mike van Riel                  | Phil Sturgeon  | Donald Gilbert  |
-| 8   | [Huggable Interface][psr8]     | Larry Garfield                 | Cal Evans      | Paul Jones      |
-| 9   | [Security Disclosure][psr9]    | Lukas Kahwe Smith              | Korvin Szanto  | Larry Garfield  |
-| 10  | [Security Advisories][psr10]   | Lukas Kahwe Smith              | Larry Garfield | Korvin Szanto   |
-| 11  | [Container Interface][psr11]   | Matthieu Napoli, David Négrier | Paul M. Jones  | Jeremy Lindblom |
-
-### Review
-
-| Num | Title                          | Editor                  |  Coordinator  | Sponsor       |
-|:---:|--------------------------------|-------------------------|---------------|---------------|
-| 6   | [Caching Interface][psr6]      | Larry Garfield          | Beau Simensen | Pádraic Brady |
-
-### Voting
-
-| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
-|:---:|--------------------------------|-------------------------|---------------|-------------|
-
 ### Accepted
 
 | Num | Title                          | Editor                  |  Coordinator  | Sponsor        |
@@ -37,6 +16,27 @@ Unless a PSR is marked as "Accepted" it is subject to change. Draft can change d
 | 3   | [Logger Interface][psr3]       | Jordi Boggiano          | _N/A_         | _N/A_          |
 | 4   | [Autoloading Standard][psr4]   | Paul M. Jones           | Phil Sturgeon | Larry Garfield |
 | 7   | [HTTP Message Interface][psr7] | Matthew Weier O'Phinney | Beau Simensen | Paul Jones     |
+
+### Voting
+
+| Num | Title                          | Editor                  |  Coordinator  | Sponsor     |
+|:---:|--------------------------------|-------------------------|---------------|-------------|
+
+### Review
+
+| Num | Title                          | Editor                  |  Coordinator  | Sponsor       |
+|:---:|--------------------------------|-------------------------|---------------|---------------|
+| 6   | [Caching Interface][psr6]      | Larry Garfield          | Beau Simensen | Pádraic Brady |
+
+### Draft
+
+| Num | Title                          | Editor(s)                      |  Coordinator   | Sponsor         |
+|:---:|--------------------------------|--------------------------------|----------------|-----------------|
+| 5   | [PHPDoc Standard][psr5]        | Mike van Riel                  | Phil Sturgeon  | Donald Gilbert  |
+| 8   | [Huggable Interface][psr8]     | Larry Garfield                 | Cal Evans      | Paul Jones      |
+| 9   | [Security Disclosure][psr9]    | Lukas Kahwe Smith              | Korvin Szanto  | Larry Garfield  |
+| 10  | [Security Advisories][psr10]   | Lukas Kahwe Smith              | Larry Garfield | Korvin Szanto   |
+| 11  | [Container Interface][psr11]   | Matthieu Napoli, David Négrier | Paul M. Jones  | Jeremy Lindblom |
 
 ## Numerical Index
 


### PR DESCRIPTION
Replaces #592 and colinodell/fig-standards@2792927427b227e13ae9ca77cb9448d2e0422fa0