### PR TITLE
Adding Larry Garfield to the list of contributors

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -358,7 +358,7 @@ therefore would be willing to switch to a Container PSR as soon as it is availab
 
 ### 9.3 Contributors
 
-Are listed here all people that contributed in the discussions or votes (on container-interop), by alphabetical order:
+Are listed here all people that contributed in the discussions or votes (on container-interop and during migration to PSR-11), by alphabetical order:
 
 - [Alexandru Pătrănescu](https://github.com/drealecs)
 - [Amy Stephen](https://github.com/AmyStephen)
@@ -367,6 +367,7 @@ Are listed here all people that contributed in the discussions or votes (on cont
 - [Don Gilbert](https://github.com/dongilbert)
 - [Jason Judge](https://github.com/judgej)
 - [Jeremy Lindblom](https://github.com/jeremeamia)
+- [Larry Garfield](https://github.com/crell)
 - [Marco Pivetta](https://github.com/Ocramius)
 - [Matthieu Napoli](https://github.com/mnapoli)
 - [Nelson J Morais](https://github.com/njasm)


### PR DESCRIPTION
We did not update the contributors list between container-interop and PSR-11. Yet, PSR-11 is different from container-interop on many points thanks to a number of additional contributors.

In this PR, I'm adding Larry Garfield as a contributor. He made major feedback during the review phase, in particular:
- [regarding the definition of an entry identifier](https://github.com/php-fig/fig-standards/pull/837)
- he got wider community feedback that led to the removal of the delegate lookup feature

Thanks @Crell 