### PR TITLE
Use "types and keywords" instead of "reserved words"

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -113,7 +113,7 @@ Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
 
 PHP [keywords][] MUST be in lower case.
 
-The PHP reserved words `int`, `true`, `object`, `float`, `false`, `mixed`,
+The PHP types and keywords `int`, `true`, `object`, `float`, `false`, `mixed`,
 `bool`, `null`, `numeric`, `string` and `resource` MUST be in lower case
 
 3. Declare Statements, Namespace, and Use Declarations


### PR DESCRIPTION
@ircmaxell mentioned that these aren't reserved words, I think "types and keywords" is a better thing to call em.