### PR TITLE
Remove `Http` prefix from `HttpClient`.

### DIFF
--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -30,7 +30,7 @@ should not follow redirect nor throw exceptions on HTTP responses with status 4x
 The following interfaces MAY be implemented together within a single class or
 in separate classes.
 
-### ClientInterface
+### Client interface
 
 ```php
 namespace Psr\Http\Client;

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -73,7 +73,7 @@ namespace Psr\Http\Client;
 /**
  * Every HTTP client related Exception MUST implement this interface.
  */
-interface ClientException
+interface ClientException extends \Throwable
 {
 }
 ```

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -30,7 +30,7 @@ should not follow redirect nor throw exceptions on HTTP responses with status 4x
 The following interfaces MAY be implemented together within a single class or
 in separate classes.
 
-### Client interface
+### ClientInterface
 
 ```php
 namespace Psr\Http\Client;
@@ -38,7 +38,7 @@ namespace Psr\Http\Client;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-interface Client
+interface ClientInterface
 {
     /**
      * Sends a PSR-7 request.


### PR DESCRIPTION
This will replace https://github.com/php-http/fig-standards/pull/42

@dbu or @sagikazarmark, could you approve this again?