### PR TITLE
Name Michael Hess Editor of PSR-9/10

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,8 +28,8 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 |:---:|--------------------------------------|--------------------------------|-------------------------|-------------------|
 | 5   | [PHPDoc Standard][psr5]              | Mike van Riel                  | Vacant                  | Vacant            |
 | 8   | [Huggable Interface][psr8]           | Larry Garfield                 | Vacant                  | Paul M. Jones     |
-| 9   | [Security Advisories][psr9]          | Lukas Kahwe Smith              | Korvin Szanto           | Larry Garfield    |
-| 10  | [Security Reporting Process][psr10]  | Lukas Kahwe Smith              | Larry Garfield          | Korvin Szanto     |
+| 9   | [Security Advisories][psr9]          | Michael Hess                   | Korvin Szanto           | Larry Garfield    |
+| 10  | [Security Reporting Process][psr10]  | Michael Hess                   | Larry Garfield          | Korvin Szanto     |
 | 11  | [Container Interface][psr11]         | Matthieu Napoli, David Négrier | Paul M. Jones           | Vacant            |
 | 12  | [Extended Coding Style Guide][psr12] | Korvin Szanto                  | Alexander Makarov       | Robert Deutz      |
 | 13  | [Hypermedia Links][psr13]            | Larry Garfield                 | Matthew Weier O'Phinney | Marc Alexander    |
@@ -54,8 +54,8 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 | A      | 6   | [Caching Interface][psr6]            | Larry Garfield                 | Paul Dragoonis          | Robert Hafner     |
 | A      | 7   | [HTTP Message Interface][psr7]       | Matthew Weier O'Phinney        | Beau Simensen           | Paul M. Jones     |
 | D      | 8   | [Huggable Interface][psr8]           | Larry Garfield                 | Vacant                  | Paul M. Jones     |
-| D      | 9   | [Security Advisories][psr9]          | Lukas Kahwe Smith              | Korvin Szanto           | Larry Garfield    |
-| D      | 10  | [Security Reporting Process][psr10]  | Lukas Kahwe Smith              | Larry Garfield          | Korvin Szanto     |
+| D      | 9   | [Security Advisories][psr9]          | Michael Hess                   | Korvin Szanto           | Larry Garfield    |
+| D      | 10  | [Security Reporting Process][psr10]  | Michael Hess                   | Larry Garfield          | Korvin Szanto     |
 | D      | 11  | [Container Interface][psr11]         | Matthieu Napoli, David Négrier | Paul M. Jones           | Vacant            |
 | D      | 12  | [Extended Coding Style Guide][psr12] | Korvin Szanto                  | Alexander Makarov       | Robert Deutz      |
 | D      | 13  | [Hypermedia Links][psr13]            | Larry Garfield                 | Matthew Weier O'Phinney | Marc Alexander    |

--- a/proposed/security-disclosure-publication-meta.md
+++ b/proposed/security-disclosure-publication-meta.md
@@ -57,7 +57,7 @@ other people to build centralized tools around this information.
 
 ### 5.1 Editor
 
-* Lukas Kahwe Smith
+* Michael Hess
 
 ### 5.2 Sponsors
 
@@ -67,6 +67,11 @@ other people to build centralized tools around this information.
 ### 5.3 Coordinator
 
 * Korvin Szanto (concrete5)
+
+### 5.4 Contributors
+
+* Lukas Kahwe Smith
+
 
 6. Votes
 --------

--- a/proposed/security-reporting-process-meta.md
+++ b/proposed/security-reporting-process-meta.md
@@ -70,7 +70,7 @@ https://groups.google.com/d/msg/php-fig-psr-9-discussion/puGV_X0bj_M/Jr_IAS40Sts
 
 ### 5.1 Editor
 
-* Lukas Kahwe Smith
+* Michael Hess
 
 ### 5.2 Sponsors
 
@@ -79,7 +79,11 @@ https://groups.google.com/d/msg/php-fig-psr-9-discussion/puGV_X0bj_M/Jr_IAS40Sts
 
 ### 5.3 Coordinator
 
-* Korvin Szanto (concrete5)
+* Larry Garfield (Drupal)
+
+### 5.4 Contributors
+
+* Lukas Kahwe Smith
 
 6. Votes
 --------


### PR DESCRIPTION
Michael has agreed to take over PSR-9 and PSR-10.  Also, the Coordinator was listed wrong on PSR-10.  (Korvin and I are coordinating one spec each at present, per the index.)