### PR TITLE
[PSR-15] Remove duplicate section

### DIFF
--- a/proposed/http-middleware/middleware-meta.md
+++ b/proposed/http-middleware/middleware-meta.md
@@ -320,14 +320,6 @@ that verb implies a queue or stack. The delegate is not required to implement
 either pattern internally in order to do its work; its only job is to _process_
 the request to return a response.
 
-#### Why does the delegate conflict with middleware?
-
-Both the middleware and delegate interface define a `process` method to
-discourage misuse of middleware as delegates.
-
-The implementation of the delegate should be defined within middleware
-dispatching systems.
-
 ## 6. People
 
 ### 6.1 Editor(s)


### PR DESCRIPTION
To be honest, I dunno why the `Why does the delegate conflict with middleware?` section got duplicated – https://github.com/php-fig/fig-standards/commit/6c878b450fb69c053278d540b02863898cd5a738 should have moved it only!?