### PR TITLE
Switches from underline to standard H2 syntax

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -22,8 +22,7 @@ interpreted as described in [RFC 2119].
 [PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
 
 
-1. Overview
------------
+## 1. Overview
 
 - Code MUST follow a "coding style guide" PSR [[PSR-1]].
 
@@ -86,8 +85,7 @@ class Foo extends Bar implements FooInterface
 }
 ~~~
 
-2. General
-----------
+## 2. General
 
 ### 2.1. Basic Coding Standard
 
@@ -137,8 +135,7 @@ The PHP constants `true`, `false`, and `null` MUST be in lower case.
 
 
 
-3. Namespace and Use Declarations
----------------------------------
+## 3. Namespace and Use Declarations
 
 When present, there MUST be one blank line after the `namespace` declaration.
 
@@ -164,8 +161,7 @@ use OtherVendor\OtherPackage\BazClass;
 ~~~
 
 
-4. Classes, Properties, and Methods
------------------------------------
+## 4. Classes, Properties, and Methods
 
 The term "class" refers to all classes, interfaces, and traits.
 
@@ -361,8 +357,7 @@ $foo->bar(
 );
 ~~~
 
-5. Control Structures
----------------------
+## 5. Control Structures
 
 The general style rules for control structures are as follows:
 
@@ -491,8 +486,7 @@ try {
 }
 ~~~
 
-6. Closures
------------
+## 6. Closures
 
 Closures MUST be declared with a space after the `function` keyword, and a
 space before and after the `use` keyword.
@@ -598,8 +592,7 @@ $foo->bar(
 ~~~
 
 
-7. Conclusion
---------------
+## 7. Conclusion
 
 There are many elements of style and practice intentionally omitted by this
 guide. These include but are not limited to:
@@ -622,8 +615,7 @@ Future recommendations MAY revise and extend this guide to address those or
 other elements of style and practice.
 
 
-Appendix A. Survey
-------------------
+## Appendix A. Survey
 
 In writing this style guide, the group took a survey of member projects to
 determine common practices.  The survey is retained herein for posterity.


### PR DESCRIPTION
Although Github-flavoured markdown has, at points, suggested the use of `-------` to define an underline-style H2 it doesn't actually apply the correct H2 styles when viewing markdown on Github.com

This commit replaces underline H2 styles with the standard `## Second level heading` syntax so the file displays correctly.

Currently the text looks like this when viewing on Github:
![current](https://cloud.githubusercontent.com/assets/377366/25138213/d68efab4-2451-11e7-84ce-ac3287392fb5.jpg)

This commit makes it look like this:
![corrected by commit](https://cloud.githubusercontent.com/assets/377366/25138238/e9478090-2451-11e7-9413-16c91c37a3da.jpg)

