### PR TITLE
Update event-manager.md

### DIFF
--- a/proposed/event-manager.md
+++ b/proposed/event-manager.md
@@ -164,14 +164,6 @@ interface EventManagerInterface
     public function detach($event, $callback);
 
     /**
-     * Clear all listeners for a given event
-     *
-     * @param  string $event
-     * @return void
-     */
-    public function clearListeners($event);
-
-    /**
      * Trigger an event
      *
      * Can accept an EventInterface or will create one if not passed


### PR DESCRIPTION
I don't think `clearListeners` should be part of the standard interface definition.  
1) Standards should provide minimum API for developing `interoperability` application.  We clearly can use an event manager in entire application life cycle without ever having a need of using `clearListeners`. 

2) If we were to include `clearListeners` to clear ALL listeners for the given event, then why not include another method such as `clearEvents(callback)` which would remove the callback from ALL the events that it is listening to.  Method detach only removes the callback from single event at a time.  Also one can suggest `hasListeners(string event) : bool`, etc.

However, I humbly think that these extra methods aren't necessary for the PSR Standard definitions.  It should be up-to the implementing class to provide these extra functionalities if so desired.