### PR TITLE
Sync with php-fig/http-message#74

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -840,7 +840,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * changed request target.
      *
-     * @see http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
+     * @see http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
      * @return self


### PR DESCRIPTION
This patch updates the `@see` annotation for the `RequestInterface::withRequestTarget()` method to link to the correct section of RFC 7230, per the issue raised in php-fig/http-message#74.