### PR TITLE
Switched from specifying HTML to markup in general.

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -193,7 +193,7 @@ use Vendor\Package\Namespace\{
 };
 ```
 
-Files containing HTML outside PHP opening and closing tags MUST, on the first
+Files containing markup outside PHP opening and closing tags MUST, on the first
 line, include an opening php tag, the strict types declaration and closing
 tag.
 


### PR DESCRIPTION
PHP can be used to generate much more than HTML.

'Files containing **HTML** outside PHP opening and closing...'

Should be more general:

'Files containing **markup** outside PHP opening and closing...'

ping @michaelcullum 