### PR TITLE
[PSR-15] HTTP Middleware: Rename DelegateInterface to RequestHandlerInterface

### DIFF
--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -32,7 +32,7 @@ provides a number of benefits:
 ## 3.1 Goals
 
 * Create a middleware interface that uses HTTP Messages.
-* Provide a suggested interface for middleware stack containers.
+* Provide a suggested interface for middleware containers.
 * Ensure that middleware will not be tied to a specific implementation of HTTP Messages.
 * Implement a middleware signature that is based on best practices.
 
@@ -171,8 +171,8 @@ that are based around StackPHP.
 The double pass approach is much newer but has already been widely adopted by
 early adopters of HTTP Messages.
 
-5. `DelegateInterface`
--------------------
+5. `RequestHandlerInterface`
+----------------------------
 
 The `$next` argument is a callable in most existing middleware systems. However using
 an interface allows to improve type safety and IDE support.

--- a/proposed/http-middleware/middleware.md
+++ b/proposed/http-middleware/middleware.md
@@ -41,8 +41,8 @@ consumer only processes client requests.
 An HTTP middleware container is an object that holds multiple middleware
 components that can be used to process one or more requests in sequence.
 
-The middleware container MUST pass the request and a dispatcher to each
-middleware component that it executes. The dispatcher MUST be able to execute
+The middleware container MUST pass the request and a request handler to each
+middleware component that it executes. The request handler MUST be able to execute
 the next available middleware or if no more middleware is available, create a
 default response.
 
@@ -78,19 +78,17 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientMiddlewareInterface extends MiddlewareInterface
 {
     /**
-     * Process a client request and return a response.
+     * Process an incoming request and return a response, optionally delegating
+     * to the next request handler.
      *
-     * Takes the incoming request and optionally modifies it before delegating
-     * to the next frame to get a response.
-     *
-     * @param RequestInterface $request
-     * @param DelegateInterface $next
+     * @param RequestInterface        $request
+     * @param RequestHandlerInterface $next
      *
      * @return ResponseInterface
      */
     public function process(
         RequestInterface $request,
-        DelegateInterface $next
+        RequestHandlerInterface $next
     );
 }
 ```
@@ -108,19 +106,17 @@ use Psr\Http\Message\ServerRequestInterface;
 interface ServerMiddlewareInterface extends MiddlewareInterface
 {
     /**
-     * Process a server request and return a response.
+     * Process an incoming server request and return a response, optionally delegating
+     * to the next request handler.
      *
-     * Takes the incoming request and optionally modifies it before delegating
-     * to the next frame to get a response.
-     *
-     * @param ServerRequestInterface $request
-     * @param DelegateInterface $frame
+     * @param ServerRequestInterface  $request
+     * @param RequestHandlerInterface $next
      *
      * @return ResponseInterface
      */
     public function process(
         ServerRequestInterface $request,
-        DelegateInterface $frame
+        RequestHandlerInterface $next
     );
 }
 ```
@@ -128,32 +124,10 @@ interface ServerMiddlewareInterface extends MiddlewareInterface
 Note that the only difference between server and client middleware is that server
 middleware must be passed a server request for processing.
 
-### 2.5 Psr\Http\Middleware\DelegateInterface
+### 2.5 Psr\Http\Middleware\RequestHandlerInterface
 
-The following interface MUST be implemented by middleware delegates.
-
-```php
-namespace Psr\Http\Middleware;
-
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-
-interface DelegateInterface
-{
-    /**
-     * Dispatch the next available middleware and return the response.
-     *
-     * @param RequestInterface $request
-     *
-     * @return ResponseInterface
-     */
-    public function next(RequestInterface $request);
-}
-```
-
-### 2.6 Psr\Http\Middleware\StackInterface
-
-The following interface MAY be implemented by middleware stack containers.
+The following interface MUST be implemented by request handlers and MAY be
+implemented by middleware containers.
 
 ```php
 namespace Psr\Http\Middleware;
@@ -161,39 +135,10 @@ namespace Psr\Http\Middleware;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-interface StackInterface
+interface RequestHandlerInterface
 {
     /**
-     * Return an instance with the specified middleware added to the stack.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the stack, and MUST return an instance that contains
-     * the specified middleware.
-     *
-     * @param MiddlewareInterface $middleware
-     *
-     * @return self
-     */
-    public function withMiddleware(MiddlewareInterface $middleware);
-
-    /**
-     * Return an instance without the specified middleware.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the stack, and MUST return an instance that does not
-     * contain the specified middleware.
-     *
-     * @param MiddlewareInterface $middleware
-     *
-     * @return self
-     */
-    public function withoutMiddleware(MiddlewareInterface $middleware);
-
-    /**
-     * Process the request through middleware and return the response.
-     *
-     * This method MUST be implemented in such a way as to allow the same
-     * stack to be reused for processing multiple requests in sequence.
+     * Process a request and return the response.
      *
      * @param RequestInterface $request
      *


### PR DESCRIPTION
@akrabat stated at [the ML](https://groups.google.com/d/topic/php-fig/V12AAcT_SxE/discussion) about the `FrameInterface`:
>  It means nothing to me

And after a long discussion about the pros and cons of having an interface in contrast to a callable, we ended up by the idea of `DelegateInterface` (please forgive me, if I oversimplify things).

The idea, as far as I can see, behind this:
* the middleware container sends a *delegate* of him to a middleware, thus
* the middleware can interact with the *delegate* and doesn't have to know the concrete container

This sounds a bit better, but the interaction is essentially:
```
$response = $delegate->delegate($request);
```

Thus, we end up with the strange oddity: the first `delegate` means something quiet different than the second `delegate`.

---

Therefore, I suggest a rename of `DelegateInterface` to `RequestHandlerInterface`:

```php
interface RequestHandlerInterface
{
    /**
     * Process a request and return the response.
     *
     * @param RequestInterface $request
     *
     * @return ResponseInterface
     */
    public function process(RequestInterface $request);
}
```

The pros, I see:
1. The concept of request handlers is easy to understand and well known.
2. It is a more general concept – the middleware doesn't have to know that it is dealing with a container (and it shouldn't know as @shadowhand mentioned).
3. It reflects the idea, that a middleware comes between a request and response (mentioned @alamin3000).
4. Containers or more precisely dispatchers do exactly the same thing, and MAY implement `RequestHandlerInterface` too.

The cons, I see:
* To be honest: none

**One more thing: This PR is not about `process` vs `__invoke`. Please, don't try to start a new debate about that here.**