### PR TITLE
Add evolvable interfaces

### DIFF
--- a/proposed/links-meta.md
+++ b/proposed/links-meta.md
@@ -27,12 +27,14 @@ formats.
 ### Why no mutator methods?
 
 One of the key targets for this specification is PSR-7 Response objects.  Response objects by design must be
-immutable.  Other value-object implementations likely would also require an immutable interface. Therefore,
-this specification focuses only on accessor methods that allow links to be extracted from a source object.
-How they got into that object is irrelevant.
+immutable.  Other value-object implementations likely would also require an immutable interface.
 
-In practice, immutable objects will likely incorporate with*()-style methods much like PSR-7 does. The definition
-of those interfaces is out of the scope of this specification, however.
+Additionally, some Link Collection objects may not be value objects but other objects within a given
+domain, which are able to generate Links on the fly, perhaps off of a database result or other underlying
+representation.  In those cases a writeable collection definition would be incompatible.
+
+Therefore, this specification splits accessor methods and evolvable methods into separate interfaces,
+allowing objects to implement just the read-only or evolvable versions as appropriate to their use case.
 
 ### Why is rel on a Link object multi-value?
 

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -101,7 +101,7 @@ that does not support URI Templates MUST ignore any templated Links it encounter
 
 ## 1.5 Evolvable collections
 
-In some cases, a Link Collection may need the ability to hbave additional links
+In some cases, a Link Collection may need the ability to have additional links
 added to it. In others, a link collection is necessarily read-only, with links
 derived at runtime from some other data source. For that reason, modifiable collections
 are a secondary interface that may optionally be implemented.

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -108,14 +108,17 @@ are a secondary interface that may optionally be implemented.
 
 Additionally, some Link Collection objects, such as PSR-7 Response objects, are
 by design immutable.  That means methods to add links to them in-place would be
-incompatible.
+incompatible. Therefore, the EvolvableLinkCollectionInterface's single method
+requires that a new object be returned, identical to the original but with
+an additional link object included.
 
 ## 1.6 Evolvable link objects
 
 Link objects are in most cases value objects. As such, allowing them to evolve
 in the same fashion as PSR-7 value objects is a useful option. For that reason,
-an additional EvolvableLinkInterface is included that provides immutable modifiers
-using the same pattern as PSR-7.
+an additional EvolvableLinkInterface is included that provides methods to
+produce new object instances with a single change.  The same model is used by PSR-7
+and, thanks to PHP's copy-on-write behavior, is still CPU and memory efficient.
 
 ## 2. Package
 

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -120,6 +120,10 @@ an additional EvolvableLinkInterface is included that provides methods to
 produce new object instances with a single change.  The same model is used by PSR-7
 and, thanks to PHP's copy-on-write behavior, is still CPU and memory efficient.
 
+There is no evolvable method for templated, however, as the templated value of a
+link is based exclusively on the href value.  It MUST NOT be set independently, but
+derived from whether or not the href value is an RFC 6570 link template.
+
 ## 2. Package
 
 The interfaces and classes described are provided as part of the
@@ -214,15 +218,6 @@ interface EvolvableLinkInterface extends LinkInterface
      * @return static
      */
     public function withHref($href);
-
-    /**
-     * Returns an instance with a specified templated value set.
-     *
-     * @param bool $templated
-     *   True if the link object should be templated, False otherwise.
-     * @return static
-     */
-    public function withTemplated($templated);
 
     /**
      * Returns an instance with the specified relationship included.

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -208,7 +208,7 @@ interface EvolvableLinkInterface extends LinkInterface
      * An implementing library SHOULD evaluate a passed object to a string
      * immediately rather than waiting for it to be returned later.
      *
-     * @return self
+     * @return static
      */
     public function withHref($href);
 
@@ -217,7 +217,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *
      * @param bool $templated
      *   True if the link object should be templated, False otherwise.
-     * @return self
+     * @return static
      */
     public function withTemplated($templated);
 
@@ -229,7 +229,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *
      * @param string $rel
      *   The relationship value to add.
-     * @return self
+     * @return static
      */
     public function withRel($rel);
 
@@ -241,7 +241,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *
      * @param string $rel
      *   The relationship value to exclude.
-     * @return self
+     * @return static
      */
     public function withoutRel($rel);
 
@@ -252,7 +252,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The attribute to include.
      * @param string $value
      *   The value of the attribute to set.
-     * @return self
+     * @return static
      */
     public function withAttribute($attribute, $value);
 }
@@ -309,8 +309,7 @@ interface EvolvableLinkCollectionInterface extends LinkCollectionInterface
      *
      * @param LinkInterface $link
      *   A link object that should be included in this collection.
-     *
-     * @return self
+     * @return static
      */
     public function withLink(LinkInterface $link);
 }

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -227,7 +227,7 @@ interface EvolvableLinkInterface extends LinkInterface
     /**
      * Returns an instance with the specified relationship included.
      *
-     * If the specified rel is already present, this methid MUST return
+     * If the specified rel is already present, this method MUST return
      * normally without errors, but without adding the rel a second time.
      *
      * @param string $rel

--- a/proposed/links.md
+++ b/proposed/links.md
@@ -251,6 +251,9 @@ interface EvolvableLinkInterface extends LinkInterface
     /**
      * Returns an instance with the specified attribute added.
      *
+     * If the specified attribute is already present, it will be overwritten
+     * with the new value.
+     *
      * @param string $attribute
      *   The attribute to include.
      * @param string $value
@@ -258,6 +261,19 @@ interface EvolvableLinkInterface extends LinkInterface
      * @return static
      */
     public function withAttribute($attribute, $value);
+
+
+    /**
+     * Returns an instance with the specified attribute excluded.
+     *
+     * If the specified attribute is not present, this method MUST return
+     * normally without errors.
+     *
+     * @param string $attribute
+     *   The attribute to remove.
+     * @return static
+     */
+    public function withoutAttribute($attribute);
 }
 ~~~
 
@@ -310,10 +326,27 @@ interface EvolvableLinkCollectionInterface extends LinkCollectionInterface
     /**
      * Returns an instance with the specified link included.
      *
+     * If the specified link is already present, this method MUST return normally
+     * without errors. The link is present if $link is === identical to a link
+     * object already in the collection.
+     *
      * @param LinkInterface $link
      *   A link object that should be included in this collection.
      * @return static
      */
     public function withLink(LinkInterface $link);
+
+    /**
+     * Returns an instance with the specifed link removed.
+     *
+     * If the specified link is not present, this method MUST return normally
+     * without errors. The link is present if $link is === identical to a link
+     * object already in the collection.
+     *
+     * @param LinkInterface $link
+     *   The link to remove.
+     * @return static
+     */
+    public function withoutLink(LinkInterface $link);
 }
 ~~~


### PR DESCRIPTION
As discussed on list, add optional interfaces for "evolvable" (with-able) objects, a la PSR-7. These are optional by design.