### PR TITLE
[PSR-11] Refining exception definitions

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -254,6 +254,36 @@ object that would describe how to create an instance.
 The conclusion of the discussion was that this was beyond the scope of getting entries from a container without
 knowing how the container provided them, and it was more fit for a factory.
 
+### 7.3. Exceptions thrown
+
+This PSR provides 2 interfaces meant to be implemented by container exceptions.
+
+#### 7.3.1 Base exception
+
+The `Psr\Container\Exception\ContainerExceptionInterface` is the base interface. It SHOULD be implemented by custom exceptions thrown directly by the container.
+
+It is expected that any exception that is part of the domain of the container implements the `ContainerExceptionInterface`. A few examples:
+
+- if a container relies on a configuration file and if that configuration file is flawed, the container might throw an `InvalidFileException` implementing the `ContainerExceptionInterface`.
+- if a cyclic dependency is detected between dependencies, the container might throw an `CyclicDependencyException` implementing the `ContainerExceptionInterface`.
+
+However, if the exception is thrown by some code out of the container's scope (for instance an exception thrown while instantiating an entry), the container is not required to wrap this exception in a custom exception implementing the `ContainerExceptionInterface`.
+
+A [discussion about the usefulness of the base exception](https://groups.google.com/forum/#!topic/php-fig/_vdn5nLuPBI) was held on the PHP-FIG's discussion group
+
+#### 7.3.2 Not found exception
+
+A call to the `get` method with a non-existing id must throw an exception implementing the `Psr\Container\Exception\NotFoundExceptionInterface`.
+
+There is a strong relationship with the behaviour of the `has` method.
+
+For a given identifier:
+
+- if the `has` method returns `false`, then the `get` method MUST throw a `Psr\Container\Exception\NotFoundExceptionInterface` on this identifier (i.e. a call to `$exception->getIdentifier()` MUST return the identifier).
+- if the `has` method returns `true`, then the `get` method MUST NOT throw a `Psr\Container\Exception\NotFoundExceptionInterface` on this identifier. However, this does not mean that the `get` method will succeed and throw no exception.
+
+Behaviour of the `NotFoundException` was discussed in [container-interop's issue #37](https://github.com/container-interop/container-interop/issues/37).
+
 ## 8. Delegate lookup feature
 
 ### 8.1. Purpose of the delegate lookup feature

--- a/proposed/container.md
+++ b/proposed/container.md
@@ -39,7 +39,7 @@ Users of dependency injections containers (DIC) are referred to as `user`.
 
 ### 1.2 Exceptions
 
-Exceptions directly thrown by the container MUST implement the
+Exceptions directly thrown by the container SHOULD implement the
 [`Psr\Container\Exception\ContainerExceptionInterface`](#container-exception).
 
 A call to the `get` method with a non-existing id SHOULD throw a
@@ -167,5 +167,11 @@ namespace Psr\Container\Exception;
  */
 interface NotFoundExceptionInterface extends ContainerExceptionInterface
 {
+    /**
+     * Returns the name of the identifier that was not found.
+     * 
+     * @return string
+     */
+    public function getIdentifier();
 }
 ~~~


### PR DESCRIPTION
**Work in progress... do not approve yet!**

My original intent with this PR with to switch from "MUST" to "SHOULD" regarding the implementation of the root `ContainerExceptionInterface` (as discussed [here](https://groups.google.com/forum/#!topic/php-fig/_vdn5nLuPBI)). I then started writing a paragraph about exceptions in the META document (because it was lacking).

At this point, I tried to explain the behaviour of `has` and `NotFoundExceptionInterface` this way:

- if the `has` method returns `true`, then the `get` method MUST NOT throw a `Psr\Container\Exception\NotFoundExceptionInterface`.

It turns out the sentence above is wrong. Indeed, a call to `get('myEntry')` might very well trigger a call to `get('myDependency')` that might not exist. In this case, a call to `get('myEntry')` would throw a `NotFoundExceptionInterface`, even if the `myEntry` instance exists. The bad part: looking at the exception, there is no way to know which entry is missing (it might be somewhere in the message but it is not available programmatically). Is it the identifier we asked? Is it a dependency? If this is a dependency, what is the dependency tree that led to the error (i.e. a requires b, b requires c, c doesn't exists)? There is no way to know.

One solution (in this PR) would be to add a `getIdentifier` method to the exception:

~~~php
 interface NotFoundExceptionInterface extends ContainerExceptionInterface
 {
    /**
     * Returns the name of the identifier that was not found.
     * 
     * @return string
     */
    public function getIdentifier();
 }
~~~

Another solution would be to create a new kind of exception (`MissingDependencyExceptionInterface`) that would wrap a `NotFoundExceptionInterface` if it happens in a dependency.

In any case, this is a breaking change with container-interop/container-interop (we could not more make container-interop interfaces extend from PSR-11 interfaces).

I'd be curious to know your thoughts about this. Shall we refine a bit the `NotFoundExceptionInterface` or am I overthinking this?

Ping @pmjones @mnapoli @Ocramius @jeremeamia