### PR TITLE
Specify that ContainerInterface::has() takes a string

### DIFF
--- a/proposed/container.md
+++ b/proposed/container.md
@@ -32,7 +32,7 @@ Users of dependency injections containers (DIC) are referred to as `user`.
   While `ContainerInterface` only defines one mandatory parameter in `get()`, implementations
   MAY accept additional optional parameters.
 
-- `has` takes one unique parameter: an entry identifier. It MUST return `true`
+- `has` takes one unique parameter: an entry identifier.  It MUST be a string. It MUST return `true`
   if an entry identifier is known to the container and `false` if it is not.
   `has($id)` returning true does not mean that `get($id)` will not throw an exception.
   It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.


### PR DESCRIPTION
See https://groups.google.com/d/msg/php-fig/L8rDUwRFsOU/R2f9-TKYCAAJ

> Small point: should the has() section in 1.1 say that the entry identifier MUST be a string, similar to how it does so for get()?