### PR TITLE
Convert ticks to tildes.

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -1,7 +1,7 @@
 Autoloading Standard
 ====================
 
-> **Deprecated** - As of 2014-10-21 PSR-0 has been marked as deprecated. [PSR-4] is now recommended 
+> **Deprecated** - As of 2014-10-21 PSR-0 has been marked as deprecated. [PSR-4] is now recommended
 as an alternative.
 
 [PSR-4]: http://www.php-fig.org/psr/psr-4/
@@ -51,7 +51,7 @@ Example Implementation
 Below is an example function to simply demonstrate how the above
 proposed standards are autoloaded.
 
-```php
+~~~php
 <?php
 
 function autoload($className)
@@ -69,7 +69,7 @@ function autoload($className)
     require $fileName;
 }
 spl_autoload_register('autoload');
-```
+~~~
 
 SplClassLoader Implementation
 -----------------------------

--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -64,7 +64,7 @@ reading from or writing to a file, and so on.
 The following is an example of a file with both declarations and side effects;
 i.e, an example of what to avoid:
 
-```php
+~~~php
 <?php
 // side effect: change ini settings
 ini_set('error_reporting', E_ALL);
@@ -80,12 +80,12 @@ function foo()
 {
     // function body
 }
-```
+~~~
 
 The following example is of a file that contains declarations without side
 effects; i.e., an example of what to emulate:
 
-```php
+~~~php
 <?php
 // declaration
 function foo()
@@ -100,7 +100,7 @@ if (! function_exists('bar')) {
         // function body
     }
 }
-```
+~~~
 
 
 3. Namespace and Class Names
@@ -117,7 +117,7 @@ Code written for PHP 5.3 and after MUST use formal namespaces.
 
 For example:
 
-```php
+~~~php
 <?php
 // PHP 5.3 and later:
 namespace Vendor\Model;
@@ -125,18 +125,18 @@ namespace Vendor\Model;
 class Foo
 {
 }
-```
+~~~
 
 Code written for 5.2.x and before SHOULD use the pseudo-namespacing convention
 of `Vendor_` prefixes on class names.
 
-```php
+~~~php
 <?php
 // PHP 5.2.x and earlier:
 class Vendor_Model_Foo
 {
 }
-```
+~~~
 
 4. Class Constants, Properties, and Methods
 -------------------------------------------
@@ -148,7 +148,7 @@ The term "class" refers to all classes, interfaces, and traits.
 Class constants MUST be declared in all upper case with underscore separators.
 For example:
 
-```php
+~~~php
 <?php
 namespace Vendor\Model;
 
@@ -157,7 +157,7 @@ class Foo
     const VERSION = '1.0';
     const DATE_APPROVED = '2012-06-01';
 }
-```
+~~~
 
 ### 4.2. Properties
 

--- a/accepted/PSR-2-coding-style-guide-meta.md
+++ b/accepted/PSR-2-coding-style-guide-meta.md
@@ -4,11 +4,11 @@ PSR-2 Meta Document
 1. Summary
 ----------
 
-The intent of this guide is to reduce cognitive friction when scanning code from different authors. It does so 
+The intent of this guide is to reduce cognitive friction when scanning code from different authors. It does so
 by enumerating a shared set of rules and expectations about how to format PHP code.
 
-The style rules herein are derived from commonalities among the various member projects. When various authors 
-collaborate across multiple projects, it helps to have one set of guidelines to be used among all those 
+The style rules herein are derived from commonalities among the various member projects. When various authors
+collaborate across multiple projects, it helps to have one set of guidelines to be used among all those
 projects. Thus, the benefit of this guide is not in the rules themselves, but in the sharing of those rules.
 
 
@@ -23,22 +23,22 @@ projects. Thus, the benefit of this guide is not in the rules themselves, but in
 
 ### 3.1 - Multi-line Arguments (09/08/2013)
 
-Using one or more multi-line arguments (i.e: arrays or anonymous functions) does not constitute 
-splitting the argument list itself, therefore Section 4.6 is not automatically enforced. Arrays and anonymous 
+Using one or more multi-line arguments (i.e: arrays or anonymous functions) does not constitute
+splitting the argument list itself, therefore Section 4.6 is not automatically enforced. Arrays and anonymous
 functions are able to span multiple lines.
 
 The following examples are perfectly valid in PSR-2:
 
-```php
+~~~php
 <?php
 somefunction($foo, $bar, [
   // ...
 ], $baz);
 
-$app->get('/hello/{name}', function ($name) use ($app) { 
-    return 'Hello '.$app->escape($name); 
+$app->get('/hello/{name}', function ($name) use ($app) {
+    return 'Hello '.$app->escape($name);
 });
-```
+~~~
 
 ### 3.2 - Extending Multiple Interfaces (10/17/2013)
 

--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -44,7 +44,7 @@ interpreted as described in [RFC 2119].
 - Visibility MUST be declared on all properties and methods; `abstract` and
   `final` MUST be declared before the visibility; `static` MUST be declared
   after the visibility.
-  
+
 - Control structure keywords MUST have one space after them; method and
   function calls MUST NOT.
 
@@ -58,7 +58,7 @@ interpreted as described in [RFC 2119].
 
 This example encompasses some of the rules below as a quick overview:
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -84,7 +84,7 @@ class Foo extends Bar implements FooInterface
         // method body
     }
 }
-```
+~~~
 
 2. General
 ----------
@@ -124,7 +124,7 @@ Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
 
 > N.b.: Using only spaces, and not mixing spaces with tabs, helps to avoid
 > problems with diffs, patches, history, and annotations. The use of spaces
-> also makes it easy to insert fine-grained sub-indentation for inter-line 
+> also makes it easy to insert fine-grained sub-indentation for inter-line
 > alignment.
 
 ### 2.5. Keywords and True/False/Null
@@ -151,7 +151,7 @@ There MUST be one blank line after the `use` block.
 
 For example:
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -161,7 +161,7 @@ use OtherVendor\OtherPackage\BazClass;
 
 // ... additional PHP code ...
 
-```
+~~~
 
 
 4. Classes, Properties, and Methods
@@ -177,7 +177,7 @@ the class name.
 The opening brace for the class MUST go on its own line; the closing brace
 for the class MUST go on the next line after the body.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -189,13 +189,13 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {
     // constants, properties, methods
 }
-```
+~~~
 
 Lists of `implements` MAY be split across multiple lines, where each
 subsequent line is indented once. When doing so, the first item in the list
 MUST be on the next line, and there MUST be only one interface per line.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -210,7 +210,7 @@ class ClassName extends ParentClass implements
 {
     // constants, properties, methods
 }
-```
+~~~
 
 ### 4.2. Properties
 
@@ -225,7 +225,7 @@ protected or private visibility.
 
 A property declaration looks like the following.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -233,7 +233,7 @@ class ClassName
 {
     public $foo = null;
 }
-```
+~~~
 
 ### 4.3. Methods
 
@@ -250,7 +250,7 @@ parenthesis, and there MUST NOT be a space before the closing parenthesis.
 A method declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -261,7 +261,7 @@ class ClassName
         // method body
     }
 }
-```    
+~~~
 
 ### 4.4. Method Arguments
 
@@ -271,7 +271,7 @@ MUST be one space after each comma.
 Method arguments with default values MUST go at the end of the argument
 list.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -282,7 +282,7 @@ class ClassName
         // method body
     }
 }
-```
+~~~
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -292,7 +292,7 @@ When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space
 between them.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -306,7 +306,7 @@ class ClassName
         // method body
     }
 }
-```
+~~~
 
 ### 4.5. `abstract`, `final`, and `static`
 
@@ -316,7 +316,7 @@ visibility declaration.
 When present, the `static` declaration MUST come after the visibility
 declaration.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -331,7 +331,7 @@ abstract class ClassName
         // method body
     }
 }
-```
+~~~
 
 ### 4.6. Method and Function Calls
 
@@ -341,25 +341,25 @@ after the opening parenthesis, and there MUST NOT be a space before the
 closing parenthesis. In the argument list, there MUST NOT be a space before
 each comma, and there MUST be one space after each comma.
 
-```php
+~~~php
 <?php
 bar();
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
-```
+~~~
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
 next line, and there MUST be only one argument per line.
 
-```php
+~~~php
 <?php
 $foo->bar(
     $longArgument,
     $longerArgument,
     $muchLongerArgument
 );
-```
+~~~
 
 5. Control Structures
 ---------------------
@@ -385,7 +385,7 @@ An `if` structure looks like the following. Note the placement of parentheses,
 spaces, and braces; and that `else` and `elseif` are on the same line as the
 closing brace from the earlier body.
 
-```php
+~~~php
 <?php
 if ($expr1) {
     // if body
@@ -394,7 +394,7 @@ if ($expr1) {
 } else {
     // else body;
 }
-```
+~~~
 
 The keyword `elseif` SHOULD be used instead of `else if` so that all control
 keywords look like single words.
@@ -408,7 +408,7 @@ from `switch`, and the `break` keyword (or other terminating keyword) MUST be
 indented at the same level as the `case` body. There MUST be a comment such as
 `// no break` when fall-through is intentional in a non-empty `case` body.
 
-```php
+~~~php
 <?php
 switch ($expr) {
     case 0:
@@ -426,7 +426,7 @@ switch ($expr) {
         echo 'Default case';
         break;
 }
-```
+~~~
 
 
 ### 5.3. `while`, `do while`
@@ -434,53 +434,53 @@ switch ($expr) {
 A `while` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 while ($expr) {
     // structure body
 }
-```
+~~~
 
 Similarly, a `do while` statement looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 do {
     // structure body;
 } while ($expr);
-```
+~~~
 
 ### 5.4. `for`
 
 A `for` statement looks like the following. Note the placement of parentheses,
 spaces, and braces.
 
-```php
+~~~php
 <?php
 for ($i = 0; $i < 10; $i++) {
     // for body
 }
-```
+~~~
 
 ### 5.5. `foreach`
-    
+
 A `foreach` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 foreach ($iterable as $key => $value) {
     // foreach body
 }
-```
+~~~
 
 ### 5.6. `try`, `catch`
 
 A `try catch` block looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 try {
     // try body
@@ -489,7 +489,7 @@ try {
 } catch (OtherExceptionType $e) {
     // catch body
 }
-```
+~~~
 
 6. Closures
 -----------
@@ -513,7 +513,7 @@ list.
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-```php
+~~~php
 <?php
 $closureWithArgs = function ($arg1, $arg2) {
     // body
@@ -522,7 +522,7 @@ $closureWithArgs = function ($arg1, $arg2) {
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     // body
 };
-```
+~~~
 
 Argument lists and variable lists MAY be split across multiple lines, where
 each subsequent line is indented once. When doing so, the first item in the
@@ -536,7 +536,7 @@ together on their own line with one space between them.
 The following are examples of closures with and without argument lists and
 variable lists split across multiple lines.
 
-```php
+~~~php
 <?php
 $longArgs_noVars = function (
     $longArgument,
@@ -581,12 +581,12 @@ $shortArgs_longVars = function ($arg) use (
 ) {
    // body
 };
-```
+~~~
 
 Note that the formatting rules also apply when the closure is used directly
 in a function or method call as an argument.
 
-```php
+~~~php
 <?php
 $foo->bar(
     $arg1,
@@ -595,7 +595,7 @@ $foo->bar(
     },
     $arg3
 );
-```
+~~~
 
 
 7. Conclusion

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -64,7 +64,7 @@ Users of loggers are referred to as `user`.
   The following is an example implementation of placeholder interpolation
   provided for reference purposes only:
 
-  ```php
+  ~~~php
   /**
    * Interpolates context values into the message placeholders.
    */
@@ -88,7 +88,7 @@ Users of loggers are referred to as `user`.
 
   // echoes "User bolivar created"
   echo interpolate($message, $context);
-  ```
+  ~~~
 
 ### 1.3 Context
 
@@ -139,7 +139,7 @@ and a test suite to verify your implementation is provided as part of the
 3. `Psr\Log\LoggerInterface`
 ----------------------------
 
-```php
+~~~php
 <?php
 
 namespace Psr\Log;
@@ -254,12 +254,12 @@ interface LoggerInterface
      */
     public function log($level, $message, array $context = array());
 }
-```
+~~~
 
 4. `Psr\Log\LoggerAwareInterface`
 ---------------------------------
 
-```php
+~~~php
 <?php
 
 namespace Psr\Log;
@@ -277,12 +277,12 @@ interface LoggerAwareInterface
      */
     public function setLogger(LoggerInterface $logger);
 }
-```
+~~~
 
 5. `Psr\Log\LogLevel`
 ---------------------
 
-```php
+~~~php
 <?php
 
 namespace Psr\Log;
@@ -301,4 +301,4 @@ class LogLevel
     const INFO      = 'info';
     const DEBUG     = 'debug';
 }
-```
+~~~

--- a/accepted/PSR-4-autoloader-examples.md
+++ b/accepted/PSR-4-autoloader-examples.md
@@ -6,49 +6,49 @@ The following are examples illustrate PSR-4 compliant code:
 Closure Example
 ---------------
 
-```php
+~~~php
 <?php
 /**
  * An example of a project-specific implementation.
- * 
+ *
  * After registering this autoload function with SPL, the following line
  * would cause the function to attempt to load the \Foo\Bar\Baz\Qux class
  * from /path/to/project/src/Baz/Qux.php:
- * 
+ *
  *      new \Foo\Bar\Baz\Qux;
- *      
+ *
  * @param string $class The fully-qualified class name.
  * @return void
  */
 spl_autoload_register(function ($class) {
-    
+
     // project-specific namespace prefix
     $prefix = 'Foo\\Bar\\';
 
     // base directory for the namespace prefix
     $base_dir = __DIR__ . '/src/';
-    
+
     // does the class use the namespace prefix?
     $len = strlen($prefix);
     if (strncmp($prefix, $class, $len) !== 0) {
         // no, move to the next registered autoloader
         return;
     }
-    
+
     // get the relative class name
     $relative_class = substr($class, $len);
-    
+
     // replace the namespace prefix with the base directory, replace namespace
     // separators with directory separators in the relative class name, append
     // with .php
     $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
-    
+
     // if the file exists, require it
     if (file_exists($file)) {
         require $file;
     }
 });
-```
+~~~
 
 Class Example
 -------------
@@ -56,7 +56,7 @@ Class Example
 The following is an example class implementation to handle multiple
 namespaces:
 
-```php
+~~~php
 <?php
 namespace Example;
 
@@ -64,10 +64,10 @@ namespace Example;
  * An example of a general-purpose implementation that includes the optional
  * functionality of allowing multiple base directories for a single namespace
  * prefix.
- * 
+ *
  * Given a foo-bar package of classes in the file system at the following
  * paths ...
- * 
+ *
  *     /path/to/packages/foo-bar/
  *         src/
  *             Baz.php             # Foo\Bar\Baz
@@ -77,30 +77,30 @@ namespace Example;
  *             BazTest.php         # Foo\Bar\BazTest
  *             Qux/
  *                 QuuxTest.php    # Foo\Bar\Qux\QuuxTest
- * 
+ *
  * ... add the path to the class files for the \Foo\Bar\ namespace prefix
  * as follows:
- * 
+ *
  *      <?php
  *      // instantiate the loader
  *      $loader = new \Example\Psr4AutoloaderClass;
- *      
+ *
  *      // register the autoloader
  *      $loader->register();
- *      
+ *
  *      // register the base directories for the namespace prefix
  *      $loader->addNamespace('Foo\Bar', '/path/to/packages/foo-bar/src');
  *      $loader->addNamespace('Foo\Bar', '/path/to/packages/foo-bar/tests');
- * 
+ *
  * The following line would cause the autoloader to attempt to load the
  * \Foo\Bar\Qux\Quux class from /path/to/packages/foo-bar/src/Qux/Quux.php:
- * 
+ *
  *      <?php
  *      new \Foo\Bar\Qux\Quux;
- * 
- * The following line would cause the autoloader to attempt to load the 
+ *
+ * The following line would cause the autoloader to attempt to load the
  * \Foo\Bar\Qux\QuuxTest class from /path/to/packages/foo-bar/tests/Qux/QuuxTest.php:
- * 
+ *
  *      <?php
  *      new \Foo\Bar\Qux\QuuxTest;
  */
@@ -116,7 +116,7 @@ class Psr4AutoloaderClass
 
     /**
      * Register loader with SPL autoloader stack.
-     * 
+     *
      * @return void
      */
     public function register()
@@ -139,7 +139,7 @@ class Psr4AutoloaderClass
     {
         // normalize namespace prefix
         $prefix = trim($prefix, '\\') . '\\';
-        
+
         // normalize the base directory with a trailing separator
         $base_dir = rtrim($base_dir, DIRECTORY_SEPARATOR) . '/';
 
@@ -147,7 +147,7 @@ class Psr4AutoloaderClass
         if (isset($this->prefixes[$prefix]) === false) {
             $this->prefixes[$prefix] = array();
         }
-        
+
         // retain the base directory for the namespace prefix
         if ($prepend) {
             array_unshift($this->prefixes[$prefix], $base_dir);
@@ -167,11 +167,11 @@ class Psr4AutoloaderClass
     {
         // the current namespace prefix
         $prefix = $class;
-        
+
         // work backwards through the namespace names of the fully-qualified
         // class name to find a mapped file name
         while (false !== $pos = strrpos($prefix, '\\')) {
-            
+
             // retain the trailing namespace separator in the prefix
             $prefix = substr($class, 0, $pos + 1);
 
@@ -186,16 +186,16 @@ class Psr4AutoloaderClass
 
             // remove the trailing namespace separator for the next iteration
             // of strrpos()
-            $prefix = rtrim($prefix, '\\');   
+            $prefix = rtrim($prefix, '\\');
         }
-        
+
         // never found a mapped file
         return false;
     }
-    
+
     /**
      * Load the mapped file for a namespace prefix and relative class.
-     * 
+     *
      * @param string $prefix The namespace prefix.
      * @param string $relative_class The relative class name.
      * @return mixed Boolean false if no mapped file can be loaded, or the
@@ -207,7 +207,7 @@ class Psr4AutoloaderClass
         if (isset($this->prefixes[$prefix]) === false) {
             return false;
         }
-            
+
         // look through base directories for this namespace prefix
         foreach ($this->prefixes[$prefix] as $base_dir) {
 
@@ -224,14 +224,14 @@ class Psr4AutoloaderClass
                 return $file;
             }
         }
-        
+
         // never found it
         return false;
     }
-    
+
     /**
      * If a file exists, require it from the file system.
-     * 
+     *
      * @param string $file The file to require.
      * @return bool True if the file exists, false if not.
      */
@@ -244,13 +244,13 @@ class Psr4AutoloaderClass
         return false;
     }
 }
-```
+~~~
 
 ### Unit Tests
 
 The following example is one way of unit testing the above class loader:
 
-```php
+~~~php
 <?php
 namespace Example\Tests;
 
@@ -276,7 +276,7 @@ class Psr4AutoloaderClassTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->loader = new MockPsr4AutoloaderClass;
-    
+
         $this->loader->setFiles(array(
             '/vendor/foo.bar/src/ClassName.php',
             '/vendor/foo.bar/src/DoomClassName.php',
@@ -285,27 +285,27 @@ class Psr4AutoloaderClassTest extends \PHPUnit_Framework_TestCase
             '/vendor/foo.bar.baz.dib/src/ClassName.php',
             '/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php',
         ));
-        
+
         $this->loader->addNamespace(
             'Foo\Bar',
             '/vendor/foo.bar/src'
         );
-        
+
         $this->loader->addNamespace(
             'Foo\Bar',
             '/vendor/foo.bar/tests'
         );
-        
+
         $this->loader->addNamespace(
             'Foo\BarDoom',
             '/vendor/foo.bardoom/src'
         );
-        
+
         $this->loader->addNamespace(
             'Foo\Bar\Baz\Dib',
             '/vendor/foo.bar.baz.dib/src'
         );
-        
+
         $this->loader->addNamespace(
             'Foo\Bar\Baz\Dib\Zim\Gir',
             '/vendor/foo.bar.baz.dib.zim.gir/src'
@@ -317,31 +317,31 @@ class Psr4AutoloaderClassTest extends \PHPUnit_Framework_TestCase
         $actual = $this->loader->loadClass('Foo\Bar\ClassName');
         $expect = '/vendor/foo.bar/src/ClassName.php';
         $this->assertSame($expect, $actual);
-        
+
         $actual = $this->loader->loadClass('Foo\Bar\ClassNameTest');
         $expect = '/vendor/foo.bar/tests/ClassNameTest.php';
         $this->assertSame($expect, $actual);
     }
-    
+
     public function testMissingFile()
     {
         $actual = $this->loader->loadClass('No_Vendor\No_Package\NoClass');
         $this->assertFalse($actual);
     }
-    
+
     public function testDeepFile()
     {
         $actual = $this->loader->loadClass('Foo\Bar\Baz\Dib\Zim\Gir\ClassName');
         $expect = '/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php';
         $this->assertSame($expect, $actual);
     }
-    
+
     public function testConfusion()
     {
         $actual = $this->loader->loadClass('Foo\Bar\DoomClassName');
         $expect = '/vendor/foo.bar/src/DoomClassName.php';
         $this->assertSame($expect, $actual);
-        
+
         $actual = $this->loader->loadClass('Foo\BarDoom\ClassName');
         $expect = '/vendor/foo.bardoom/src/ClassName.php';
         $this->assertSame($expect, $actual);

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -92,7 +92,7 @@ Examples:
 Some common usage patterns are shown below.  These are non-normative but should
 demonstrate the application of some design decisions.
 
-```php
+~~~php
 /**
  * Gets a list of available widgets.
  *
@@ -110,9 +110,9 @@ function get_widget_list()
     }
     return $item->get();
 }
-```
+~~~
 
-```php
+~~~php
 /**
  * Caches a list of available widgets.
  *
@@ -126,9 +126,9 @@ function save_widget_list($list)
     $item->set($list);
     $pool->save($item);
 }
-```
+~~~
 
-```php
+~~~php
 /**
  * Clears the list of available widgets.
  *
@@ -140,9 +140,9 @@ function clear_widget_list()
     $pool = get_cache_pool('widgets');
     $pool->deleteItems(['widget_list']);
 }
-```
+~~~
 
-```php
+~~~php
 /**
  * Clears all widget information.
  *
@@ -154,9 +154,9 @@ function clear_widget_cache()
     $pool = get_cache_pool('widgets');
     $pool->clear();
 }
-```
+~~~
 
-```php
+~~~php
 /**
  * Load widgets.
  *
@@ -193,9 +193,9 @@ function load_widgets(array $ids)
 
     return $widgets;
 }
-```
+~~~
 
-```php
+~~~php
 /**
  * This examples reflects functionality that is NOT included in this
  * specification, but is shown as an example of how such functionality MIGHT
@@ -228,7 +228,7 @@ function set_widget(TaggablePoolInterface $pool, Widget $widget)
     $item->set($widget);
     $pool->save($item);
 }
-```
+~~~
 
 ### 4.2 Alternative: "Weak item" approach
 

--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -169,7 +169,7 @@ be requested from a Pool object via the getItem() method.  Calling Libraries
 SHOULD NOT assume that an Item created by one Implementing Library is
 compatible with a Pool from another Implementing Library.
 
-```php
+~~~php
 namespace Psr\Cache;
 
 /**
@@ -258,7 +258,7 @@ interface CacheItemInterface
     public function expiresAfter($time);
 
 }
-```
+~~~
 
 ### CacheItemPoolInterface
 
@@ -268,7 +268,7 @@ It is also the primary point of interaction with the entire cache collection.
 All configuration and initialization of the Pool is left up to an Implementing
 Library.
 
-```php
+~~~php
 namespace Psr\Cache;
 
 /**
@@ -399,7 +399,7 @@ interface CacheItemPoolInterface
      */
     public function commit();
 }
-```
+~~~
 
 ### CacheException
 
@@ -409,7 +409,7 @@ or invalid credentials supplied.
 
 Any exception thrown by an Implementing Library MUST implement this interface.
 
-```php
+~~~php
 namespace Psr\Cache;
 
 /**
@@ -418,11 +418,11 @@ namespace Psr\Cache;
 interface CacheException
 {
 }
-```
+~~~
 
 ### InvalidArgumentException
 
-```php
+~~~php
 namespace Psr\Cache;
 
 /**
@@ -434,4 +434,4 @@ namespace Psr\Cache;
 interface InvalidArgumentException extends CacheException
 {
 }
-```
+~~~

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -250,7 +250,7 @@ For HTTP clients, they allow consumers to build a base request with data such
 as the base URI and required headers, without needing to build a brand new
 request or reset request state for each message the client sends:
 
-```php
+~~~php
 $uri = new Uri('http://api.example.com');
 $baseRequest = new Request($uri, null, [
     'Authorization' => 'Bearer ' . $token,
@@ -276,7 +276,7 @@ $response = $client->send($request)
 // No need to overwrite headers or body!
 $request = $baseRequest->withUri($uri->withPath('/tasks'))->withMethod('GET');
 $response = $client->send($request);
-```
+~~~
 
 On the server-side, developers will need to:
 
@@ -299,17 +299,17 @@ changes necessary in consuming true value objects are:
 
 As an example, in Zend Framework 2, instead of the following:
 
-```php
+~~~php
 function (MvcEvent $e)
 {
     $response = $e->getResponse();
     $response->setHeaderLine('x-foo', 'bar');
 }
-```
+~~~
 
 one would now write:
 
-```php
+~~~php
 function (MvcEvent $e)
 {
     $response = $e->getResponse();
@@ -317,7 +317,7 @@ function (MvcEvent $e)
         $response->withHeader('x-foo', 'bar')
     );
 }
-```
+~~~
 
 The above combines assignment and notification in a single call.
 
@@ -375,11 +375,11 @@ like `isReadable()`, `isWritable()`, etc. This approach is used by Python,
 In some cases, you may want to return a file from the filesystem. The typical
 way to do this in PHP is one of the following:
 
-```php
+~~~php
 readfile($filename);
 
 stream_copy_to_stream(fopen($filename, 'r'), fopen('php://output', 'w'));
-```
+~~~
 
 Note that the above omits sending appropriate `Content-Type` and
 `Content-Length` headers; the developer would need to emit these prior to
@@ -390,7 +390,7 @@ implementation that accepts a filename and/or stream resource, and to provide
 this to the response instance. A complete example, including setting appropriate
 headers:
 
-```php
+~~~php
 // where Stream is a concrete StreamInterface:
 $stream   = new Stream($filename);
 $finfo    = new finfo(FILEINFO_MIME);
@@ -398,7 +398,7 @@ $response = $response
     ->withHeader('Content-Type', $finfo->file($filename))
     ->withHeader('Content-Length', (string) filesize($filename))
     ->withBody($stream);
-```
+~~~
 
 Emitting this response will send the file to the client.
 
@@ -413,7 +413,7 @@ example](https://github.com/phly/psr7examples#direct-output). Wrap any code
 emitting output directly in a callback, pass that to an appropriate
 `StreamInterface` implementation, and provide it to the message body:
 
-```php
+~~~php
 $output = new CallbackStream(function () use ($request) {
     printf("The requested URI was: %s<br>\n", $request->getUri());
     return '';
@@ -421,7 +421,7 @@ $output = new CallbackStream(function () use ($request) {
 return (new Response())
     ->withHeader('Content-Type', 'text/html')
     ->withBody($output);
-```
+~~~
 
 #### What if I want to use an iterator for content?
 
@@ -496,11 +496,11 @@ to be an array, with the following rationale:
 The main argument is that if the body parameters are an array, developers have
 predictable access to values:
 
-```php
+~~~php
 $foo = isset($request->getBodyParams()['foo'])
     ? $request->getBodyParams()['foo']
     : null;
-```
+~~~
 
 The argument for using "parsed body" was made by examining the domain. A message
 body can contain literally anything. While traditional web applications use
@@ -519,7 +519,7 @@ parsing the body. These might include:
 
 The end result is that a developer now has to look in multiple locations:
 
-```php
+~~~php
 $data = $request->getBodyParams();
 if (isset($data['__parsed__']) && is_object($data['__parsed__'])) {
     $data = $data['__parsed__'];
@@ -530,20 +530,20 @@ $data = $request->getBodyParams();
 if ($request->hasAttribute('__body__')) {
     $data = $request->getAttribute('__body__');
 }
-```
+~~~
 
 The solution presented is to use the terminology "ParsedBody", which implies
 that the values are the results of parsing the message body. This also means
 that the return value _will_ be ambiguous; however, because this is an attribute
 of the domain, this is also expected. As such, usage will become:
 
-```php
+~~~php
 $data = $request->getParsedBody();
 if (! $data instanceof \stdClass) {
     // raise an exception!
 }
 // otherwise, we have what we expected
-```
+~~~
 
 This approach removes the limitations of forcing an array, at the expense of
 ambiguity of return value. Considering that the other suggested solutions —

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -17,12 +17,12 @@ making a request to an HTTP API, or handling an incoming request.
 
 Every HTTP request message has a specific form:
 
-```http
+~~~http
 POST /path HTTP/1.1
 Host: example.com
 
 foo=bar&baz=bat
-```
+~~~
 
 The first line of a request is the "request line", and contains, in order, the
 HTTP request method, the request target (usually either an absolute URI or a
@@ -31,12 +31,12 @@ or more HTTP headers, an empty line, and the message body.
 
 HTTP response messages have a similar structure:
 
-```http
+~~~http
 HTTP/1.1 200 OK
 Content-Type: text/plain
 
 This is the response body
-```
+~~~
 
 The first line is the "status line", and contains, in order, the HTTP protocol
 version, the HTTP status code, and a "reason phrase," a human-readable
@@ -84,7 +84,7 @@ manner. For example, retrieving the `foo` header will return the same result as
 retrieving the `FoO` header. Similarly, setting the `Foo` header will overwrite
 any previously set `foo` header value.
 
-```php
+~~~php
 $message = $message->withHeader('foo', 'bar');
 
 echo $message->getHeaderLine('foo');
@@ -96,7 +96,7 @@ echo $message->getHeaderLine('FOO');
 $message = $message->withHeader('fOO', 'baz');
 echo $message->getHeaderLine('foo');
 // Outputs: baz
-```
+~~~
 
 Despite that headers may be retrieved case-insensitively, the original case
 MUST be preserved by the implementation, in particular when retrieved with
@@ -116,7 +116,7 @@ header values of a case-insensitive header by name concatenated with a comma.
 Use `getHeader()` to retrieve an array of all the header values for a
 particular case-insensitive header by name.
 
-```php
+~~~php
 $message = $message
     ->withHeader('foo', 'bar')
     ->withAddedHeader('foo', 'baz');
@@ -126,7 +126,7 @@ $header = $message->getHeaderLine('foo');
 
 $header = $message->getHeader('foo');
 // ['bar', 'baz']
-```
+~~~
 
 Note: Not all header values can be concatenated using a comma (e.g.,
 `Set-Cookie`). When working with such headers, consumers of
@@ -252,18 +252,18 @@ Calling this method does not affect the URI, as it is returned from `getUri()`.
 
 For example, a user may want to make an asterisk-form request to a server:
 
-```php
+~~~php
 $request = $request
     ->withMethod('OPTIONS')
     ->withRequestTarget('*')
     ->withUri(new Uri('https://example.org/'));
-```
+~~~
 
 This example may ultimately result in an HTTP request that looks like this:
 
-```http
+~~~http
 OPTIONS * HTTP/1.1
-```
+~~~
 
 But the HTTP client will be able to use the effective URL (from `getUri()`),
 to determine the protocol, hostname and TCP port.
@@ -330,7 +330,7 @@ of file inputs. As an example, if you have a form that submits an array of files
 — e.g., the input name "files", submitting `files[0]` and `files[1]` — PHP will
 represent this as:
 
-```php
+~~~php
 array(
     'files' => array(
         'name' => array(
@@ -344,11 +344,11 @@ array(
         /* etc. */
     ),
 )
-```
+~~~
 
 instead of the expected:
 
-```php
+~~~php
 array(
     'files' => array(
         0 => array(
@@ -363,7 +363,7 @@ array(
         ),
     ),
 )
-```
+~~~
 
 The result is that consumers need to know this language implementation detail,
 and write code for gathering the data for a given upload.
@@ -398,13 +398,13 @@ were submitted.
 
 In the simplest example, this might be a single named form element submitted as:
 
-```html
+~~~html
 <input type="file" name="avatar" />
-```
+~~~
 
 In this case, the structure in `$_FILES` would look like:
 
-```php
+~~~php
 array(
     'avatar' => array(
         'tmp_name' => 'phpUxcOty',
@@ -414,25 +414,25 @@ array(
         'error' => 0,
     ),
 )
-```
+~~~
 
 The normalized form returned by `getUploadedFiles()` would be:
 
-```php
+~~~php
 array(
     'avatar' => /* UploadedFileInterface instance */
 )
-```
+~~~
 
 In the case of an input using array notation for the name:
 
-```html
+~~~html
 <input type="file" name="my-form[details][avatar]" />
-```
+~~~
 
 `$_FILES` ends up looking like this:
 
-```php
+~~~php
 array(
     'my-form' => array(
         'details' => array(
@@ -446,11 +446,11 @@ array(
         ),
     ),
 )
-```
+~~~
 
 And the corresponding tree returned by `getUploadedFiles()` should be:
 
-```php
+~~~php
 array(
     'my-form' => array(
         'details' => array(
@@ -458,14 +458,14 @@ array(
         ),
     ),
 )
-```
+~~~
 
 In some cases, you may specify an array of files:
 
-```html
+~~~html
 Upload an avatar: <input type="file" name="my-form[details][avatars][]" />
 Upload an avatar: <input type="file" name="my-form[details][avatars][]" />
-```
+~~~
 
 (As an example, JavaScript controls might spawn additional file upload inputs to
 allow uploading multiple files at once.)
@@ -474,7 +474,7 @@ In such a case, the specification implementation must aggregate all information
 related to the file at the given index. The reason is because `$_FILES` deviates
 from its normal structure in such cases:
 
-```php
+~~~php
 array(
     'my-form' => array(
         'details' => array(
@@ -508,12 +508,12 @@ array(
         ),
     ),
 )
-```
+~~~
 
 The above `$_FILES` array would correspond to the following structure as
 returned by `getUploadedFiles()`:
 
-```php
+~~~php
 array(
     'my-form' => array(
         'details' => array(
@@ -525,13 +525,13 @@ array(
         ),
     ),
 )
-```
+~~~
 
 Consumers would access index `1` of the nested array using:
 
-```php
+~~~php
 $request->getUploadedFiles()['my-form']['details']['avatars'][1];
-```
+~~~
 
 Because the uploaded files data is derivative (derived from `$_FILES` or the
 request body), a mutator method, `withUploadedFiles()`, is also present in the
@@ -539,7 +539,7 @@ interface, allowing delegation of the normalization to another process.
 
 In the case of the original examples, consumption resembles the following:
 
-```php
+~~~php
 $file0 = $request->getUploadedFiles()['files'][0];
 $file1 = $request->getUploadedFiles()['files'][1];
 
@@ -550,7 +550,7 @@ printf(
 );
 
 // "Received the files file0.txt and file1.html"
-```
+~~~
 
 This proposal also recognizes that implementations may operate in non-SAPI
 environments. As such, `UploadedFileInterface` provides methods for ensuring
@@ -567,7 +567,7 @@ operations will work regardless of environment. In particular:
 
 As examples:
 
-```
+~~~
 // Move a file to an upload directory
 $filename = sprintf(
     '%s.%s',
@@ -582,7 +582,7 @@ $file0->moveTo(DATA_DIR . '/' . $filename);
 // StreamWrapper.
 $stream = new Psr7StreamWrapper($file1->getStream());
 stream_copy_to_stream($stream, $s3wrapper);
-```
+~~~
 
 ## 2. Package
 
@@ -593,7 +593,7 @@ The interfaces and classes described are provided as part of the
 
 ### 3.1 `Psr\Http\Message\MessageInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -781,11 +781,11 @@ interface MessageInterface
      */
     public function withBody(StreamInterface $body);
 }
-```
+~~~
 
 ### 3.2 `Psr\Http\Message\RequestInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -914,11 +914,11 @@ interface RequestInterface extends MessageInterface
      */
     public function withUri(UriInterface $uri, $preserveHost = false);
 }
-```
+~~~
 
 #### 3.2.1 `Psr\Http\Message\ServerRequestInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -1179,11 +1179,11 @@ interface ServerRequestInterface extends RequestInterface
      */
     public function withoutAttribute($name);
 }
-```
+~~~
 
 ### 3.3 `Psr\Http\Message\ResponseInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -1251,11 +1251,11 @@ interface ResponseInterface extends MessageInterface
      */
     public function getReasonPhrase();
 }
-```
+~~~
 
 ### 3.4 `Psr\Http\Message\StreamInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -1413,11 +1413,11 @@ interface StreamInterface
      */
     public function getMetadata($key = null);
 }
-```
+~~~
 
 ### 3.5 `Psr\Http\Message\UriInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -1742,11 +1742,11 @@ interface UriInterface
      */
     public function __toString();
 }
-```
+~~~
 
 ### 3.6 `Psr\Http\Message\UploadedFileInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Message;
 
@@ -1869,4 +1869,4 @@ interface UploadedFileInterface
      */
     public function getClientMediaType();
 }
-```
+~~~

--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -255,7 +255,7 @@ It was proposed here: https://github.com/container-interop/container-interop/pul
 The interface would have had the behaviour of the delegate lookup feature but would have forced the addition of
 a `setParentContainter` method:
 
-```php
+~~~php
 interface ParentAwareContainerInterface extends ReadableContainerInterface {
     /**
      * Sets the parent container associated to that container. This container will call
@@ -265,7 +265,7 @@ interface ParentAwareContainerInterface extends ReadableContainerInterface {
      */
     public function setParentContainer(ContainerInterface $container);
 }
-```
+~~~
 
 The interface idea was first questioned by @Ocramius [here](https://github.com/container-interop/container-interop/pull/8#issuecomment-51721777).
 @Ocramius expressed the idea that an interface should not contain setters, otherwise, it is forcing implementation
@@ -280,7 +280,7 @@ If we had had an interface, we could have delegated the registration of the dele
 delegate/composite container itself.
 For instance:
 
-```php
+~~~php
 $containerA = new ContainerA();
 $containerB = new ContainerB();
 
@@ -301,7 +301,7 @@ class CompositeContainer {
   }
 }
 
-```
+~~~
 
 **Cons:**
 

--- a/proposed/container.md
+++ b/proposed/container.md
@@ -87,7 +87,7 @@ The interfaces and classes described as well as relevant exception are provided 
 <a name="container-interface"></a>
 ### 2.1. `Psr\Container\ContainerInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Container;
 
@@ -121,12 +121,12 @@ interface ContainerInterface
      */
     public function has($id);
 }
-```
+~~~
 
 <a name="container-exception"></a>
 ### 2.2. `Psr\Container\Exception\ContainerExceptionInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Container\Exception;
 
@@ -136,12 +136,12 @@ namespace Psr\Container\Exception;
 interface ContainerExceptionInterface
 {
 }
-```
+~~~
 
 <a name="not-found-exception"></a>
 ### 2.3. `Psr\Container\Exception\NotFoundExceptionInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Container\Exception;
 
@@ -151,4 +151,4 @@ namespace Psr\Container\Exception;
 interface NotFoundExceptionInterface extends ContainerExceptionInterface
 {
 }
-```
+~~~

--- a/proposed/event-manager.md
+++ b/proposed/event-manager.md
@@ -51,7 +51,7 @@ OPTIONALLY the event can have additional parameters for use within the event.
 The event MUST contain a propegation flag that signals the EventManager to stop
 passing along the event to other listeners.
 
-```php
+~~~php
 
 namespace Psr\EventManager;
 
@@ -127,7 +127,7 @@ interface EventInterface
      */
     public function isPropagationStopped();
 }
-```
+~~~
 
 ### EventManagerInterface
 
@@ -135,7 +135,7 @@ The EventManager holds all the listeners for a particular event.  Since an
 event can have many listeners that each return a result, the EventManager
  MUST return the result from the last listener.
 
-```php
+~~~php
 
 namespace Psr\EventManager;
 
@@ -183,4 +183,4 @@ interface EventManagerInterface
      */
     public function trigger($event, $target = null, $argv = array());
 }
-```
+~~~

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -38,7 +38,7 @@ of PHP supported by your project.
 
 This example encompasses some of the rules below as a quick overview:
 
-```php
+~~~php
 <?php
 declare(strict_types=1);
 
@@ -68,7 +68,7 @@ class Foo extends Bar implements FooInterface
         // method body
     }
 }
-```
+~~~
 
 2. General
 ----------
@@ -154,7 +154,7 @@ followed by functions and then constants.
 
 Example of the above notices about namespace, strict types and use declarations:
 
-```php
+~~~php
 <?php
 declare(strict_types=1);
 
@@ -172,11 +172,11 @@ class FooBar
     // ... additional PHP code ...
 }
 
-```
+~~~
 
 Compound namespaces with a depth of two or more MUST not be used. Therefore the
 following is the maximum compounding depth allowed:
-```php
+~~~php
 <?php
 
 use Vendor\Package\Namespace\{
@@ -185,10 +185,10 @@ use Vendor\Package\Namespace\{
     SubnamespaceTwo\ClassY,
     ClassZ,
 };
-```
+~~~
 
 And the following would not be allowed:
-```php
+~~~php
 <?php
 
 use Vendor\Package\Namespace\{
@@ -196,14 +196,14 @@ use Vendor\Package\Namespace\{
     SubnamespaceOne\ClassB,
     ClassZ,
 };
-```
+~~~
 
 When wishing to declare strict types in files containing markup outside PHP
 opening and closing tags MUST, on the first line, include an opening php tag,
 the strict types declaration and closing tag.
 
 For example:
-```php
+~~~php
 <?php declare(strict_types=1); ?>
 <html>
 <body>
@@ -212,17 +212,17 @@ For example:
     ?>
 </body>
 </html>
-```
+~~~
 
 Declare statements MUST contain no spaces and MUST look like `declare(strict_types=1);`.
 
 Block declare statements are allowed and MUST be formatted as below. Note position of
 braces and spacing:
-```php
+~~~php
 declare(ticks=1) {
     //some code
 }
-```
+~~~
 
 4. Classes, Properties, and Methods
 -----------------------------------
@@ -235,9 +235,9 @@ same line.
 When instantiating a new class, parenthesis MUST always be present even when
 there are no arguments passed to the constructor.
 
-```php
+~~~php
 new Foo();
-```
+~~~
 
 ### 4.1 Extends and Implements
 
@@ -253,7 +253,7 @@ by a blank line.
 Closing braces MUST be on their own line and MUST NOT be preceded by a blank
 line.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -265,13 +265,13 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {
     // constants, properties, methods
 }
-```
+~~~
 
 Lists of `implements` and `extends` MAY be split across multiple lines, where
 each subsequent line is indented once. When doing so, the first item in the
 list MUST be on the next line, and there MUST be only one interface per line.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -286,14 +286,14 @@ class ClassName extends ParentClass implements
 {
     // constants, properties, methods
 }
-```
+~~~
 
 ### 4.2 Using traits
 
 The `use` keyword used inside the classes to implement traits MUST be
 declared on the next line after the opening brace.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -303,12 +303,12 @@ class ClassName
 {
     use FirstTrait;
 }
-```
+~~~
 
 Each individual Trait that is imported into a class MUST be included
 one-per-line, and each inclusion MUST have its own `use` statement.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -322,12 +322,12 @@ class ClassName
     use SecondTrait;
     use ThirdTrait;
 }
-```
+~~~
 
 When the class has nothing after the `use` declaration, the class
 closing brace MUST be on the next line after the `use` declaration.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -337,11 +337,11 @@ class ClassName
 {
     use FirstTrait;
 }
-```
+~~~
 
 Otherwise it MUST have a blank line after the `use` declaration.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -353,7 +353,7 @@ class ClassName
 
     private $property;
 }
-```
+~~~
 
 ### 4.3 Properties
 
@@ -369,7 +369,7 @@ no meaning.
 
 A property declaration looks like the following.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -377,7 +377,7 @@ class ClassName
 {
     public $foo = null;
 }
-```
+~~~
 
 ### 4.4 Methods and Functions
 
@@ -395,7 +395,7 @@ parenthesis, and there MUST NOT be a space before the closing parenthesis.
 A method declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -406,19 +406,19 @@ class ClassName
         // method body
     }
 }
-```
+~~~
 
 A function declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-```php
+~~~php
 <?php
 
 function fooBarBaz($arg1, &$arg2, $arg3 = [])
 {
     // function body
 }
-```
+~~~
 
 ### 4.5 Method and function Arguments
 
@@ -430,7 +430,7 @@ list.
 
 Method and function argument scalar type hints MUST be lowercase.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -441,7 +441,7 @@ class ClassName
         // method body
     }
 }
-```
+~~~
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -451,7 +451,7 @@ When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space
 between them.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -465,14 +465,14 @@ class ClassName
         // method body
     }
 }
-```
+~~~
 
 When you have a return type declaration present there MUST be one space after
 the colon with followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parentheses with no spaces between
 the two characters. The declaration keyword (e.g. string) MUST be lowercase.
 
-```php
+~~~php
 <?php
 declare(strict_types=1);
 
@@ -485,7 +485,7 @@ class ReturnTypeVariations
         return 'foo';
     }
 }
-```
+~~~
 
 ### 4.6 `abstract`, `final`, and `static`
 
@@ -495,7 +495,7 @@ visibility declaration.
 When present, the `static` declaration MUST come after the visibility
 declaration.
 
-```php
+~~~php
 <?php
 namespace Vendor\Package;
 
@@ -510,7 +510,7 @@ abstract class ClassName
         // method body
     }
 }
-```
+~~~
 
 ### 4.7 Method and Function Calls
 
@@ -520,13 +520,13 @@ after the opening parenthesis, and there MUST NOT be a space before the
 closing parenthesis. In the argument list, there MUST NOT be a space before
 each comma, and there MUST be one space after each comma.
 
-```php
+~~~php
 <?php
 
 bar();
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
-```
+~~~
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -534,7 +534,7 @@ next line, and there MUST be only one argument per line. A single argument being
 split across multiple lines (as might be the case with an anonymous function or
 array) does not constitute splitting the argument list itself.
 
-```php
+~~~php
 <?php
 
 $foo->bar(
@@ -542,9 +542,9 @@ $foo->bar(
     $longerArgument,
     $muchLongerArgument
 );
-```
+~~~
 
-```php
+~~~php
 <?php
 
 somefunction($foo, $bar, [
@@ -554,7 +554,7 @@ somefunction($foo, $bar, [
 $app->get('/hello/{name}', function ($name) use ($app) {
     return 'Hello ' . $app->escape($name);
 });
-```
+~~~
 
 5. Control Structures
 ---------------------
@@ -580,7 +580,7 @@ An `if` structure looks like the following. Note the placement of parentheses,
 spaces, and braces; and that `else` and `elseif` are on the same line as the
 closing brace from the earlier body.
 
-```php
+~~~php
 <?php
 
 if ($expr1) {
@@ -590,7 +590,7 @@ if ($expr1) {
 } else {
     // else body;
 }
-```
+~~~
 
 The keyword `elseif` SHOULD be used instead of `else if` so that all control
 keywords look like single words.
@@ -604,7 +604,7 @@ from `switch`, and the `break` keyword (or other terminating keyword) MUST be
 indented at the same level as the `case` body. There MUST be a comment such as
 `// no break` when fall-through is intentional in a non-empty `case` body.
 
-```php
+~~~php
 <?php
 
 switch ($expr) {
@@ -623,7 +623,7 @@ switch ($expr) {
         echo 'Default case';
         break;
 }
-```
+~~~
 
 
 ### 5.3 `while`, `do while`
@@ -631,57 +631,57 @@ switch ($expr) {
 A `while` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 
 while ($expr) {
     // structure body
 }
-```
+~~~
 
 Similarly, a `do while` statement looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 
 do {
     // structure body;
 } while ($expr);
-```
+~~~
 
 ### 5.4 `for`
 
 A `for` statement looks like the following. Note the placement of parentheses,
 spaces, and braces.
 
-```php
+~~~php
 <?php
 
 for ($i = 0; $i < 10; $i++) {
     // for body
 }
-```
+~~~
 
 ### 5.5 `foreach`
 
 A `foreach` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 
 foreach ($iterable as $key => $value) {
     // foreach body
 }
-```
+~~~
 
 ### 5.6 `try`, `catch`, `finally`
 
 A `try-catch-finally` block looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-```php
+~~~php
 <?php
 
 try {
@@ -693,7 +693,7 @@ try {
 } finally {
     // finally body
 }
-```
+~~~
 
 6. Operators
 -----------
@@ -705,7 +705,7 @@ Other operators are left undefined.
 
 For example:
 
-```php
+~~~php
 <?php
 
 if ($a === $b) {
@@ -713,7 +713,7 @@ if ($a === $b) {
 } elseif ($a > $b) {
     $variable = $foo ? 'foo' : 'bar';
 }
-```
+~~~
 
 7. Closures
 -----------
@@ -737,7 +737,7 @@ list.
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-```php
+~~~php
 <?php
 
 $closureWithArgs = function ($arg1, $arg2) {
@@ -747,7 +747,7 @@ $closureWithArgs = function ($arg1, $arg2) {
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     // body
 };
-```
+~~~
 
 Argument lists and variable lists MAY be split across multiple lines, where
 each subsequent line is indented once. When doing so, the first item in the
@@ -761,7 +761,7 @@ together on their own line with one space between them.
 The following are examples of closures with and without argument lists and
 variable lists split across multiple lines.
 
-```php
+~~~php
 <?php
 
 $longArgs_noVars = function (
@@ -807,12 +807,12 @@ $shortArgs_longVars = function ($arg) use (
 ) {
    // body
 };
-```
+~~~
 
 Note that the formatting rules also apply when the closure is used directly
 in a function or method call as an argument.
 
-```php
+~~~php
 <?php
 
 $foo->bar(
@@ -822,7 +822,7 @@ $foo->bar(
     },
     $arg3
 );
-```
+~~~
 
 8. Anonymous Classes
 --------------------
@@ -831,18 +831,18 @@ Anonymous Classes MUST follow the same guidelines and principles as closures
 in the above section.
 
 
-```php
+~~~php
 <?php
 
 $instance = new class {};
-```
+~~~
 
 The opening parenthesis MAY be on the same line as the `class` keyword so long as
 the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the parenthesis MUST be placed on the line immediately following the last
 interface.
 
-```php
+~~~php
 <?php
 
 // Parenthesis on the same line
@@ -858,7 +858,7 @@ $instance = new class extends \Foo implements
 {
     // Class content
 };
-```
+~~~
 
 [PSR-1]: http://www.php-fig.org/psr/psr-1/
 [PSR-2]: http://www.php-fig.org/psr/psr-2/

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -30,7 +30,7 @@ A Hypermedia Link consists of, at minimum:
 - A URI representing the target resource being referenced.
 - A relationship defining how the target resource relates to the source.
 
-Various other attributes of the Link may exist, depending on the format used. As additional attributes 
+Various other attributes of the Link may exist, depending on the format used. As additional attributes
 are not well-standardized or universal, this specification does not seek to standardize them.
 
 For the purposes of this specification, the following definitions apply.
@@ -80,12 +80,12 @@ The interfaces and classes described are provided as part of the
 
 ### 3.1 `Psr\Http\Link\LinkInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Link;
 
 /**
- * 
+ *
  */
 interface LinkInterface
 {
@@ -131,16 +131,16 @@ interface LinkInterface
      */
     public function getAttributes();
 }
-```
+~~~
 
 #### 3.2.1 `Psr\Http\Link\LinkCollectionInterface`
 
-```php
+~~~php
 <?php
 namespace Psr\Http\Link;
 
 /**
- * 
+ *
  */
 interface LinkCollectionInterface
 {
@@ -164,4 +164,4 @@ interface LinkCollectionInterface
      */
     public function getLinksByRel($rel);
 }
-```
+~~~

--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -44,7 +44,7 @@ to support and affirm multiple objects at once.
 
 ### HuggableInterface
 
-````php
+~~~`php
 namespace Psr\Hug;
 
 /**
@@ -67,9 +67,9 @@ interface Huggable
      */
     public function hug(Huggable $h);
 }
-````
+~~~`
 
-````php
+~~~`php
 namespace Psr\Hug;
 
 /**
@@ -92,5 +92,5 @@ interface GroupHuggable extends Huggable
    */
   public function groupHug($huggables);
 }
-````
+~~~`
 


### PR DESCRIPTION
Okay let's try this again. Evidently I don't know how to Git, and had an old copy of this repo around when I made these changes.

The new GitHub pages uses the rouge highlighter now, which doesn't support ticks for code blocks. We're getting build warnings on the website, and this is the first step to fixing this. Learn more here: https://github.com/php-fig/php-fig.github.com/issues/191

I've done a quick scan through, and I don't see any issues caused by this update. There will likely be some more tweaks yet, but I'll handle them as separate pull requests.

Thanks! :feelsgood: 