### PR TITLE
the param of groupHug should be from type Huggable[]

### DIFF
--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -87,7 +87,7 @@ interface GroupHuggable extends Huggable
    * provided. The order of the collection is not significant, and this object
    * MAY hug each of the objects in any order provided that all are hugged.
    *
-   * @param $huggables
+   * @param Huggable[] $huggables
    *   An array or iterator of objects implementing the Huggable interface.
    */
   public function groupHug($huggables);


### PR DESCRIPTION
It is not hard failure in annotation but it allows type hints