### PR TITLE
[PSR-15] Use broader definition of dispatchers

### DIFF
--- a/proposed/http-middleware/middleware.md
+++ b/proposed/http-middleware/middleware.md
@@ -33,23 +33,19 @@ Middleware using this standard MUST implement the following interface:
 
 - `Psr\Http\ServerMiddleware\MiddlewareInterface`
 
-Middleware dispatching systems using this standard MUST implement the following
-interface:
-
-- `Psr\Http\ServerMiddleware\DelegateInterface`
-
 Legacy middleware implementing a double pass approach MUST be wrapped using an
 object that implements the `MiddlewareInterface`.
 
-### 1.1 Dispatchers
+### 1.1 Dispatchers and Delegates
 
-An HTTP middleware dispatcher is an object that holds multiple middleware
-components that can be used to process one or more requests in sequence.
+An HTTP middleware dispatcher is a component that is able to process server
+requests by dispatching middlewares. In order to dispatch a middleware the
+dispatcher MUST pass the request and a delegate to the middleware for further
+processing.
 
-The middleware dispatcher MUST pass the request and a delegate to each
-middleware for further processing. The delegate MUST be able to dispatch
-the next available middleware or if no more middleware is available, create a
-default response.
+Delegate using this standard MUST implement the following interface:
+
+- `Psr\Http\ServerMiddleware\DelegateInterface`
 
 ### 1.2 Generating Responses
 

--- a/proposed/http-middleware/middleware.md
+++ b/proposed/http-middleware/middleware.md
@@ -36,18 +36,20 @@ Middleware using this standard MUST implement the following interface:
 Legacy middleware implementing a double pass approach MUST be wrapped using an
 object that implements the `MiddlewareInterface`.
 
-### 1.1 Dispatchers and Delegates
+### 1.1 Dispatchers
 
 An HTTP middleware dispatcher is a component that is able to process server
 requests by dispatching middlewares. In order to dispatch a middleware the
 dispatcher MUST pass the request and a delegate to the middleware for further
 processing.
 
+### 1.2 Delegates
+
 Delegate using this standard MUST implement the following interface:
 
 - `Psr\Http\ServerMiddleware\DelegateInterface`
 
-### 1.2 Generating Responses
+### 1.3 Generating Responses
 
 It is RECOMMENDED that any middleware that needs to generate a response will
 use HTTP Factories as defined in [PSR-17](http://www.php-fig.org/psr/psr-17/),


### PR DESCRIPTION
* Dispatcher are not necessarily objects, functions can dispatch middlewares as well.
* Dispatcher usually hold `0`, `1`, `1…n` or `0…n` middleware (components), depending on their purpose and framework design; "multiple" is therefore too restrictive.

**NB:** The _next available middleware_ sentence is still part of the `DelegateInterface` contract (section 2.2).