### PR TITLE
fix_wrong_word_spelling Update PSR-6-cache.md

### DIFF
--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -45,7 +45,7 @@ below with whole-second granularity.
 when that item is stored and it is considered stale. The TTL is normally defined
 by an integer representing time in seconds, or a DateInterval object.
 
-*    **Expiration** - The actual time when an item is set to go stale. This it
+*    **Expiration** - The actual time when an item is set to go stale. This is
 typically calculated by adding the TTL to the time when an object is stored, but
 may also be explicitly set with DateTime object.
 


### PR DESCRIPTION
i think the psr-6 has a wrong word spelling ,  the word 'it' should be 'is' , pls check my pr and thx