### PR TITLE
[PSR-16] Fix typehint for DateInterval

### DIFF
--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -157,11 +157,11 @@ interface CacheInterface
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
      *
-     * @param string                $key   The key of the item to store.
-     * @param mixed                 $value The value of the item to store, must be serializable.
-     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
-     *                                     the driver supports TTL then the library may set a default value
-     *                                     for it or let the driver take care of that.
+     * @param string                 $key   The key of the item to store.
+     * @param mixed                  $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
      *
      * @return bool True on success and false on failure.
      *
@@ -206,10 +206,10 @@ interface CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable              $values A list of key => value pairs for a multiple-set operation.
-     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
-     *                                      the driver supports TTL then the library may set a default value
-     *                                      for it or let the driver take care of that.
+     * @param iterable               $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     *                                       the driver supports TTL then the library may set a default value
+     *                                       for it or let the driver take care of that.
      *
      * @return bool True on success and false on failure.
      *


### PR DESCRIPTION
Currently the typehint in the interface points to `null|int|DateInterval`. DateInterval is a reference to the non-existing \Psr\SimpleCache\DateInterval class, whereas \DateInterval was intended. This throws off IDE's such as PHPStorm.