### PR TITLE
Proposal coming from Symfony trial implementation

### DIFF
--- a/proposed/simplecache.md
+++ b/proposed/simplecache.md
@@ -31,7 +31,6 @@ standardized streamlined interface for common cases.  It is independent of
 PSR-6 but has been designed to make compatibility with PSR-6 as straightforward
 as possible.
 
-
 ### 1.2 Definitions
 
 Definitions for Calling Library, Implementing Library, TTL, Expiration and Key
@@ -52,7 +51,7 @@ below with whole-second granularity.
 when that item is stored and it is considered stale. The TTL is normally defined
 by an integer representing time in seconds, or a DateInterval object.
 
-*    **Expiration** - The actual time when an item is set to go stale. This it
+*    **Expiration** - The actual time when an item is set to go stale. This is
 calculated by adding the TTL to the time when an object is stored.
 
     An item with a 300 second TTL stored at 1:30:00 will have an expiration of
@@ -82,9 +81,8 @@ supported by implementing libraries: `{}()/\@:`
 *    **Cache** - An object that implements the `Psr\SimpleCache\CacheInterface` interface.
 
 *    **Cache Misses** - A cache miss will return null and therefore detecting
-if one stored null is not possible. This is the main deviation from PSR-6's
+if one stored `null` is not possible. This is the main deviation from PSR-6's
 assumptions.
-
 
 ### 1.3 Cache
 
@@ -120,85 +118,110 @@ namespace Psr\SimpleCache;
 interface CacheInterface
 {
     /**
-     * Fetch a value from the cache.
+     * Fetches a value from the cache.
      *
-     * @param string $key     The unique key of this item in the cache
-     * @param mixed  $default Default value to return if the key does not exist
+     * @param string $key     The unique key of this item in the cache.
+     * @param mixed  $default Default value to return if the key does not exist.
      *
-     * @return mixed The value of the item from the cache, or $default in case of cache miss
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
     public function get($key, $default = null);
 
     /**
-     * Persist data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
      *
-     * @param string                $key   The key of the item to store
-     * @param mixed                 $value The value of the item to store, must be serializable
+     * @param string                $key   The key of the item to store.
+     * @param mixed                 $value The value of the item to store, must be serializable.
      * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
      *                                     the driver supports TTL then the library may set a default value
      *                                     for it or let the driver take care of that.
      *
-     * @return bool True on success and false on failure
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
     public function set($key, $value, $ttl = null);
 
     /**
-     * Delete an item from the cache by its unique key
+     * Delete an item from the cache by its unique key.
      *
-     * @param string $key The unique cache key of the item to delete
+     * @param string $key The unique cache key of the item to delete.
      *
-     * @return void
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
     public function delete($key);
 
     /**
-     * Wipe clean the entire cache's keys
+     * Wipes clean the entire cache's keys.
      *
-     * @return void
+     * @return bool True on success and false on failure.
      */
     public function clear();
 
     /**
-     * Obtain multiple cache items by their unique keys
+     * Obtains multiple cache items by their unique keys.
      *
-     * @param array|Traversable $keys A list of keys that can obtained in a single operation.
+     * @param array|\Traversable $keys    A list of keys that can obtained in a single operation.
+     * @param mixed              $default Default value to return for keys that do not exist.
      *
-     * @return array An array of key => value pairs. Cache keys that do not exist or are stale will have a value of null.
+     * @return array|\Traversable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
      */
-    public function getMultiple($keys);
+    public function getMultiple($keys, $default = null);
 
     /**
-     * Persisting a set of key => value pairs in the cache, with an optional TTL.
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param array|Traversable     $items An array of key => value pairs for a multiple-set operation.
-     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
-     *                                     the driver supports TTL then the library may set a default value
-     *                                     for it or let the driver take care of that.
+     * @param array|\Traversable    $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
      *
-     * @return bool True on success and false on failure
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
      */
-    public function setMultiple($items, $ttl = null);
+    public function setMultiple($values, $ttl = null);
 
     /**
-     * Delete multiple cache items in a single operation
+     * Deletes multiple cache items in a single operation.
      *
-     * @param array|Traversable $keys The array of string-based keys to be deleted
+     * @param array|\Traversable $keys A list of string-based keys to be deleted.
      *
-     * @return void
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
      */
     public function deleteMultiple($keys);
 
     /**
-     * Determine whether an item is present in the cache.
+     * Determines whether an item is present in the cache.
      *
      * NOTE: It is recommended that has() is only to be used for cache warming type purposes
      * and not to be used within your live applications operations for get/set, as this method
      * is subject to a race condition where your has() will return true and immediately after,
      * another script can remove it making the state of your app out of date.
      *
-     * @param string $key The cache item key
+     * @param string $key The cache item key.
      *
      * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
     public function has($key);
 }
@@ -216,8 +239,8 @@ interface CacheException
 }
 ```
 
-
 ### 2.3 InvalidArgumentException
+
 ```
 <?php
 


### PR DESCRIPTION
I tried to implement the current state of PSR-16 on Symfony Cache to see what it could look like:
https://github.com/symfony/symfony/pull/20636

This has raised a number of issues/questions, namely:

On CacheInterface:
- doesn't say what happens when $key is invalid => the same exception as PSR-6?
- the fact that `getMultiple` returns *all* keys, even cache misses, makes it impossible to (efficiently) implement a PSR-16 to PSR-6 bridge, because it makes it impossible to detect cache misses. When given an array, `apcu_fetch` for example has this other behavior of returning only the "hit", so it doesn't suffer from this. Could this be worth considering?
- accepting `Traversable` for `*Multiple` methods is not consistent with PSR-6 which only takes arrays as arguments
- returning `array` for `getMultiple` is not consistent with PSR-6 `getItems` which returns `array|Traversable`
- some methods return `void` when they could return `bool` => this is both inconsistent with some other methods, and with PSR-6

On CounterInterface:
- the draft doesn't say what happens when $key is invalid => the same exception as PSR-6?
- nor does it say what happens when $step is not an integer => return false? throw something?
- what should happen when $key already exists in the storage but is not "incrementable"? (Redis INCR fails, I didn't check apcu) => return false? throw? erase and store $step? other?
- atomicity misses a normative MUST or SHOULD.

About exceptions:
- if the PSR is going to document when exceptions should be thrown, then it should either define new exception classes or reuse those from PSR-6
- reusing exceptions defined in PSR-6 would look the most sensible to me
- yet, they are currently not in the same namespace. But: couldn't all these new interfaces move in the Psr\Cache namespace (thus releasing them as psr/cache 1.1 on packagist?)

This PR is a proposal to fix all aforementioned notes; namespace renaming excluded for now.