### PR TITLE
Apply formatting to all headings in PSR-2 style-guide

### DIFF
--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -1,5 +1,4 @@
-Coding Style Guide
-==================
+# Coding Style Guide
 
 This guide extends and expands on [PSR-1], the basic coding standard.
 
@@ -22,8 +21,7 @@ interpreted as described in [RFC 2119].
 [PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
 
 
-1. Overview
------------
+## 1. Overview
 
 - Code MUST follow a "coding style guide" PSR [[PSR-1]].
 
@@ -86,8 +84,7 @@ class Foo extends Bar implements FooInterface
 }
 ~~~
 
-2. General
-----------
+## 2. General
 
 ### 2.1. Basic Coding Standard
 
@@ -137,8 +134,7 @@ The PHP constants `true`, `false`, and `null` MUST be in lower case.
 
 
 
-3. Namespace and Use Declarations
----------------------------------
+## 3. Namespace and Use Declarations
 
 When present, there MUST be one blank line after the `namespace` declaration.
 
@@ -164,8 +160,7 @@ use OtherVendor\OtherPackage\BazClass;
 ~~~
 
 
-4. Classes, Properties, and Methods
------------------------------------
+## 4. Classes, Properties, and Methods
 
 The term "class" refers to all classes, interfaces, and traits.
 
@@ -361,8 +356,7 @@ $foo->bar(
 );
 ~~~
 
-5. Control Structures
----------------------
+## 5. Control Structures
 
 The general style rules for control structures are as follows:
 
@@ -491,8 +485,7 @@ try {
 }
 ~~~
 
-6. Closures
------------
+## 6. Closures
 
 Closures MUST be declared with a space after the `function` keyword, and a
 space before and after the `use` keyword.
@@ -598,8 +591,7 @@ $foo->bar(
 ~~~
 
 
-7. Conclusion
---------------
+## 7. Conclusion
 
 There are many elements of style and practice intentionally omitted by this
 guide. These include but are not limited to:
@@ -622,8 +614,7 @@ Future recommendations MAY revise and extend this guide to address those or
 other elements of style and practice.
 
 
-Appendix A. Survey
-------------------
+## Appendix A. Survey
 
 In writing this style guide, the group took a survey of member projects to
 determine common practices.  The survey is retained herein for posterity.


### PR DESCRIPTION
Hi,

Had attempted to link to `3. Namespace and Use Declarations`, though the lack of a heading meant that this wasn't possible. I've tweaked the formatting slightly to take advantage of what GHFM adds for free…
