### PR TITLE
A HTTP client must never throw exception on 4xx or 5xx

### DIFF
--- a/proposed/http-client/http-client-meta.md
+++ b/proposed/http-client/http-client-meta.md
@@ -41,8 +41,7 @@ specify the default behaviours.
 The intention of this PSR is to provide library developers with HTTP clients that 
 have a well defined behaviour. A library should be able to use any compliant client
 without special code to handle client implementation details (Liskov substitution
-principle). The PSR does not try to restrict nor define configuration interface 
-for HTTP clients. 
+principle). The PSR does not try to restrict nor define how to configure HTTP clients. 
 
 An alternative approach would be to pass configuration to the client. That approach
 would have a few drawbacks: 

--- a/proposed/http-client/http-client-meta.md
+++ b/proposed/http-client/http-client-meta.md
@@ -39,10 +39,8 @@ specify the default behaviours.
 ### Default behavior
 
 The intention of this PSR is ensure library developers that all HTTP clients have the same 
-**default behavior**. That means that all HTTP clients MUST follow Liskov substitution principle
-when no configuration is provided. The PSR does not try to restrict nor define configuration for 
-HTTP clients. An implementing library is free to be configured by the application author to follow
-redirects, to throw exceptions or any other possible setting.  
+behavior. That means that all HTTP clients MUST follow Liskov substitution principle. 
+The PSR does not try to restrict nor define configuration for HTTP clients. 
 
 An alternative approach would be to pass configuration to the client. That approach would have
 a few drawbacks: 
@@ -53,9 +51,9 @@ a few drawbacks:
 
 ### Exceptions
 
-The domain exceptions `NetworkException`, `RequestException` and `HttpException` define
+The domain exceptions `NetworkException` and `RequestException` define
 a contract very similar to each other. The chosen approach is to not let them extend each other
-because inheritance does not make sense in the domain model. A `RequestException` is not a
+because inheritance does not make sense in the domain model. A `RequestException` is simply not a
 `NetworkException`.
 
 Allowing exception to extend a `RequestAwareException` and/or `ResponseAwareException` interface

--- a/proposed/http-client/http-client-meta.md
+++ b/proposed/http-client/http-client-meta.md
@@ -38,12 +38,14 @@ specify the default behaviours.
 
 ### Default behavior
 
-The intention of this PSR is ensure library developers that all HTTP clients have the same 
-behavior. That means that all HTTP clients MUST follow Liskov substitution principle. 
-The PSR does not try to restrict nor define configuration for HTTP clients. 
+The intention of this PSR is to provide library developers with HTTP clients that 
+have a well defined behaviour. A library should be able to use any compliant client
+without special code to handle client implementation details (Liskov substitution
+principle). The PSR does not try to restrict nor define configuration interface 
+for HTTP clients. 
 
-An alternative approach would be to pass configuration to the client. That approach would have
-a few drawbacks: 
+An alternative approach would be to pass configuration to the client. That approach
+would have a few drawbacks: 
 
 * Configuration must be defined by the PSR
 * All client must support the defined configuration

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -41,12 +41,9 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientInterface
 {
     /**
-     * Sends a PSR-7 request.
-     *
-     * If a request is sent without any prior configuration, an exception MUST NOT be thrown
-     * when a response is recieved, no matter the HTTP status code.
-     *
-     * If a request is sent without any prior configuration, a HTTP client MUST NOT follow redirects.
+     * Sends a PSR-7 request and returns a PSR-7 response. No response will get a special treatment. Ie: 
+     *   - Redirects will not be followed
+     *   - No exceptions will be thrown on 4xx or 5xx responses 
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to Client::sendRequest will be the same
@@ -136,39 +133,5 @@ interface NetworkException extends ClientException
 }
 ```
 
-
-### HttpException
-
-```php
-namespace Psr\Http\Client\Exception;
-
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Client\ClientException;
-
-/**
- * Thrown when a response was received but the request itself failed.
- *
- * This exception MAY be thrown on HTTP response codes 4xx and 5xx.
- * This exception MUST NOT be thrown when using the client's default configuration.
- */
-interface HttpException extends ClientException
-{
-    /**
-     * Returns the request.
-     *
-     * The request object MAY be a different object from the one passed to Client::sendRequest()
-     *
-     * @return RequestInterface
-     */
-    public function getRequest();
-
-    /**
-     * Returns the response.
-     *
-     * @return ResponseInterface
-     */
-    public function getResponse();
-}
-```
 
 [Liskov]: https://en.wikipedia.org/wiki/Liskov_substitution_principle

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -41,7 +41,7 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientInterface
 {
     /**
-     * Sends a PSR-7 request and returns a PSR-7 response. Every technically correct HTTP respons 
+     * Sends a PSR-7 request and returns a PSR-7 response. Every technically correct HTTP response 
      * MUST be returned as is, even if it represents a HTTP error response or a redirect instruction.
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -44,8 +44,8 @@ interface ClientInterface
      * Sends a PSR-7 request and returns a PSR-7 response. 
      * 
      * Every technically correct HTTP response MUST be returned as is, even if it represents a HTTP 
-     * error response or a redirect instruction. The only exception is 100 request which MUST be 
-     * put together in the HTTP client. 
+     * error response or a redirect instruction. The only exception is 1xx responses which MUST be 
+     * assembled in the HTTP client. 
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to Client::sendRequest will be the same

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -41,8 +41,10 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientInterface
 {
     /**
-     * Sends a PSR-7 request and returns a PSR-7 response. Every technically correct HTTP response 
-     * MUST be returned as is, even if it represents a HTTP error response or a redirect instruction.
+     * Sends a PSR-7 request and returns a PSR-7 response. 
+     * 
+     * Every technically correct HTTP response MUST be returned as is, even if it represents a HTTP 
+     * error response or a redirect instruction.
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to Client::sendRequest will be the same

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -41,9 +41,8 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientInterface
 {
     /**
-     * Sends a PSR-7 request and returns a PSR-7 response. No response will get a special treatment. Ie: 
-     *   - Redirects will not be followed
-     *   - No exceptions will be thrown on 4xx or 5xx responses 
+     * Sends a PSR-7 request and returns a PSR-7 response. Every technically correct HTTP respons 
+     * MUST be returned as is, even if it represents a HTTP error response or a redirect instruction.
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to Client::sendRequest will be the same

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -44,7 +44,8 @@ interface ClientInterface
      * Sends a PSR-7 request and returns a PSR-7 response. 
      * 
      * Every technically correct HTTP response MUST be returned as is, even if it represents a HTTP 
-     * error response or a redirect instruction.
+     * error response or a redirect instruction. The only exception is 100 request which MUST be 
+     * put together in the HTTP client. 
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to Client::sendRequest will be the same


### PR DESCRIPTION
This will address issues in https://github.com/php-http/fig-standards/pull/34, https://github.com/php-http/fig-standards/issues/41 and https://github.com/php-http/fig-standards/issues/28