### PR TITLE
More PSR-12 changes

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -458,7 +458,7 @@ class ClassName
 When you have a return type declaration present there MUST be one space after
 the colon with followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parentheses with no spaces between
-the two characters.
+the two characters. The declaration keyword (e.g. string) MUST be lowercase.
 
 ```php
 <?php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -116,10 +116,20 @@ PHP [keywords][] MUST be in lower case.
 The PHP reserved words `int`, `true`, `object`, `float`, `false`, `mixed`,
 `bool`, `null`, `numeric`, `string` and `resource` MUST be in lower case
 
-Strict Types, Namespace, and Use Declarations
+Declare declarations, Namespace, and Use Declarations
 --------------------------------------------
 
-When present, there MUST be one blank line after the `declare` declaration.
+When present, there MUST be one blank line after the `declare` statement(s)
+e.g. `declare(ticks=);`
+
+There MUST NOT be a blank line before declare statements such as those for strict
+types or ticks. They MUST be contained on the lines immediately following the
+opening tag (which must be on the first line when declare statement(s) are present).
+
+Each declare statement (e.g. `declare(ticks=);`) MUST be on its own line.
+
+When no declare declarations are present there MUST be a blank line after the
+opening `<?php` tag.
 
 When present, there MUST be one blank line after the `namespace` declaration.
 
@@ -186,25 +196,6 @@ use Vendor\Package\Namespace\{
 };
 ```
 
-All files MUST declare strict types.
-
-Files containing only PHP MUST place the strict types declaration on the
-first line following the opening PHP tag.
-
-There MUST NOT be a blank line before the strict types declaration.
-
-For example:
-
-```php
-<?php
-declare(strict_types=1);
-
-namespace Vendor\Package;
-
-// ... additional PHP code ...
-
-```
-
 Files containing HTML outside PHP opening and closing tags MUST, on the first
 line, include an opening php tag, the strict types declaration and closing
 tag.
@@ -220,6 +211,17 @@ For example:
 </body>
 </html>
 ```
+
+Declare statements MUST contain no spaces and MUST look like `declare(strict_types=1);`.
+
+Block declare statements are allowed and MUST be formatted as below. Note position of
+braces and spacing:
+```php
+declare(ticks=1) {
+    //some code
+}
+```
+
 
 
 Classes, Properties, and Methods

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -166,8 +166,7 @@ class FooBar
 
 ```
 
-Compound namespaces with a depth of two or more MUST not be used. Therefore the
-following is the maximum compounding depth allowed:
+Compound namespaces with a depth of two or more MUST not be used.
 ```php
 <?php
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -233,7 +233,7 @@ same line.
 When instantiating a new class, parenthesis MUST always be present even when
 there are no arguments passed to the constructor.
 
-``php
+```php
 new Foo();
 ```
 
@@ -350,6 +350,7 @@ class ClassName
 
     private $property;
 }
+```
 
 ### Properties
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -245,9 +245,9 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 }
 ```
 
-Lists of `implements` MAY be split across multiple lines, where each
-subsequent line is indented once. When doing so, the first item in the list
-MUST be on the next line, and there MUST be only one interface per line.
+Lists of `implements` and `extends` MAY be split across multiple lines, where
+each subsequent line is indented once. When doing so, the first item in the
+list MUST be on the next line, and there MUST be only one interface per line.
 
 ```php
 <?php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -222,8 +222,6 @@ declare(ticks=1) {
 }
 ```
 
-
-
 Classes, Properties, and Methods
 -----------------------------------
 
@@ -424,13 +422,15 @@ MUST be one space after each comma.
 Method and function arguments with default values MUST go at the end of the argument
 list.
 
+Method and function argument scalar type hints MUST be lowercase.
+
 ```php
 <?php
 namespace Vendor\Package;
 
 class ClassName
 {
-    public function foo($arg1, &$arg2, $arg3 = [])
+    public function foo(int $arg1, &$arg2, $arg3 = [])
     {
         // method body
     }

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -77,6 +77,9 @@ General
 
 Code MUST follow all rules outlined in [PSR-1].
 
+The term 'StudlyCaps' in PSR-1 MUST be interpreted as PascalCase where the first letter of
+each word is capitalised including the very first letter.
+
 ### Files
 
 All PHP files MUST use the Unix LF (linefeed) line ending.

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -166,7 +166,8 @@ class FooBar
 
 ```
 
-Compound namespaces with a depth of two or more MUST not be used.
+Compound namespaces with a depth of two or more MUST not be used. Therefore the
+following is the maximum compounding depth allowed:
 ```php
 <?php
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -266,6 +266,13 @@ class ClassName extends ParentClass implements
 }
 ```
 
+When instantiating a new class, parenthesis MUST always be present even when
+there are no arguments passed to the constructor.
+
+``php
+new Foo();
+```
+
 ### Using traits
 
 The `use` keyword used inside the classes to implement traits MUST be
@@ -333,14 +340,6 @@ class ClassName
 
     private $property;
 }
-
-When instantiating a new class, parenthesis MUST always be present even when
-there are no arguments passed to the constructor.
-
-``php
-new Foo();
->>>>>>> 7fa2283... Clarify brackets are always required on class instantiation
-```
 
 ### Properties
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -228,6 +228,9 @@ the class name.
 The opening brace for the class MUST go on its own line; the closing brace
 for the class MUST go on the next line after the body.
 
+There MUST NOT be a blank line preceding a closing brace and the next line
+after the opening brace MUST NOT be a blank line.
+
 ```php
 <?php
 namespace Vendor\Package;

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -116,7 +116,7 @@ PHP [keywords][] MUST be in lower case.
 The PHP reserved words `int`, `true`, `object`, `float`, `false`, `mixed`,
 `bool`, `null`, `numeric`, `string` and `resource` MUST be in lower case
 
-Declare declarations, Namespace, and Use Declarations
+Declare Statements, Namespace, and Use Declarations
 --------------------------------------------
 
 When present, there MUST be one blank line after the `declare` statement(s)
@@ -245,8 +245,11 @@ the class name.
 The opening brace for the class MUST go on its own line; the closing brace
 for the class MUST go on the next line after the body.
 
-There MUST NOT be a blank line preceding a closing brace and the next line
-after the opening brace MUST NOT be a blank line.
+Opening braces MUST be on their own line and MUST NOT be preceeded or followed
+by a blank line.
+
+Closing braces MUST be on their own line and MUST NOT be preceeded by a blank
+line.
 
 ```php
 <?php
@@ -464,6 +467,18 @@ class ClassName
 }
 ```
 
+```php
+<?php
+
+somefunction($foo, $bar, [
+  // ...
+], $baz);
+
+$app->get('/hello/{name}', function ($name) use ($app) {
+    return 'Hello '.$app->escape($name);
+});
+```
+
 When you have a return type declaration present there MUST be one space after
 the colon with followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parentheses with no spaces between
@@ -479,7 +494,7 @@ class ReturnTypeVariations
 {
     public function functionName($arg1, $arg2): string
     {
-        return;
+        return 'foo';
     }
 }
 ```

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -317,6 +317,13 @@ class ClassName
 
     private $property;
 }
+
+When instantiating a new class, parenthesis MUST always be present even when
+there are no arguments passed to the constructor.
+
+``php
+new Foo();
+>>>>>>> 7fa2283... Clarify brackets are always required on class instantiation
 ```
 
 ### Properties

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -227,6 +227,16 @@ Classes, Properties, and Methods
 
 The term "class" refers to all classes, interfaces, and traits.
 
+Any closing brace must not be followed by any comment or statement on the
+same line.
+
+When instantiating a new class, parenthesis MUST always be present even when
+there are no arguments passed to the constructor.
+
+``php
+new Foo();
+```
+
 ### Extends and Implements
 
 The `extends` and `implements` keywords MUST be declared on the same line as
@@ -271,13 +281,6 @@ class ClassName extends ParentClass implements
 {
     // constants, properties, methods
 }
-```
-
-When instantiating a new class, parenthesis MUST always be present even when
-there are no arguments passed to the constructor.
-
-``php
-new Foo();
 ```
 
 ### Using traits

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -166,6 +166,19 @@ class FooBar
 
 ```
 
+Compound namespaces with a depth of two or more MUST not be used. Therefore the
+following is the maximum compounding depth allowed:
+```php
+<?php
+
+use Vendor\Package\Namespace\{
+    SubnamespaceOne\ClassA,
+    SubnamespaceOne\ClassB,
+    SubnamespaceTwo\ClassY,
+    ClassZ,
+};
+```
+
 All files MUST declare strict types.
 
 Files containing only PHP MUST place the strict types declaration on the

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -455,6 +455,26 @@ class ClassName
 }
 ```
 
+When you have a return type declaration present there MUST be one space after
+the colon with followed by the type declaration. The colon and declaration MUST be
+on the same line as the argument list closing parentheses with no spaces between
+the two characters.
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Vendor\Package;
+
+class ReturnTypeVariations
+{
+    public function functionName($arg1, $arg2): string
+    {
+        return;
+    }
+}
+```
+
 ### `abstract`, `final`, and `static`
 
 When present, the `abstract` and `final` declarations MUST precede the

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -369,7 +369,7 @@ Visibility MUST be declared on all methods.
 Method names SHOULD NOT be prefixed with a single underscore to indicate
 protected or private visibility.
 
-Method and Function names MUST NOT be declared with a space after the method name. The
+Method and function names MUST NOT be declared with a space after the method name. The
 opening brace MUST go on its own line, and the closing brace MUST go on the
 next line following the body. There MUST NOT be a space after the opening
 parenthesis, and there MUST NOT be a space before the closing parenthesis.

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -691,6 +691,8 @@ excluding string concatenation operators. This includes all [arithmetic][],
 [comparison][], [assignment][], [bitwise][], [logical][] (excluding `!`)
 and [type][] operators.
 
+Other operators such as string concatenation operators are left to interpetation.
+
 For example:
 
 ```php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -215,7 +215,7 @@ For example:
 ```
 
 
-4. Classes, Properties, and Methods
+Classes, Properties, and Methods
 -----------------------------------
 
 The term "class" refers to all classes, interfaces, and traits.
@@ -428,7 +428,9 @@ class ClassName
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
-next line, and there MUST be only one argument per line.
+next line, and there MUST be only one argument per line. A single argument being
+split across multiple lines (As might be the case with an anonymous function or
+array) does not constitute splitting the argument list itself.
 
 When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -668,6 +668,26 @@ try {
 }
 ```
 
+Operators
+-----------
+All binary and ternary operators MUST be preceded and followed by a space
+excluding string concatenation operators. This includes all [arithmetic][],
+[comparison][], [assignment][], [bitwise][], [logical][] (excluding `!`)
+and [type][] operators.
+
+For example:
+
+```php
+<?php
+
+if ($a === $b) {
+    $foo = $bar ?? $a ?? $b;
+} elseif ($a > $b) {
+    $variable = $foo ? 'foo' : 'bar';
+}
+```
+
+
 Closures
 -----------
 
@@ -813,3 +833,9 @@ $instance = new class extends \Foo implements
 [PSR-1]: http://www.php-fig.org/psr/psr-1/
 [PSR-2]: http://www.php-fig.org/psr/psr-2/
 [keywords]: http://php.net/manual/en/reserved.keywords.php
+[arithmetic]: http://php.net/manual/en/language.operators.arithmetic.php
+[assignment]: http://php.net/manual/en/language.operators.assignment.php
+[comparison]: http://php.net/manual/en/language.operators.comparison.php
+[bitwise]: http://php.net/manual/en/language.operators.bitwise.php
+[logical]: http://php.net/manual/en/language.operators.logical.php
+[type]: http://php.net/manual/en/language.operators.type.php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -108,7 +108,7 @@ Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
 
 ### Keywords and True/False/Null
 
-PHP [keywords] MUST be in lower case.
+PHP [keywords][] MUST be in lower case.
 
 The PHP reserved words `int`, `true`, `object`, `float`, `false`, `mixed`,
 `bool`, `null`, `numeric`, `string` and `resource` MUST be in lower case

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -128,6 +128,10 @@ declaration.
 
 There MUST be one `use` keyword per declaration.
 
+You MUST NOT use `use` statements for classes in the root namespace. Therefore
+you should use `throw new \Exception();` instead of
+`use Exception; throw new Exception();`
+
 Multiple classes, functions, or constants within one namespace MUST group use
 statements within one namespace.
 


### PR DESCRIPTION
- [x] Typo and wording changes
- [x] PSR-2 Errata
- [x] Disallow more than two levels of depth to compound namespaces
- [x] Add clarification statement forbidding blank lines before/after closing/opening braces
- [x] Clarify brackets are always required on class instantiation
- [x] Add instruction not to import classes in the root namespace
- [x] Return type declarations
- [x] Note that StudlyCaps in PSR-1 should be interpreted to be PascalCase
- [x] Note that closing braces cannot be followed by any other statement or comment on the same line in any case.
- [x] Argument type hints
- [x] Add declaration usage information
- [x] Add operators