### PR TITLE
Fix markdown syntax for heading levels

### DIFF
--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -14,8 +14,7 @@ interfaces/functionality first.
 
 [RFC 2119]: http://tools.ietf.org/html/rfc2119
 
-1. Specification
------------------
+# 1. Specification
 
 ## 1.1 Introduction
 
@@ -31,7 +30,7 @@ standardized streamlined interface for common cases.  It is independent of
 PSR-6 but has been designed to make compatibility with PSR-6 as straightforward
 as possible.
 
-### 1.2 Definitions
+## 1.2 Definitions
 
 Definitions for Calling Library, Implementing Library, TTL, Expiration and Key
 are copied from PSR-6 as the same assumptions are true.
@@ -83,7 +82,7 @@ supported by implementing libraries: `{}()/\@:`
 if one stored `null` is not possible. This is the main deviation from PSR-6's
 assumptions.
 
-### 1.3 Cache
+## 1.3 Cache
 
 Implementations MAY provide a mechanism for a user to specify a default TTL
 if one is not specified for a specific cache item.  If no user-specified default
@@ -91,7 +90,7 @@ is provided implementations MUST default to the maximum legal value allowed by
 the underlying implementation.  If the underlying implementation does not
 support TTL, the user-specified TTL MUST be silently ignored.
 
-### 1.4 Data
+## 1.4 Data
 
 Implementing libraries MUST support all serializable PHP data types, including:
 
@@ -117,10 +116,9 @@ If it is not possible to return the exact saved value for any reason, implementi
 libraries MUST respond with a cache miss rather than corrupted data.
 
 
-2. Interfaces
--------------
+# 2. Interfaces
 
-### 2.1 CacheInterface
+## 2.1 CacheInterface
 
 The cache interface defines the most basic operations on a collection of cache-entries, which
 entails basic reading, writing and deleting individual cache items.
@@ -251,7 +249,8 @@ interface CacheInterface
 }
 ~~~
 
-### 2.2 CacheException
+## 2.2 CacheException
+
 ~~~php
 
 <?php
@@ -265,7 +264,7 @@ interface CacheException
 }
 ~~~
 
-### 2.3 InvalidArgumentException
+## 2.3 InvalidArgumentException
 
 ~~~php
 <?php


### PR DESCRIPTION
Minor issues with the markdown syntax causes 1st level headings not to be rendered properly.

Also, increase levels of headings for X.Y sections from 3rd level to 2nd level, where they belong.