### PR TITLE
Less ambiguous final line ending

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -84,7 +84,7 @@ each word is capitalised including the very first letter.
 
 All PHP files MUST use the Unix LF (linefeed) line ending, applying to every line in the file.
 
-All PHP files MUST end with a non-blank line, terminated with a single LF like all other lines in the file.
+All PHP files MUST end with a non-blank line, terminated with a single LF.
 
 The closing `?>` tag MUST be omitted from files containing only PHP.
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -82,9 +82,9 @@ each word is capitalised including the very first letter.
 
 ### 2.2 Files
 
-All PHP files MUST use the Unix LF (linefeed) line ending.
+All PHP files MUST use the Unix LF (linefeed) line ending, applying to every line in the file.
 
-All PHP files MUST end with a single line, containing only a single newline (LF) character.
+All PHP files MUST end with a non-blank line.
 
 The closing `?>` tag MUST be omitted from files containing only PHP.
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -84,7 +84,7 @@ each word is capitalised including the very first letter.
 
 All PHP files MUST use the Unix LF (linefeed) line ending, applying to every line in the file.
 
-All PHP files MUST end with a non-blank line.
+All PHP files MUST end with a non-blank line, terminated with a single LF like all other lines in the file.
 
 The closing `?>` tag MUST be omitted from files containing only PHP.
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -82,7 +82,7 @@ each word is capitalised including the very first letter.
 
 ### 2.2 Files
 
-All PHP files MUST use the Unix LF (linefeed) line ending, applying to every line in the file.
+All PHP files MUST use the Unix LF (linefeed) line ending only.
 
 All PHP files MUST end with a non-blank line, terminated with a single LF.
 


### PR DESCRIPTION
The original text was ambiguous in stating that a file must end with "a single line, containing only a single newline (LF) character". Issues with that are:
- A line will only ever contain one LF character, since the LF is what defines the end of the line. So there is an implication the term "single newline" is hinting at something else the author meant.
- The intent of this is to ensure:
  - The file does not end with a string of blank lines. In fact, it does not end with ANY blank lines. That was the intent behind the original PSR-2 when it stated all files "MUST end with a single blank line" - it actually meant a single LF.
  - Every line has a LF line ending. The LF line ending and everything before it (up to the previous LF or the start of the file) is what defines a line.
- This standard should be looking at lines from the file POV, and not how an editor may present it. Some editors may show a blank line on the end, and some may not. It all depends on how they choose to position the cursor when going beyond the final LF.

~~I think perhaps the statement "All PHP files MUST use the Unix LF (linefeed) line ending" is now surplus, and can be removed? The "Every line MUST have a single LF (linefeed) line ending" statement kind of says the same thing, but looks at it from a _line_ POV and not a _file_ POV. For example, a file could still use LF line endings, and yet never put a LF on the last line (older DOS files were like this) while stateing that every line MUST end in a LF makes sure the file both uses LFs _and_ will always end in a LF.~~ Okay, merged these.
