### PR TITLE
Add Errata regarding DateTimeInterface handling for pre-5.5 environments, using exceptions

### DIFF
--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -332,8 +332,15 @@ class ExpiresAtInvalidParameterException implements Psr\Cache\InvalidArgumentExc
 
 // ...
 
-if (!(null === $expiration || $expiration instanceof \DateTime || $expiration instanceof \DateTimeInterface)) {
-  $error = sprintf('Argument 1 passed to %s::expiresAt() must be an instance of DateTime or DateTimeImmutable, %s given', get_class($this), gettype($expiration));
-  throw new ExpiresAtInvalidParameterException($error);
+if (! (
+        null === $expiration
+        || $expiration instanceof \DateTime
+        || $expiration instanceof \DateTimeInterface
+)) {
+    throw new ExpiresAtInvalidParameterException(sprintf(
+        'Argument 1 passed to %s::expiresAt() must be an instance of DateTime or DateTimeImmutable; %s given',
+        get_class($this),
+        is_object($expiration) ? get_class($expiration) : gettype($expiration)
+    ));
 }
 ```

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -319,7 +319,7 @@ specification.
 Despite that, any value that is not null or an object of `\DateTimeInterface` (either
 `\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
 the future) MUST be treated as an invalid argument error.  Implementers are
-encouraged to actively reject values that do not implement that interface.
+required to actively reject values that do not implement that interface.
 
 Simulating a failed type check unfortunately varies between PHP versions and thus is not
 recommended.  Instead, implementors SHOULD throw an instance of `\Psr\Cache\InvalidArgumentException`.  

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -316,10 +316,9 @@ However, `\DateTimeInterface` and `\DateTimeImmutable` were added in PHP 5.5, an
 the authors chose not to impose a hard syntactic requirement for PHP 5.5 on the
 specification.
 
-Despite that, any value that is not null or an object of `\DateTimeInterface` (either
-`\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
-the future) MUST be treated as an invalid argument error.  Implementers are
-required to actively reject values that do not implement that interface.
+Despite that, implementers MUST accept only `\DateTimeInterface` or compatible types
+(such as `\DateTime` and `\DateTimeImmutable`) as if the method was explicitly typed.
+(Note that the variance rules for a typed parameter may vary between language versions.)
 
 Simulating a failed type check unfortunately varies between PHP versions and thus is not
 recommended.  Instead, implementors SHOULD throw an instance of `\Psr\Cache\InvalidArgumentException`.  

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -318,7 +318,7 @@ specification.
 
 Despite that, any value that is not null or an object of `\DateTimeInterface` (either
 `\DateTime` or `\DateTimeImmutable`, or possibly others added to the language in
-the future) MUST be treated as an invalid syntax error.  Implementers are
+the future) MUST be treated as an invalid argument error.  Implementers are
 encouraged to actively reject values that do not implement that interface.
 
 Simulating a failed type check unfortunately varies between PHP versions and thus is not


### PR DESCRIPTION
Trying this again... Here's an Errata for PSR-6 that addresses the missing type hint on expiresAt() using an exception rather than a simulated type check failure.