### PR TITLE
PSR-7: Describe the format of $_FILES correctly for nested element names

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -433,15 +433,31 @@ In the case of an input using array notation for the name:
 `$_FILES` ends up looking like this:
 
 ```php
-array(
-    'my-form' => array(
-        'details' => array(
-            'avatar' => array(
-                'tmp_name' => 'phpUxcOty',
-                'name' => 'my-avatar.png',
-                'size' => 90996,
-                'type' => 'image/png',
-                'error' => 0,
+array (
+    'my-form' => array (
+        'name' => array (
+            'details' => array (
+                'avatar' => 'my-avatar.png',
+            ),
+        ),
+        'type' => array (
+            'details' => array (
+                'avatar' => 'image/png',
+            ),
+        ),
+        'tmp_name' => array (
+            'details' => array (
+                'avatar' => 'phpmFLrzD',
+            ),
+        ),
+        'error' => array (
+            'details' => array (
+                'avatar' => 0,
+            ),
+        ),
+        'size' => array (
+            'details' => array (
+                'avatar' => 90996,
             ),
         ),
     ),
@@ -475,34 +491,50 @@ related to the file at the given index. The reason is because `$_FILES` deviates
 from its normal structure in such cases:
 
 ```php
-array(
-    'my-form' => array(
-        'details' => array(
-            'avatars' => array(
-                'tmp_name' => array(
-                    0 => '...',
-                    1 => '...',
-                    2 => '...',
+array (
+    'my-form' => array (
+        'name' => array (
+            'details' => array (
+                'avatar' => array (
+                    0 => 'my-avatar.png',
+                    1 => 'my-avatar2.png',
+                    2 => 'my-avatar3.png',
                 ),
-                'name' => array(
-                    0 => '...',
-                    1 => '...',
-                    2 => '...',
+            ),
+        ),
+        'type' => array (
+            'details' => array (
+                'avatar' => array (
+                    0 => 'image/png',
+                    1 => 'image/png',
+                    2 => 'image/png',
                 ),
-                'size' => array(
-                    0 => '...',
-                    1 => '...',
-                    2 => '...',
+            ),
+        ),
+        'tmp_name' => array (
+            'details' => array (
+                'avatar' => array (
+                    0 => 'phpmFLrzD',
+                    1 => 'phpV2pBil',
+                    2 => 'php8RUG8v',
                 ),
-                'type' => array(
-                    0 => '...',
-                    1 => '...',
-                    2 => '...',
+            ),
+        ),
+        'error' => array (
+            'details' => array (
+                'avatar' => array (
+                    0 => 0,
+                    1 => 0,
+                    2 => 0,
                 ),
-                'error' => array(
-                    0 => '...',
-                    1 => '...',
-                    2 => '...',
+            ),
+        ),
+        'size' => array (
+            'details' => array (
+                'avatar' => array (
+                    0 => 90996,
+                    1 => 90996,
+                    3 => 90996,
                 ),
             ),
         ),


### PR DESCRIPTION
When the input element's name is a nested array, then format of $_FILES is more complicated as the nested key names appear underneath the five _FILES core array element names.

This PR updates to match reality rather than the wishful thinking that it might have been reasonably logical…
