### PR TITLE
fix incorrect return type-hints

### DIFF
--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -169,7 +169,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function emergency($message, array $context = array());
 
@@ -181,7 +181,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function alert($message, array $context = array());
 
@@ -192,7 +192,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function critical($message, array $context = array());
 
@@ -202,7 +202,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function error($message, array $context = array());
 
@@ -214,7 +214,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function warning($message, array $context = array());
 
@@ -223,7 +223,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function notice($message, array $context = array());
 
@@ -234,7 +234,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function info($message, array $context = array());
 
@@ -243,7 +243,7 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function debug($message, array $context = array());
 
@@ -253,7 +253,7 @@ interface LoggerInterface
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function log($level, $message, array $context = array());
 }
@@ -276,7 +276,7 @@ interface LoggerAwareInterface
      * Sets a logger instance on the object
      *
      * @param LoggerInterface $logger
-     * @return null
+     * @return void
      */
     public function setLogger(LoggerInterface $logger);
 }


### PR DESCRIPTION
Return type is `void`, not `null` - these are incorrectly hinted and static analysis strictly should fail. (and does, at least in Php Storm.)
