### PR TITLE
Method body indentation rule added + updated formatting

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -237,15 +237,17 @@ class ClassName
 
 ### 4.3. Methods
 
-Visibility MUST be declared on all methods.
+The general style rules for methods are as follows:
 
-Method names SHOULD NOT be prefixed with a single underscore to indicate
+- Visibility MUST be declared on all methods.
+- Method names SHOULD NOT be prefixed with a single underscore to indicate
 protected or private visibility.
-
-Method names MUST NOT be declared with a space after the method name. The
-opening brace MUST go on its own line, and the closing brace MUST go on the
-next line following the body. There MUST NOT be a space after the opening
-parenthesis, and there MUST NOT be a space before the closing parenthesis.
+- Method names MUST NOT be declared with a space after the method name.
+- The opening brace MUST go on its own line
+- There MUST NOT be a space after the opening parenthesis
+- There MUST NOT be a space before the closing parenthesis
+- The method body MUST be indented once
+- The closing brace MUST be on the next line after the body
 
 A method declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:


### PR DESCRIPTION
- In section "4.3. Methods", the rule for method body indentation was missing which is added.
- Also the formatting of the rules listing in this section is updated as bullet-points, as in section "5. Control Structures"