### PR TITLE
Method versus function naming consistency change

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -68,7 +68,7 @@ use OtherVendor\OtherPackage\BazClass;
 
 class Foo extends Bar implements FooInterface
 {
-    public function sampleFunction($a, $b = null)
+    public function sampleMethod($a, $b = null)
     {
         if ($a === $b) {
             bar();


### PR DESCRIPTION
The existing example of a class in section 1.1 includes the method `sampleFunction`, but this should be named `sampleMethod` to be consistent with the class and method language used throughout the rest of this document and [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md#43-methods).