### PR TITLE
New coordinator and sponsor for PSR-11

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -561,8 +561,8 @@ therefore would be willing to switch to a Container PSR as soon as it is availab
 
 ### 10.2 Sponsors
 
-* [Paul M. Jones](https://github.com/pmjones) (Coordinator)
-* [Jeremy Lindblom](https://github.com/jeremeamia)
+* [Matthew Weier O'Phinney](https://github.com/weierophinney) (Coordinator)
+* [Korvin Szanto](https://github.com/KorvinSzanto)
 
 ### 10.3 Contributors
 


### PR DESCRIPTION
Per announcement on-list by editors (see https://groups.google.com/d/msgid/php-fig/cb58da1f-5ba7-4eb1-b745-33ac8b2f5e4a%40googlegroups.com).