### PR TITLE
Add "editor" names on pre-workflow-bylaw PSRs

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,8 +10,8 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 
 | Num | Title                          | Editor                  |  Coordinator  | Sponsor        |
 |:---:|--------------------------------|-------------------------|---------------|----------------|
-| 1   | [Basic Coding Standard][psr1]  | _N/A_                   | _N/A_         | _N/A_          |
-| 2   | [Coding Style Guide][psr2]     | _N/A_                   | _N/A_         | _N/A_          |
+| 1   | [Basic Coding Standard][psr1]  | Paul M. Jones           | _N/A_         | _N/A_          |
+| 2   | [Coding Style Guide][psr2]     | Paul M. Jones           | _N/A_         | _N/A_          |
 | 3   | [Logger Interface][psr3]       | Jordi Boggiano          | _N/A_         | _N/A_          |
 | 4   | [Autoloading Standard][psr4]   | Paul M. Jones           | Phil Sturgeon | Larry Garfield |
 | 6   | [Caching Interface][psr6]      | Larry Garfield          | Paul Dragoonis | Robert Hafner |
@@ -38,7 +38,7 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 
 | Num | Title                          | Editor                  |  Coordinator  | Sponsor        |
 |:---:|--------------------------------|-------------------------|---------------|----------------|
-| 0   | [Autoloading Standard][psr0]   | _N/A_                   | _N/A_         | _N/A_          |
+| 0   | [Autoloading Standard][psr0]   | Matthew Weier O'Phinney | _N/A_         | _N/A_          |
 
 ## Numerical Index
 


### PR DESCRIPTION
"Editor" seems the closest correct role for PSRs before the adoption of the workflow bylaw. Happy to entertain challenges to the attribution of editorship on PSRs 0, 1, and 2.