### PR TITLE
Added method Pool::resolveItem() to PSR-6 cache proposal

### DIFF
--- a/proposed/cache.md
+++ b/proposed/cache.md
@@ -294,6 +294,35 @@ interface CacheItemPoolInterface
     public function getItem($key);
 
     /**
+     * Returns a Cache Item representing the specified key that is a cache hit.
+     *
+     * In the case of a cache miss, the Implementation Library will use the callback
+     * parameters to generate the Cache Item. The Cache Item will then be persisted
+     * and returned.
+     *
+     * @param string $key
+     *   The key for which to return the corresponding Cache Item.
+     *
+     * @param callable $valueCallback
+     *   A callback used to generate the value of the Cache Item in the event of a
+     *   cache miss. The callback is not passed any parameters and it must return
+     *   a serializable value to be stored.
+     *
+     * @param callable|null $metaCallback
+     *   An optional callback that is passed the the Cache Item as a single
+     *   parameter in the event of a cache miss. This callback will be called after
+     *   the $valueCallback is called and before the Cache Item is persisted.
+     *
+     * @throws InvalidArgumentException
+     *   If the $key string is not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return CacheItemInterface
+     *   The corresponding Cache Item.
+     */
+    public function resolveItem($key, $valueCallback, $metaCallback = null);
+
+    /**
      * Returns a traversable set of cache items.
      *
      * @param array $keys

--- a/proposed/cache.md
+++ b/proposed/cache.md
@@ -294,11 +294,14 @@ interface CacheItemPoolInterface
     public function getItem($key);
 
     /**
-     * Returns a Cache Item representing the specified key that is a cache hit.
+     * Resolves a Cache Item representing the specified key.
      *
-     * In the case of a cache miss, the Implementation Library will use the callback
-     * parameters to generate the Cache Item. The Cache Item will then be persisted
-     * and returned.
+     * In the case of a cache hit, this method will behave identically to the getItem
+     * method and the $valueCallback and $metaCallback parameters will be ignored.
+     *
+     * In the case of a cache miss, the Implementation Library will use the
+     * $valueCallback and $metaCallback parameters to generate the Cache Item. The
+     * Cache Item will then be persisted and returned.
      *
      * @param string $key
      *   The key for which to return the corresponding Cache Item.

--- a/proposed/cache.md
+++ b/proposed/cache.md
@@ -323,7 +323,7 @@ interface CacheItemPoolInterface
      * @return CacheItemInterface
      *   The corresponding Cache Item.
      */
-    public function resolveItem($key, $valueCallback, $metaCallback = null);
+    public function resolveItem($key, callable $valueCallback, callable $metaCallback = null);
 
     /**
      * Returns a traversable set of cache items.


### PR DESCRIPTION
Discussion thread: https://groups.google.com/d/msg/php-fig/l2Cl34zkAJ8/K7m6j-8UBgAJ

This method would allow for code to be rewritten from:

```php
function getThingyValue() {
    $item = $pool->getItem('thingy');

    if(!$item->isHit()){
        $item->set(computeThingy());
        $item->expireAfter(300);
        $item->addTag('foo');
        $item->addTag('bar');
        $pool->save($item);
    }

    return $item->get();
}
```

To

```php
function getThingyValue() {
    return $pool->resolveItem('thingy', 'computeThingy', function (CacheItemInterface $item) {
        $item->expireAfter(300);
        $item->addTag('foo');
        $item->addTag('bar');
    })->get();
}
```
