### PR TITLE
Sync with php-fig/http-message#69

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -894,7 +894,7 @@ interface RequestInterface extends MessageInterface
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
      * `true`, this method interacts with the Host header in the following ways:
      *
-     * - If the the Host header is missing or empty, and the new URI contains
+     * - If the Host header is missing or empty, and the new URI contains
      *   a host component, this method MUST update the Host header in the returned
      *   request.
      * - If the Host header is missing or empty, and the new URI does not contain a


### PR DESCRIPTION
This patch removes a duplicate word found in the `RequestInterface::withUri()` method docblock, as reported with php-fig/http-message#69.