### PR TITLE
[WIP] Rewording the definition of NotFoundExceptionInterface (simpler more concise sentence)

### DIFF
--- a/proposed/container.md
+++ b/proposed/container.md
@@ -39,21 +39,14 @@ An entry identifier is any PHP-legal string of at least one character that uniqu
 - `has` takes one unique parameter: an entry identifier, which MUST be a string.
   `has` MUST return `true` if an entry identifier is known to the container and `false` if it is not.
   `has($id)` returning true does not mean that `get($id)` will not throw an exception.
-  It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
 
 ### 1.2 Exceptions
 
 Exceptions directly thrown by the container SHOULD implement the
 [`Psr\Container\ContainerExceptionInterface`](#container-exception).
 
-A call to the `get` method with a non-existing id MUST throw a
-[`Psr\Container\NotFoundExceptionInterface`](#not-found-exception).
-
-A call to `get` can trigger additional calls to `get` (to fetch the dependencies).
-If one of those dependencies is missing, the `NotFoundExceptionInterface` triggered by the
-inner `get` call SHOULD NOT bubble out. Instead, it should be wrapped in an exception 
-implementing the `ContainerExceptionInterface` that does not implement the 
-`NotFoundExceptionInterface`.
+A call to the `get($id)` MUST throw a [`Psr\Container\NotFoundExceptionInterface`](#not-found-exception) if and only 
+if `has($id)` returns `false`.
 
 ### 1.3 Recommended usage
 


### PR DESCRIPTION
This is an attempt to reword the "current" wording of PSR-11. This PR is therefore "incompatible" with #869 (so at some point one or the other must be rejected)

This PR does not change anything to the way exceptions work currently, it is only an attempt to make the sentence easier to understand.

The idea is that `NotFoundExceptionInterface` duplicates the meaning of `has` (as noticed by @nicolas-grekas). So instead of making a complicated sentence explaining that the `NotFoundExceptionInterface` should not bubble out, we simply say that `NotFoundExceptionInterface` <=> 'has returns false'.

If we decide to keep exceptions the way they work, I think this is a great rewrite :) 
