### PR TITLE
Throwing a NotFoundException should be compulsory (MUST instead of SHOULD)

### DIFF
--- a/proposed/container.md
+++ b/proposed/container.md
@@ -42,7 +42,7 @@ Users of dependency injections containers (DIC) are referred to as `user`.
 Exceptions directly thrown by the container MUST implement the
 [`Psr\Container\Exception\ContainerExceptionInterface`](#container-exception).
 
-A call to the `get` method with a non-existing id SHOULD throw a
+A call to the `get` method with a non-existing id MUST throw a
 [`Psr\Container\Exception\NotFoundExceptionInterface`](#not-found-exception).
 
 ### 1.3 Recommended usage


### PR DESCRIPTION
As proposed on the mailing list (https://groups.google.com/forum/#!topic/php-fig/QJtsmJaT_uA), this PR proposes to make throwing a NotFoundException compulsory if the identifier does not exists in the container.

> The current text says a container SHOULD throw an exception. Searching through the history of container-interop, I cannot find why we put a "should" here.
> I'd like to propose replacing it with a MUST. For instance, it is never ok if a container returns null instead of throwing an exception. Therefore, the need for "MUST".