### PR TITLE
PSR2 Coding Style Typo Fix

### DIFF
--- a/accepted/fr/PSR-2-coding-style-guide.md
+++ b/accepted/fr/PSR-2-coding-style-guide.md
@@ -506,7 +506,7 @@ try {
 6. Closures
 -----------
 
-Les closures DOIVENT être déclarées avec un espace après le mot-clé `fonction`
+Les closures DOIVENT être déclarées avec un espace après le mot-clé `function`
 et un espace avant et après le mot clé `use`.
 
 L'accolade ouvrante DOIT aller sur la même ligne, et l'accolade fermante doit


### PR DESCRIPTION
The keyword `function` should not be translated to `fonction` in french (only in the text but not as a keyword).