### PR TITLE
Update to php-fig/http-message#61

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1806,7 +1806,7 @@ interface UploadedFileInterface
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
      * @param string $targetPath Path to which to move the uploaded file.
-     * @throws \InvalidArgumentException if the $path specified is invalid.
+     * @throws \InvalidArgumentException if the $targetPath specified is invalid.
      * @throws \RuntimeException on any error during the move operation.
      * @throws \RuntimeException on the second or subsequent call to the method.
      */


### PR DESCRIPTION
This patch updates a `@throws` annotation in the `UploadedFileInterface::moveTo()` method docblock to correctly reference `$targetPath` instead of `$path` (the former is the name of the sole argument to the method).

(Patch ports the original made in php-fig/http-message#61)