### PR TITLE
Disallow leading backslash on namespaced names

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -147,6 +147,8 @@ declaration.
 
 There MUST be one `use` keyword per declaration.
 
+Namespaces in `use` declarations MUST NOT have a leading backslash.
+
 There MUST be one blank line after the `use` block.
 
 For example:


### PR DESCRIPTION
According to the PHP manual, namespaced names shouldn't have leading backslashes:

> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as _Foo\Bar_ as opposed to global names that do not, such as _FooBar_), the leading backslash is unnecessary and not recommended, as import names must be fully qualified, and are not processed relative to the current namespace.

(See that text immediately following the example at: http://php.net/manual/en/language.namespaces.importing.php#example-285)

I've seen code that uses leading backslashes, which indicates some developers don't know when they need to be used and aren't aware of the recommendation.  Therefore, let's add a prohibition of them in the style guide.