### PR TITLE
[PSR-6] Put the actual title of the PSR at the top of the document, instead of the word introduction.

### DIFF
--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -1,4 +1,4 @@
-## Introduction
+# Caching Interface
 
 Caching is a common way to improve the performance of any project, making
 caching libraries one of the most common features of many frameworks and


### PR DESCRIPTION
This puts the actual title of the PSR at the top of the document, instead of the word introduction.

This fixes errors by automated tools that expect the name of the PSR on the first line of the document, such as seen on http://www.php-fig.org/psr/psr-6/ which displays "PSR-6: # Introduction" instead of the expected "PSR-6: Caching Interface" as the title of the page.