### PR TITLE
[PSR-11] Sending links at the bottom of the META doc

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -189,7 +189,7 @@ In the rest of this meta document, you will see frequent references to
 
 The interface name is the same as the one discussed for `container-interop`
 (only the namespace is changed to match the other PSRs).
-It has been thoroughly discussed on `container-interop` and was decided by a vote.
+It has been thoroughly discussed on `container-interop` [[1]](#link_naming_discussion) and was decided by a vote [[2]](#link_naming_vote).
 
 The list of options considered with their respective votes are:
 
@@ -202,14 +202,9 @@ The list of options considered with their respective votes are:
 - `ObjectStore`: -8
 - `ConsumerInterface`: -9
 
-[Full results of the vote](https://github.com/container-interop/container-interop/wiki/%231-interface-name:-Vote)
-
-The complete discussion can be read in [container-interop's issue #1](https://github.com/container-interop/container-interop/issues/1).
-
 ## 7. Interface methods
 
-The choice of which methods the interface would contain was made after a statistical analysis of existing containers.
-The results of this analysis are available [in this document](https://gist.github.com/mnapoli/6159681).
+The choice of which methods the interface would contain was made after a statistical analysis of existing containers. [[3]](#link_statistical_analysis).
 
 The summary of the analysis showed that:
 
@@ -223,8 +218,7 @@ The summary of the analysis showed that:
 - a large majority of the containers throw an exception rather than returning null when an entry is not found in `get()`
 - a large majority of the containers don't implement `ArrayAccess`
 
-The question of whether to include methods to define entries has been discussed in
-[container-interop's issue #1](https://github.com/container-interop/container-interop/issues/1).
+The question of whether to include methods to define entries has been discussed at the very start of the container-interop project [[1]](#link_naming_discussion).
 It has been judged that such methods do not belong in the interface described here because it is out of its scope
 (see the "Goal" section).
 
@@ -243,15 +237,15 @@ This issue has been discussed in [container-interop's issue #6](https://github.c
 
 ### 7.2. Type of the `$id` parameter
 
-The type of the `$id` parameter in `get()` and `has()` has been discussed in
-[container-interop's issue #6](https://github.com/container-interop/container-interop/issues/6).
+The type of the `$id` parameter in `get()` and `has()` has been discussed in the container-interop project.
+
 While `string` is used in all the containers that were analyzed, it was suggested that allowing
 anything (such as objects) could allow containers to offer a more advanced query API.
 
 An example given was to use the container as an object builder. The `$id` parameter would then be an
 object that would describe how to create an instance.
 
-The conclusion of the discussion was that this was beyond the scope of getting entries from a container without
+The conclusion of the discussion [[4]](#link_method_and_parameters_details) was that this was beyond the scope of getting entries from a container without
 knowing how the container provided them, and it was more fit for a factory.
 
 ### 7.3. Exceptions thrown
@@ -269,7 +263,9 @@ It is expected that any exception that is part of the domain of the container im
 
 However, if the exception is thrown by some code out of the container's scope (for instance an exception thrown while instantiating an entry), the container is not required to wrap this exception in a custom exception implementing the `ContainerExceptionInterface`.
 
-A [discussion about the usefulness of the base exception](https://groups.google.com/forum/#!topic/php-fig/_vdn5nLuPBI) was held on the PHP-FIG's discussion group
+The usefulness of the base exception interface was questioned: it is not an exception one would typically catch [[5]](#link_base_exception_usefulness).
+
+However, most PHP-FIG members considered it to be a best practice. Base exception interface are implemented in previous PSRs and several member projects. The base exception interface was therefore kept.
 
 #### 7.3.2 Not found exception
 
@@ -285,7 +281,7 @@ For a given identifier:
 When discussing the `ǸotFoundException`, a question arose to know whether the `NotFoundExceptionInterface` should have a `getMissingIdentifier()` method allowing the user catching the exception to know which identifier was not found.
 Indeed, a `ǸotFoundExceptionInterface` may have been triggered by a call to `get` in one of the dependencies, which is different from a call to `get` on a non existing identifier.
 
-After some discussion, it was decided that the `getIdentifier` method was not needed. Instead, it is important to stress out that the `get` method of the container SHOULD NOT throw a `NotFoundExceptionInterface` in case of a missing dependency. Instead, the container is expected to wrap the `NotFoundExceptionInterface` into another exception simply implementing the `ContainerExceptionInterface`.
+After some discussion [[6]](#link_not_found_behaviour), it was decided that the `getIdentifier` method was not needed. Instead, it is important to stress out that the `get` method of the container SHOULD NOT throw a `NotFoundExceptionInterface` in case of a missing dependency. Instead, the container is expected to wrap the `NotFoundExceptionInterface` into another exception simply implementing the `ContainerExceptionInterface`.
 
 In pseudo-code, a correct implementation of `get` should look like this:
 
@@ -306,8 +302,6 @@ public function get($identifier) {
 ~~~
 
 With this rule in place, a user of a container can safely know that a `NotFoundExceptionInterface` means the identifier he provided to the `get` method is missing, and not that some dependency is missing.
-
-Behaviour of the `NotFoundException` was discussed in [container-interop's issue #37](https://github.com/container-interop/container-interop/issues/37).
 
 ## 8. Delegate lookup feature
 
@@ -392,7 +386,7 @@ The first proposed approach we tried was to perform all the lookups in the "loca
 and if a lookup fails in the container, to use the delegate container. In this scenario, the
 delegate container is used in "fallback" mode.
 
-This strategy has been described in @moufmouf blog post: http://mouf-php.com/container-interop-whats-next (solution 1).
+This strategy has been described in @moufmouf [blog post (see solution 1)](http://mouf-php.com/container-interop-whats-next).
 It was also discussed [here](https://github.com/container-interop/container-interop/pull/8#issuecomment-33570697) and
 [here](https://github.com/container-interop/container-interop/pull/20#issuecomment-56599631).
 
@@ -589,5 +583,10 @@ Are listed here all people that contributed in the discussions or votes (on cont
 - [Discussion about the container PSR and the service locator](https://groups.google.com/forum/#!topic/php-fig/pyTXRvLGpsw)
 - [Container-interop's `ContainerInterface.php`](https://github.com/container-interop/container-interop/blob/master/src/Interop/Container/ContainerInterface.php)
 - [List of all issues](https://github.com/container-interop/container-interop/issues?labels=ContainerInterface&milestone=&page=1&state=closed)
-- [Vote for the interface name](https://github.com/container-interop/container-interop/wiki/%231-interface-name:-Vote)
+- <a name="link_naming_discussion"></a>[Discussion about the interface name and container-interop scope](https://github.com/container-interop/container-interop/issues/1)
+- <a name="link_naming_vote"></a>[Vote for the interface name](https://github.com/container-interop/container-interop/wiki/%231-interface-name:-Vote)
+- <a name="link_statistical_analysis"></a>[Statistical analysis of existing containers method names](https://gist.github.com/mnapoli/6159681)
+- <a name="link_method_and_parameters_details"></a>[Discussion about the method names and parameters](https://github.com/container-interop/container-interop/issues/6)
+- <a name="link_base_exception_usefulness"></a>[Discussion about the usefulness of the base exception](https://groups.google.com/forum/#!topic/php-fig/_vdn5nLuPBI)
+- <a name="link_not_found_behaviour"></a>[Discussion about the `NotFoundExceptionInterface` structure](https://github.com/container-interop/container-interop/issues/37)
 - [Original article exposing the delegate lookup idea along many others](http://mouf-php.com/container-interop-whats-next)


### PR DESCRIPTION
As suggested by @Crell , I'm removing most external links from the core of the META document and pushing them in the "links" section at the end of the document to make the whole document easier to read.

I've made sure the text of the META is clear enough without needing to refer to the provided links.

Note: this PR does not cover links in the "delegate lookup" section as discussion about "delegate lookup" has not started yet in the review phase and I suspect there will be a need for a big rewrite of some parts.

Ping @php-fig/psr-11 