### PR TITLE
Sync with php-fig/http-message#45

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1063,7 +1063,7 @@ interface ServerRequestInterface extends RequestInterface
      * immutability of the message, and MUST return an instance that has the
      * updated body parameters.
      *
-     * @param array An array tree of UploadedFileInterface instances.
+     * @param array $uploadedFiles An array tree of UploadedFileInterface instances.
      * @return self
      * @throws \InvalidArgumentException if an invalid structure is provided.
      */


### PR DESCRIPTION
This patch duplicates php-fig/http-message#45, which corrects the method docblock for `ServerRequestInterface::withUploadedFiles()` to provide the name of the accepted parameter.