### PR TITLE
Common sense bylaw caveats on member expulsion

### DIFF
--- a/bylaws/003-membership.md
+++ b/bylaws/003-membership.md
@@ -70,7 +70,7 @@ become a Member Project.
 Voting Representatives
 -----------------------
 
-The votes of all Member Projects are cast by Voting Representives who have been
+The votes of all Member Projects are cast by Voting Representatives who have been
 authorised to do so by the Member Project. Each Voting Representative is chosen
 solely by a Member Project and their selection is not subject to the approval
 of PHP-FIG. A Voting Representative may be replaced by the Member Project which
@@ -98,9 +98,13 @@ will be assumed.
 
 If, in the judgement of PHP-FIG, a Voting Representative is acting
 inappropriately and to the detriment of PHP-FIG's ability to meet its
-objectives, a vote may be taken to request a replacement Voting Representative in
-accordance with the [Voting Protocol bylaw][voting] or to expel the Member
-Project where replacing a Voting Representative is not possible.
+objectives, a vote may be taken to request a replacement Voting Representative,
+or to expel the Member Project where replacing a Voting Representative is not
+possible.
+
+The expulsion of a Voting Representative requires a vote in accordance with the
+[Voting Protocol bylaw][voting], with the exception that said Voting Representative
+will not have the ability to vote in their expulsion.
 
 Resignation Of Member Projects
 ------------------------------
@@ -126,7 +130,8 @@ to a replacement request from PHP-FIG but a suitable replacement is not
 available.
 
 The expulsion of a Member Project requires a vote in accordance with the
-[Voting Protocol bylaw][voting].
+[Voting Protocol bylaw][voting], with the exception that the Voting Representative
+for said Member Project will not have the ability to vote.
 
 FIG Secretary
 -------------


### PR DESCRIPTION
Whilst the FIG does not need to get into the habit of making bylaws for every decision the secretaries end up needing to make, we can certainly keep the bylaws up to date with some of the precedence being set.

Sure, some people will worry about some authoritarian group trying to take control - or something, but really this specific caveat should be common sense. Let's not panic about slippery slopes, and quite simply let's add this rule which should have been there since the start.

A bouncer doesn't get to ask you if you think you should be kicked out of a bar, and a potentially expelled member doesn't need a vote on their exclusion. So long as they respect the self throttling rules, they'll have plenty of time to put their points forward during the discussion period. But really, this shouldn't happen often. Maybe once or twice.

Consider this a solution to the discussion thread started [here](https://groups.google.com/forum/#!topic/php-fig/gMnU02lU1D0).