### PR TITLE
Align PSR-5 @method signatures with PHP7 with regard to return types

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -479,7 +479,7 @@ An example of this is:
 
 ```php
 /**
- * @method int MyMagicMethod(string $argument1) {
+ * @method MyMagicMethod(string $argument1): int {
  *     This is the summary for MyMagicMethod.
  *
  *     @param string $argument1 Description for argument 1.
@@ -578,7 +578,7 @@ Some tags may even feature an "Inline PHPDoc" as shown in the following example.
 
 ```php
 /**
- * @method int MyMagicMethod(string $argument1) {
+ * @method MyMagicMethod(string $argument1): int {
  *     This is the summary for MyMagicMethod.
  *
  *     @param string $argument1 Description for argument 1.
@@ -1220,18 +1220,19 @@ The @method allows a class to know which 'magic' methods are callable.
 
 #### Syntax
 
-    @method [return type] [name]([type] [parameter], [...]) [description]
+    @method <static|> [name]([type] [parameter], [...])[: return type] [description]
 
 #### Description
 
-The @method tag is used in situation where a class contains the `__call()` magic
-method and defines some definite uses.
+The @method tag is used in situation where a class contains the `__call()` or
+`__callStatic()` magic methods and defines some definite uses.
 
-An example of this is a child class whose parent has a `__call()` to have dynamic
-getters or setters for predefined properties. The child knows which getters and
-setters need to be present but relies on the parent class to use the `__call()`
-method to provide it. In this situation, the child class would have a @method
-tag for each magic setter or getter method.
+An example of this is a child class whose parent has a `__call()` or
+`__callStatic` to have dynamic getters or setters for predefined properties.
+The child knows which getters and setters need to be present but relies on the
+parent class to use the `__call()` or `__callStatic()` method to provide it.
+In this situation, the child class would have a @method tag for each magic
+setter or getter method.
 
 The @method tag allows the author to communicate the type of the arguments and
 return value by including those types in the signature.
@@ -1254,9 +1255,11 @@ class Parent
 }
 
 /**
- * @method string getString()
- * @method void setInteger(int $integer)
+ * @method getString(): string
+ * @method setInteger(int $integer): void
  * @method setString(int $integer)
+ * @method static setStaticString(int $integer)
+ * @method static setStaticStringFluid(int $integer): static
  */
 class Child extends Parent
 {

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -1220,7 +1220,7 @@ The @method allows a class to know which 'magic' methods are callable.
 
 #### Syntax
 
-    @method <static|> [name]([type] [parameter], [...])[: return type] [description]
+    @method [static] [name]([type] [parameter], [...])[: return type] [description]
 
 #### Description
 


### PR DESCRIPTION
Currently, the placement of the return type does not match that of PHP7.

For a new developer, this would seem 'wrong' as there are now 2 different signatures for methods.

In addition, allows for the documentation to support static methods that are processed by `__callStatic()`.

And finally, this change removes the ambiguity where a method may be one of two;

```php
<?php

class Parent
{
    public function __call()
    {

    }

    public static function __callStatic()
    {

    }
}

/**
 * @method static getString()
 */
class Child extends Parent
{
    <...>
}
```

Is `getString()` a static method returning void, or a regular method returning a static instance?

By having the scope and return type separated, the ambiguity is removed.
