### PR TITLE
Remove out of scope text

### DIFF
--- a/proposed/simplecache.md
+++ b/proposed/simplecache.md
@@ -109,8 +109,7 @@ to perform, and lets you perform your operations in a single call to the cache s
 times dramatically.
 
 An instance of CacheInterface corresponds to a single collection of cache items with a single key namespace,
-and is equivalent to a "Pool" in PSR-6.  Different CacheInterface instances MAY be backed by the same
-datastore, but MUST be logically independent.
+and is equivalent to a "Pool" in PSR-6.
 
 ``` php
 <?php


### PR DESCRIPTION
> Different CacheInterface instances MAY be backed by the same datastore, but MUST be logically independent.

I'm of the opinion that infrastructure and _what a cache object represents_ are both outside the scope of what this standard should address, and that this sentence should be removed.

Furthermore, the second clause, which stipulates that "CacheInterface instances ... MUST be logically independent" is needlessly restrictive and prevents many valid use cases, such as decorator objects.