### PR TITLE
Add Errata regarding DateTimeInterface handling for pre-5.5 environments

### DIFF
--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -291,23 +291,23 @@ specification.
 Despite that, any value that is not an object of  `\DateTimeInterface` (either
 `\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
 the future) MUST be treated as an invalid syntax error.  Implementers are
-encouraged to actively reject values that do not implement that interface. The
-recommended way of doing so is by using an assertion, as assertions are the
-closest equivalent to type checks.  Throwing `\InvalidArgumentException` is
-another widely used alternative, however, that would be a change in the
-specification (as Calling Libraries would then need to know to catch that
-exception as well).
+encouraged to actively reject values that do not implement that interface.
+Simulating a failed type check unfortunately varies between PHP versions. In PHP 5,
+it is a trigger_error().  In PHP 7, it is a thrown `\TypeError`. Implementing
+Libraries SHOULD try to mimic the behavior of the appropriate PHP version.
 
-Example of a PHP 5.3-compatible assertion:
+The following sample code is recommended in order to enforce the type check on
+the expiresAt() method:
 
 ```php
-assert('$expiration instanceof \DateTime || $expiration instanceof \DateTimeImmutable');
+if (! ($expiration instanceof \DateTime || $expiration instanceof \DateTimeImmutable)) {
+  $error = sprintf('Argument 1 passed to %s::expiresAt() must be an instance of DateTime or DateTimeImmutable, %s given', get_class($this), gettype($expiration));
+  if (class_exists('\TypeError')) {
+    throw new \TypeError($error);
+  }
+  trigger_error($error, E_USER_ERROR);
+}
 ```
-
-PHP 5.5-and-higher implementations can assert against `\DateTimeInterface`
-instead.  PHP 7.0-and-higher implementations can omit the quotation marks, as
-`assert()` is now smart enough to not run that code anyway when assertions are
-disabled. 
 
 
 6. People

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -300,7 +300,7 @@ The following sample code is recommended in order to enforce the type check on
 the expiresAt() method:
 
 ```php
-if (! (is_null($expiration) || $expiration instanceof \DateTime || $expiration instanceof \DateTimeInterface)) {
+if (!(null === $expiration || $expiration instanceof \DateTime || $expiration instanceof \DateTimeInterface)) {
   $error = sprintf('Argument 1 passed to %s::expiresAt() must be an instance of DateTime or DateTimeImmutable, %s given', get_class($this), gettype($expiration));
   if (class_exists('\TypeError')) {
     throw new \TypeError($error);

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -276,25 +276,59 @@ default control information is all that's possible), and because it's trivial
 for a particular implementation to include as an add-on should it desire to
 do so.
 
-5. People
+5. Errata
 ---------
 
-### 5.1 Editor
+### 5.1 Handling of incorrect DateTime values in expiresAt()
+
+The `CacheItemInterface::expiresAt()` method's `$expiration` parameter is untyped
+in the interface, but in the docblock is specified as `\DateTimeInterface`.  The
+intent is that either a `\DateTime` or `\DateTimeImmutable` object is allowed.
+However, `\DateTimeInterface` and `\DateTimeImmutable` were added in PHP 5.5, and
+the authors chose not to impose a hard syntactic requirement for PHP 5.5 on the
+specification.
+
+Despite that, any value that is not an object of  `\DateTimeInterface` (either
+`\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
+the future) MUST be treated as an invalid syntax error.  Implementers are
+encouraged to actively reject values that do not implement that interface. The
+recommended way of doing so is by using an assertion, as assertions are the
+closest equivalent to type checks.  Throwing `\InvalidArgumentException` is
+another widely used alternative, however, that would be a change in the
+specification (as Calling Libraries would then need to know to catch that
+exception as well).
+
+Example of a PHP 5.3-compatible assertion:
+
+```php
+assert('$expiration instanceof \DateTime || $expiration instanceof \DateTimeImmutable');
+```
+
+PHP 5.5-and-higher implementations can assert against `\DateTimeInterface`
+instead.  PHP 7.0-and-higher implementations can omit the quotation marks, as
+`assert()` is now smart enough to not run that code anyway when assertions are
+disabled. 
+
+
+6. People
+---------
+
+### 6.1 Editor
 
 * Larry Garfield
 
-### 5.2 Sponsors
+### 6.2 Sponsors
 
 * Paul Dragoonis, PPI Framework (Coordinator)
 * Robert Hafner, Stash
 
-6. Votes
+7. Votes
 --------
 
 [Acceptance vote on the mailing list](https://groups.google.com/forum/#!msg/php-fig/dSw5IhpKJ1g/O9wpqizWAwAJ)
 
 
-7. Relevant Links
+8. Relevant Links
 -----------------
 
 _**Note:** Order descending chronologically._

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -288,7 +288,7 @@ However, `\DateTimeInterface` and `\DateTimeImmutable` were added in PHP 5.5, an
 the authors chose not to impose a hard syntactic requirement for PHP 5.5 on the
 specification.
 
-Despite that, any value that is not null or an object of  `\DateTimeInterface` (either
+Despite that, any value that is not null or an object of `\DateTimeInterface` (either
 `\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
 the future) MUST be treated as an invalid syntax error.  Implementers are
 encouraged to actively reject values that do not implement that interface.

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -288,7 +288,7 @@ However, `\DateTimeInterface` and `\DateTimeImmutable` were added in PHP 5.5, an
 the authors chose not to impose a hard syntactic requirement for PHP 5.5 on the
 specification.
 
-Despite that, any value that is not an object of  `\DateTimeInterface` (either
+Despite that, any value that is not null or an object of  `\DateTimeInterface` (either
 `\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
 the future) MUST be treated as an invalid syntax error.  Implementers are
 encouraged to actively reject values that do not implement that interface.
@@ -300,7 +300,7 @@ The following sample code is recommended in order to enforce the type check on
 the expiresAt() method:
 
 ```php
-if (! ($expiration instanceof \DateTime || $expiration instanceof \DateTimeImmutable)) {
+if (! (is_null($expiration) || $expiration instanceof \DateTime || $expiration instanceof \DateTimeInterface)) {
   $error = sprintf('Argument 1 passed to %s::expiresAt() must be an instance of DateTime or DateTimeImmutable, %s given', get_class($this), gettype($expiration));
   if (class_exists('\TypeError')) {
     throw new \TypeError($error);


### PR DESCRIPTION
Based on implementation discussion in https://github.com/google/google-auth-library-php/pull/126
