### PR TITLE
[WIP] Reworking NotFoundExceptionInterface purpose

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -280,7 +280,7 @@ For a given identifier:
 - if the `has` method returns `false`, then the `get` method MUST throw a `Psr\Container\NotFoundExceptionInterface`.
 - if the `has` method returns `true`, this does not mean that the `get` method will succeed and throw no exception. It can even throw a `Psr\Container\NotFoundExceptionInterface` if one of the dependencies of the requested entry is missing.
 
-Therefore, when a user catches the `Psr\Container\NotFoundExceptionInterface`, it has 2 possibles meanings [[9]](#link_not_found_behaviour):
+Therefore, when a user catches the `Psr\Container\NotFoundExceptionInterface`, it has 2 possible meanings [[9]](#link_not_found_behaviour):
 
 - the requested entry does not exist (bad request)
 - or a dependency of the requested entry does not exist (i.e. the container is misconfigured)

--- a/proposed/container.md
+++ b/proposed/container.md
@@ -38,8 +38,7 @@ An entry identifier is any PHP-legal string of at least one character that uniqu
 
 - `has` takes one unique parameter: an entry identifier, which MUST be a string.
   `has` MUST return `true` if an entry identifier is known to the container and `false` if it is not.
-  `has($id)` returning true does not mean that `get($id)` will not throw an exception.
-  It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+  If `has($id)` returns false, `get($id)` MUST throw a `NotFoundExceptionInterface`.
 
 ### 1.2 Exceptions
 
@@ -48,12 +47,6 @@ Exceptions directly thrown by the container SHOULD implement the
 
 A call to the `get` method with a non-existing id MUST throw a
 [`Psr\Container\NotFoundExceptionInterface`](#not-found-exception).
-
-A call to `get` can trigger additional calls to `get` (to fetch the dependencies).
-If one of those dependencies is missing, the `NotFoundExceptionInterface` triggered by the
-inner `get` call SHOULD NOT bubble out. Instead, it should be wrapped in an exception 
-implementing the `ContainerExceptionInterface` that does not implement the 
-`NotFoundExceptionInterface`.
 
 ### 1.3 Recommended usage
 


### PR DESCRIPTION
Here is an attempt to solve the debate going on on the ML. More discussion needs to be done and meta needs to be fixed so do not merge this yet!

@nicolas-grekas and @weierophinney mails ([here](https://groups.google.com/d/msg/php-fig/I1a2Xzv9wN8/Ja3ma6pWFQAJ) and [here](https://groups.google.com/d/msg/php-fig/I1a2Xzv9wN8/njO0oBZvFQAJ)) pointed a few things that were never said before.

Namely:

- The `NotFoundExceptionInterface` duplicates the concept of the `has` method (in Nicolas post)
- Using exceptions for control flow is often a questionable design choice (in Matthew post)

Based on these 2 assertions (I agree with both), we should question the usefulness of `NotFoundExceptionInterface` as it is defined today.

We spent a lot of time to make sure that containers implementing PSR-11 are differentiating the `NotFoundExceptionInterface` from a "missing dependency exception" (that should exist in the container even if it is not standardized). This involves that implementing containers MUST catch the `NotFoundExceptionInterface` and rethrow another exception. So we are forcing an "implementation detail" into implementors.

And I've come to realize we absolutely don't need that.

The change I'm proposing is dead simple: let's drop any distinction between "entry not found" and "dependency missing". We don't need this because users of containers can anyway figure that out.

If a user of a container wants to make the distinction between "not found" and "missing dependency", he can simply perform a call to `has` before calling `get`:

```php
if (!$container->has($id)) {
    // The requested instance does not exist
    // Let's do some stuff like display an error message
    return;
}
try {
    $entry = $container->get($id);
} catch (NotFoundExceptionInterface $e) {
    // Since the requested entry DOES exist, a NotFoundExceptionInterface means that a dependency is missing!
}
```

Advantages:

- it is dead simple
- we don't dictate that `NotFoundExceptionInterface` must not bubble up (no forced catch and rethrow)
- containers can do whatever they want:
    - either let `NotFoundExceptionInterface` bubble up
    - or catch the `NotFoundExceptionInterface` and wrap it in a "MissingDependencyException" of their own that must itself implement the `NotFoundExceptionInterface`

Inconvenient:

- slight incompatibility with container-interop, since in container-interop, the  "MissingDependencyException" was not supposed to implement the `NotFoundExceptionInterface` (this is actually not clearly stated in the container-interop documentation)

The more I think about it, the more I'm seduced by this solution. It is simple, it leaves complete freedom to implementors, and container users can still figure out if the exception they get is a "not found" or a "missing dependency" with a simple `has` call. It also enforces best practices as users that want to check if an entry exists will use `has` instead of `NotFoundExceptionInterface` (the exception can no more be used for control flow)

Note: I haven't had a chance to speak with @mnapoli about it yet since deadlines are tight, I'm sharing it right now. Matthieu, let me know what you think about this change.

What do you think?