### PR TITLE
Uppercasing key word

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -178,7 +178,7 @@ class FooBar
 
 ~~~
 
-Compound namespaces with a depth of more than two MUST not be used. Therefore the
+Compound namespaces with a depth of two or more MUST NOT be used. Therefore the
 following is the maximum compounding depth allowed:
 ~~~php
 <?php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -178,7 +178,7 @@ class FooBar
 
 ~~~
 
-Compound namespaces with a depth of two or more MUST NOT be used. Therefore the
+Compound namespaces with a depth of more than two MUST NOT be used. Therefore the
 following is the maximum compounding depth allowed:
 ~~~php
 <?php


### PR DESCRIPTION
Minor typo. The `MUST NOT` keyword should always be uppercase.

See #824