### PR TITLE
Updates to EventManager component proposal

### DIFF
--- a/proposed/event-manager.md
+++ b/proposed/event-manager.md
@@ -82,43 +82,9 @@ interface EventInterface
     public function getParams();
 
     /**
-     * Get a single parameter by name
-     *
-     * @param  string $name
-     * @return mixed
+     * Indicate to stop propagating this event
      */
-    public function getParam($name);
-
-    /**
-     * Set the event name
-     *
-     * @param  string $name
-     * @return void
-     */
-    public function setName($name);
-
-    /**
-     * Set the event target
-     *
-     * @param  null|string|object $target
-     * @return void
-     */
-    public function setTarget($target);
-
-    /**
-     * Set event parameters
-     *
-     * @param  array $params
-     * @return void
-     */
-    public function setParams(array $params);
-
-    /**
-     * Indicate whether or not to stop propagating this event
-     *
-     * @param  bool $flag
-     */
-    public function stopPropagation($flag);
+    public function stopPropagation();
 
     /**
      * Has this event indicated event propagation should stop?
@@ -142,7 +108,7 @@ namespace Psr\EventManager;
 /**
  * Interface for EventManager
  */
-interface EventManagerInterface
+interface EventNotifierInterface
 {
     /**
      * Attaches a listener to an event
@@ -164,14 +130,6 @@ interface EventManagerInterface
     public function detach($event, $callback);
 
     /**
-     * Clear all listeners for a given event
-     *
-     * @param  string $event
-     * @return void
-     */
-    public function clearListeners($event);
-
-    /**
      * Trigger an event
      *
      * Can accept an EventInterface or will create one if not passed
@@ -181,6 +139,6 @@ interface EventManagerInterface
      * @param  array|object $argv
      * @return mixed
      */
-    public function trigger($event, $target = null, $argv = array());
+    public function notify($event, $target = null, $argv = array());
 }
 ~~~


### PR DESCRIPTION
I don't know the progress of this EventManager (PSR-14) proposal, whether it is even under any consideration or not; however, I do feel that it is very important building block of applications and should be standardized.

The current state of the proposed API is very weak to be considered as PSR standards in my opinion.  I don't know where to have a discussion about this, if it open for discussion (which I think should be at this stage).  Therefore I am using this PR to propose some changes, hope this will help shape this component.

### `EventManagerInterface`
1.a) Lets start with naming, `EventManagerInterface` is not a good name for standards.  I don't think PSR should try to standardize any "manager".  Usually 'Manager' prefix is used throughout application to define various services.  However, if we change the name to something like `EventNotifierInterface` (or `EventDispatcherInterface`) this would be a better name for standards.  Which leads me to next suggestions:

- 1.b) I particular favor `EventNotifierInterface` because of the nature of the component.  It is less about 'managing' events, but more about notifying an event occurrence.

- 1.c) I also think `notify` is better naming for this instead of `trigger`.  Trigger has some kind of user action, or explicit demand (like triggering errors).  However, 'notify' sounds more softer and flows with the purpose of the component.

- 1.d) It also have changes requested in the PR #833, removing the clearListener() method.

### `EventInterface`
- 2.a) Most of the suggestion for this interface goes along with my previous PR #833.  PSR SHOULD try to have minimum number of methods in its API definitions.  Therefore following methods are NOT necessary for the interface:
 - `getParam(string)`
 - `setParams(array)`
 - `setTarget(mixed)`
 - `setName(string)`
 There are many ways to create and set these values.  Interface need not to define these.  One can choose not to have these methods such as `setName` and `setTarget` defined, rather use constructor to have them assigned and mandate as such.  As for convenient method like `getParam(string)`, this is also really not necessary.

- 2.b) The method `stopPropagation` should NOT take any argument.  It doesn't make much sense to have one listener stopping the propagation, and other event (or any where else) starting again, which would be counter to the intent of the method to begin with.  Any listener when decides to stop the event chain, it will simply call stopPropagation().

I have been spending a LOT of time lately with events related component by doing researching various frameworks, and platforms.  As with most things, there are MANY ways to accomplish this.  But I would like to see PSR or other standard community standardize this component.