### PR TITLE
Remove scalar lowercase rules from unrelated sections

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -117,6 +117,8 @@ PHP [keywords][] MUST be in lower case.
 The PHP types and keywords `array`, `int`, `true`, `object`, `float`, `false`, `mixed`,
 `bool`, `null`, `numeric`, `string`, `void` and `resource` MUST be in lower case.
 
+Any new types and keywords added to future PHP versions MUST be in lower case.
+
 Short form of type keywords MUST be used i.e. `bool` instead of `boolean`,
 `int` instead of `integer` etc.
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -456,8 +456,6 @@ MUST be one space after each comma.
 Method and function arguments with default values MUST go at the end of the argument
 list.
 
-Method and function argument scalar type hints MUST be lowercase.
-
 ~~~php
 <?php
 namespace Vendor\Package;
@@ -498,7 +496,7 @@ class ClassName
 When you have a return type declaration present there MUST be one space after
 the colon followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parentheses with no spaces between
-the two characters. The declaration keyword (e.g. string) MUST be lowercase.
+the two characters.
 
 ~~~php
 <?php


### PR DESCRIPTION
The rules regarding capitalization of scalar type hints and reserved keywords are specifically mentioned in [Section 2.5](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#25-keywords-and-types). Repeating this standard in other sections related to other style guides seems redundant. If there is an argument for doing so that I have missed in the discussion group, I'd love to hear about it.

Also, specifically the text "The declaration keyword (e.g. string) MUST be lowercase." located in [Section 4.5](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#45-method-and-function-arguments) does not specify a scalar type or keyword, and could be interpreted as the specified style for _any_ return type hint.
