### PR TITLE
Add Strix to PSR-11 Meta

### DIFF
--- a/accepted/PSR-11-container-meta.md
+++ b/accepted/PSR-11-container-meta.md
@@ -315,6 +315,7 @@ At the time of writing, the following projects already implement and/or consume 
 - [Njasm Container](https://github.com/njasm/container)
 - [PHP-DI](http://php-di.org)
 - [PimpleInterop](https://github.com/moufmouf/pimple-interop)
+- [Strix](https://github.com/anned20/strix)
 - [XStatic](https://github.com/jeremeamia/xstatic)
 - [Zend ServiceManager](https://github.com/zendframework/zend-servicemanager)
 


### PR DESCRIPTION
I'd like my new implementation of PSR-11 to be added to the PSR-11 Meta document. 

https://anned20.github.io/Strix/