### PR TITLE
Incorporate feedback on http-middleware

### DIFF
--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -292,7 +292,7 @@ dispatcher that uses middleware implementing `MiddlewareInterface`.
 The term "delegate" means something designated to act for or represent another.
 In terms of middleware design, a delegate is called upon by middleware when the
 middleware is unable to handle the request itself; the delegate then processes
-the request to return a response.
+the request _for the original middleware_ in order to return a response.
 
 #### Why isn't the delegate a `callable`?
 

--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -1,5 +1,5 @@
-HTTP Server Middleware
-======================
+HTTP Server Middleware Meta Document
+====================================
 
 1. Summary
 ----------
@@ -83,10 +83,10 @@ request and response being passed to the middleware.
 
 #### 4.1.1 Projects Using Double Pass
 
-* [mindplay/middleman](https://github.com/mindplay-dk/middleman/blob/1.0.0/src/MiddlewareInterface.php#L24)
-* [relay/relay](https://github.com/relayphp/Relay.Relay/blob/1.0.0/src/MiddlewareInterface.php#L24)
-* [slim/slim](https://github.com/slimphp/Slim/blob/3.4.0/Slim/MiddlewareAwareTrait.php#L66-L75)
-* [zendframework/zend-stratigility](https://github.com/zendframework/zend-stratigility/blob/1.0.0/src/MiddlewarePipe.php#L69-L79)
+* [mindplay/middleman v1](https://github.com/mindplay-dk/middleman/blob/1.0.0/src/MiddlewareInterface.php#L24)
+* [relay/relay v1](https://github.com/relayphp/Relay.Relay/blob/1.0.0/src/MiddlewareInterface.php#L24)
+* [slim/slim v3](https://github.com/slimphp/Slim/blob/3.4.0/Slim/MiddlewareAwareTrait.php#L66-L75)
+* [zendframework/zend-stratigility v1](https://github.com/zendframework/zend-stratigility/blob/1.0.0/src/MiddlewarePipe.php#L69-L79)
 
 #### 4.1.2 Middleware Implementing Double Pass
 
@@ -181,7 +181,7 @@ community for many years. This is most evident with the large number of packages
 that are based around StackPHP.
 
 The double pass approach is much newer but has been almost universally used by
-early adopters of HTTP Messages.
+early adopters of PSR-7 (HTTP Messages).
 
 ### 4.4 Chosen Approach
 
@@ -256,8 +256,9 @@ following were commonly used:
 [DispatchableInterface]: https://github.com/zendframework/zend-stdlib/blob/980ce463c29c1a66c33e0eb67961bba895d0e19e/src/DispatchableInterface.php
 
 We chose to allow a forwards-compatible approach for such classes to repurpose
-themselves as middleware, and, as such, needed to choose a name not in common
-usage. As such, we chose `process`, to indicate _processing_ a request.
+themselves as middleware (or middleware compatible with this specification),
+and, as such, needed to choose a name not in common usage. As such, we chose
+`process`, to indicate _processing_ a request.
 
 #### Why is a server request required?
 
@@ -269,7 +270,7 @@ server request interface, external requests are typically handled asynchronously
 and would typically return a [promise][promises] of a response. (This is primarily
 due to the fact that multiple requests can be made in parallel and processed as
 they are returned.) It is outside the scope of this proposal to address the needs
-of asynchronous request/response life cycle.
+of asynchronous request/response life cycles.
 
 Attempting to define client middleware would be premature at this point. Any future
 proposal that is focused on client side request processing should have the opportunity
@@ -313,10 +314,11 @@ return a response.
 
 #### Why does the delegate conflict with middleware?
 
-Both the middleware and delegate interface define a `process` method to discourage
-misuse of middleware as delegates.
+Both the middleware and delegate interface define a `process` method to
+discourage misuse of middleware as delegates.
 
-The implementation of delegate should be defined within middleware dispatching systems.
+The implementation of the delegate should be defined within middleware
+dispatching systems.
 
 6. People
 ---------

--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -286,12 +286,30 @@ The `DelegateInterface` defines a single method that accepts a request and
 returns a response. The delegate interface must be implemented by any middleware
 dispatcher that uses middleware implementing `MiddlewareInterface`.
 
+#### Why the term "delegate"?
+
+The term "delegate" means something designated to act for or represent another.
+In terms of middleware design, a delegate is called upon by middleware when the
+middleware is unable to handle the request itself; the delegate then processes
+the request to return a response.
+
 #### Why isn't the delegate a `callable`?
 
 Using an interface type hint improves runtime safety and IDE support.
 
 _See "discussion of FrameInterface" in [relevant links](#8-relevant-links) for
 additional information._
+
+#### Why not the term `$next`?
+
+Several existing middleware libraries use the term `$next` instead of
+`$delegate`. `$next` implies an action: "Next, please!" As such, these libraries
+define `$next` as a `callable`, which we note was undesirable for purposes of
+this specification in the previous section.
+
+Additionally, since we are defining an object, we chose to use a noun instead of
+a verb to name the interface. The delegate then _processes_ the request to
+return a response.
 
 #### Why does the delegate conflict with middleware?
 

--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -235,11 +235,29 @@ and a delegate and must return a response. The middleware may:
 #### Why doesn't middleware use `__invoke`?
 
 Doing so would conflict with existing middleware that implements the double-pass
-approach and may want to implement the middleware interface.
+approach and may want to implement the middleware interface for purposes of
+forwards compatibility with this specification.
 
-In addition, classes that define `__invoke` can be type hinted as `callable`,
-which results in less strict typing. This is generally undesirable, especially
-when the `__invoke` method uses strict typing.
+In addition, classes that define `__invoke` can be more loosely type hinted as
+`callable`, which results in less strict typing. This is generally undesirable,
+especially when the `__invoke` method uses strict typing.
+
+#### Why the name `process()`?
+
+We reviewed a number of existing MVC and middleware frameworks to determine
+what method(s) each defined for handling incoming requests. We found the
+following were commonly used:
+
+- `__invoke` (within middleware systems, such as Slim, Expressive, Relay, etc.)
+- `handle` (in particular, software derived from Symfony's [HttpKernel][HttpKernel])
+- `dispatch` (Zend Framework's [DispatchableInterface][DispatchableInterface])
+
+[HttpKernel]: https://symfony.com/doc/current/components/http_kernel.html
+[DispatchableInterface]: https://github.com/zendframework/zend-stdlib/blob/980ce463c29c1a66c33e0eb67961bba895d0e19e/src/DispatchableInterface.php
+
+We chose to allow a forwards-compatible approach for such classes to repurpose
+themselves as middleware, and, as such, needed to choose a name not in common
+usage. As such, we chose `process`, to indicate _processing_ a request.
 
 #### Why is a server request required?
 

--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -309,8 +309,12 @@ define `$next` as a `callable`, which we note was undesirable for purposes of
 this specification in the previous section.
 
 Additionally, since we are defining an object, we chose to use a noun instead of
-a verb to name the interface. The delegate then _processes_ the request to
-return a response.
+a verb to name the interface.
+
+Further, we did not choose the term `next` for the action delegates invoke, as
+that verb implies a queue or stack. The delegate is not required to implement
+either pattern internally in order to do its work; its only job is to _process_
+the request to return a response.
 
 #### Why does the delegate conflict with middleware?
 

--- a/proposed/http-middleware/middleware.md
+++ b/proposed/http-middleware/middleware.md
@@ -1,8 +1,8 @@
-HTTP Middleware
-===============
+HTTP Server Middleware
+======================
 
-This document describes a common standard for HTTP middleware components using
-HTTP Messages defined by [PSR-7](http://www.php-fig.org/psr/psr-7/).
+This document describes a common standard for HTTP server middleware components
+using HTTP Messages defined by [PSR-7](http://www.php-fig.org/psr/psr-7/).
 
 HTTP middleware has been an important concept on other web development platforms
 for a good number of years, and since the introduction of a formal HTTP Messages
@@ -10,6 +10,9 @@ standard has been growing increasingly popular with web frameworks.
 
 The interfaces described in this document are abstractions for HTTP middleware
 and the containers that are used to process HTTP requests.
+
+_**Note:** Any references to "middleware" in this document are specific to
+**server middleware**._
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be


### PR DESCRIPTION
This patch incorporates feedback that was provided via #867, including the following:

- Updated the titles of each document:
  - Both now use the verbiage "HTTP Server Middleware"
  - Meta document now advertises itself as such
- Added to the meta document:
  - Minor additions to the discussion on why `__invoke` was not chosen.
  - Added a section on why `process` was chosen.
  - Added a section on why "delegate" was chosen, and another on why `$next` was not.

Additionally, combed through the documents for typos, line wraps, etc.