### PR TITLE
Relocate relationship definitions

### DIFF
--- a/proposed/links-meta.md
+++ b/proposed/links-meta.md
@@ -15,12 +15,9 @@ of the process of deciding what those links should be.
 
 The following questions are still outstanding, in the opinion of the Editor, and should be resolved.
 
-* How do we support "empty" attributes, as HTML5 permits but few other systems do?
 * Should Href be a string, or can/should we use PSR-7 URI objects? I'm very very tempted to go with the latter.
 * Currently, technically, URL templates would be disallowed. That's a problem for, say, HAL. How do we want to square
   that, especially if Href becomes an object?
-* Should we allow rels to be multi-value, or force multiple rels to be multiple objects? (IE, each uri/rel combination
-  becomes a distinct object.)
 
 ## 2. Scope
 

--- a/proposed/links-meta.md
+++ b/proposed/links-meta.md
@@ -18,8 +18,6 @@ The following questions are still outstanding, in the opinion of the Editor, and
 * How do we support "empty" attributes, as HTML5 permits but few other systems do?
 * Should Href be a string, or can/should we use PSR-7 URI objects? I'm very very tempted to go with the latter.
 * Is there wording we should clean up around rel definitions?
-* Should the rel definition information move from the interfaces to the spec, or stay in the interface docblocks where
-  people can easily find it when using it?
 * Currently, technically, URL templates would be disallowed. That's a problem for, say, HAL. How do we want to square
   that, especially if Href becomes an object?
 * Should we allow rels to be multi-value, or force multiple rels to be multiple objects? (IE, each uri/rel combination

--- a/proposed/links-meta.md
+++ b/proposed/links-meta.md
@@ -17,7 +17,6 @@ The following questions are still outstanding, in the opinion of the Editor, and
 
 * How do we support "empty" attributes, as HTML5 permits but few other systems do?
 * Should Href be a string, or can/should we use PSR-7 URI objects? I'm very very tempted to go with the latter.
-* Is there wording we should clean up around rel definitions?
 * Currently, technically, URL templates would be disallowed. That's a problem for, say, HAL. How do we want to square
   that, especially if Href becomes an object?
 * Should we allow rels to be multi-value, or force multiple rels to be multiple objects? (IE, each uri/rel combination

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -71,6 +71,25 @@ unless doing so changes the semantic meaning of the result. This rule applies if
 and only if the attribute is boolean `false`, not for any other "falsey" value in PHP
 such as integer 0.
 
+### 1.3 Relationships
+
+Link relationships are defined as strings, and are either a simple keyword in
+case of a publicly defined relationship or an absolute URI in the case of a
+private relationships.
+
+In case a simple keyword is used, it SHOULD match one from the IANA registry at:
+
+http://www.iana.org/assignments/link-relations/link-relations.xhtml
+
+Optionally the microformats.org registry MAY be used, but this may not be valid
+in every context:
+
+http://microformats.org/wiki/existing-rel-values
+
+A relationship that is not defined in one of the above registries or a similar
+public registry is considered "private", that is, specific to a particular
+application or use case.  Such relationships MUST use an absolute URI.
+
 ## 2. Package
 
 The interfaces and classes described are provided as part of the
@@ -103,19 +122,6 @@ interface LinkInterface
      *
      * This method returns 0 or more relationship types for a link, expressed
      * as an array of strings.
-     *
-     * The returned values should be either a simple keyword or an absolute
-     * URI. In case a simple keyword is used, it should match one from the
-     * IANA registry at:
-     *
-     * http://www.iana.org/assignments/link-relations/link-relations.xhtml
-     *
-     * Optionally the microformats.org registry may be used, but this may not
-     * be valid in every context:
-     *
-     * http://microformats.org/wiki/existing-rel-values
-     *
-     * Private relationship types should always be an absolute URI.
      *
      * @return string[]
      */

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -18,8 +18,8 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 - [RFC 2119](http://tools.ietf.org/html/rfc2119)
 - [RFC 4287](https://tools.ietf.org/html/rfc4287)
 - [RFC 5988](https://tools.ietf.org/html/rfc5988)
-- [Microformats Relations List](http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions)
 - [IANA Link Relations Registry](http://www.iana.org/assignments/link-relations/link-relations.xhtml)
+- [Microformats Relations List](http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions)
 
 
 ## 1. Specification


### PR DESCRIPTION
Move the relationship definition from the docblock to the prose section of the spec, for clarity. No substantive changes.