### PR TITLE
Fix: Headline in PSR-13 proposal

### DIFF
--- a/proposed/links.md
+++ b/proposed/links.md
@@ -109,7 +109,7 @@ interface LinkInterface
 }
 ```
 
-#### 3.2.1 `Psr\Http\Message\LinkableInterface`
+#### 3.2.1 `Psr\Http\Link\LinkableInterface`
 
 ```php
 <?php


### PR DESCRIPTION
This PR

* [x] fixes a headline using an invalid namespace, as pointed out by @renan

Follows https://github.com/php-fig/fig-standards/pull/683#discussion_r47165863.