### PR TITLE
Objects that are allowed to be null MUST go at the end of the argument list

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -430,7 +430,7 @@ In the argument list, there MUST NOT be a space before each comma, and there
 MUST be one space after each comma.
 
 Method and function arguments with default values MUST go at the end of the argument
-list.
+list including objects that are allowed to be null.
 
 Method and function argument scalar type hints MUST be lowercase.
 
@@ -440,7 +440,7 @@ namespace Vendor\Package;
 
 class ClassName
 {
-    public function foo(int $arg1, &$arg2, $arg3 = [])
+    public function foo(int $arg1, &$arg2, $arg3 = [], MyClass $obj = null)
     {
         // method body
     }


### PR DESCRIPTION
After the discussion I had [here](https://github.com/squizlabs/PHP_CodeSniffer/issues/1092) I believe that the new PSR must explicitly mention that the Objects that are allowed to be null must also go at the end of the argument list.