### PR TITLE
Compound namespaces with a depth of *three* or more MUST not be used.

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -178,7 +178,7 @@ class FooBar
 
 ~~~
 
-Compound namespaces with a depth of two or more MUST not be used. Therefore the
+Compound namespaces with a depth of three or more MUST not be used. Therefore the
 following is the maximum compounding depth allowed:
 ~~~php
 <?php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -178,7 +178,7 @@ class FooBar
 
 ~~~
 
-Compound namespaces with a depth of three or more MUST not be used. Therefore the
+Compound namespaces with a depth of more than two MUST not be used. Therefore the
 following is the maximum compounding depth allowed:
 ~~~php
 <?php


### PR DESCRIPTION
It says:

> Compound namespaces with a depth of two or more MUST not be used.

Then gives some examples of compound namespaces with a depth of two, stating that they are valid. If they really are valid, then the depth that cannot be used is *three* or more. This is a one-indexed reality and not zero-indexed ;-)