### PR TITLE
Preserve indentation whitespace in blank lines

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -101,7 +101,8 @@ be split into multiple subsequent lines of no more than 80 characters each.
 There MUST NOT be trailing whitespace at the end of non-blank lines.
 
 Blank lines MAY be added to improve readability and to indicate related
-blocks of code except where explictly forbidden.
+blocks of code except where explictly forbidden. These lines SHOULD preserve
+indentation whitespace.
 
 There MUST NOT be more than one statement per line.
 


### PR DESCRIPTION
Editors such as atom remove all trailing whitespace by default, which is extremely annoying when when navigating code in some editors.