### PR TITLE
Unify different technical terms

### DIFF
--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -190,7 +190,7 @@ significant issues regarding implementation.
 
 The most severe is that passing an empty response has no guarantees that the
 response is in a usable state. This is further exacerbated by the fact that a
-middleware may modify the response before passing it for further dispatching.
+middleware may modify the response before passing it for further processing.
 
 Further compounding the problem is that there is no way to ensure that the
 response body has not been written to, which can lead to incomplete output or
@@ -230,7 +230,7 @@ and a delegate and must return a response. The middleware may:
   available middleware.
 - Evolve the response received from the delegate before returning it.
 - Create and return a response without passing it to the delegate, thereby
-  preventing any further middleware from executing.
+  preventing any further middleware from processing.
 
 #### Why doesn't middleware use `__invoke`?
 
@@ -245,7 +245,7 @@ especially when the `__invoke` method uses strict typing.
 #### Why the name `process()`?
 
 We reviewed a number of existing MVC and middleware frameworks to determine
-what method(s) each defined for handling incoming requests. We found the
+what method(s) each defined for processing incoming requests. We found the
 following were commonly used:
 
 - `__invoke` (within middleware systems, such as Slim, Expressive, Relay, etc.)
@@ -266,7 +266,7 @@ To make it clear that the middleware can only be used in a synchronous, server
 side context.
 
 While not all middleware will need to use the additional methods defined by the
-server request interface, external requests are typically handled asynchronously
+server request interface, external requests are typically processed asynchronously
 and would typically return a [promise][promises] of a response. (This is primarily
 due to the fact that multiple requests can be made in parallel and processed as
 they are returned.) It is outside the scope of this proposal to address the needs
@@ -291,7 +291,7 @@ dispatcher that uses middleware implementing `MiddlewareInterface`.
 
 The term "delegate" means something designated to act for or represent another.
 In terms of middleware design, a delegate is called upon by middleware when the
-middleware is unable to handle the request itself; the delegate then processes
+middleware is unable to process the request itself; the delegate then processes
 the request _for the original middleware_ in order to return a response.
 
 #### Why isn't the delegate a `callable`?

--- a/proposed/http-middleware/middleware.md
+++ b/proposed/http-middleware/middleware.md
@@ -47,7 +47,7 @@ An HTTP middleware dispatcher is an object that holds multiple middleware
 components that can be used to process one or more requests in sequence.
 
 The middleware dispatcher MUST pass the request and a delegate to each
-middleware component that it executes. The delegate MUST be able to execute
+middleware for further processing. The delegate MUST be able to dispatch
 the next available middleware or if no more middleware is available, create a
 default response.
 


### PR DESCRIPTION
In my opinion, a standard should use as few technical terms as possible to not confuse implementers (this PR supersedes http-interop/http-middleware/pull/59).

It unifies different technical terms (_process_, _handle_, _execute_ and _dispatch_):
1. _requests_ and _responses_ are _processed_
2. middleware dispatchers and delegates (of dispatchers) _dispatch_ middlewares

##### _process_ aligns with the method names and the wording introduced by @weierophinney at `middleware-meta.md` (#878):

> #### Why the term "delegate"?
> […] the delegate then processes the request […]

##### _dispatch_ aligns with the wording chosen at `middleware.md`:
> ### 1.1 Dispatchers
> An HTTP middleware dispatcher is an object […]

---

@weierophinney I've replaced some of the wording you've recently introduced, please take a look.