### PR TITLE
Add default value parameter to get()

### DIFF
--- a/proposed/simplecache.md
+++ b/proposed/simplecache.md
@@ -119,10 +119,11 @@ interface CacheInterface
      * Fetch a value from the cache.
      *
      * @param string $key The unique key of this item in the cache
+     * @param mixed $default Default value to return if the key doesn't exist
      *
      * @return mixed The value of the item from the cache, or null in case of cache miss
      */
-    public function get($key);
+    public function get($key, $default = null);
 
     /**
      * Persist data in the cache, uniquely referenced by a key with an optional expiration TTL time.


### PR DESCRIPTION
`->get()` should have a fallback argument for convenience, to avoid additional isset() calls / null checks when using this method.