### PR TITLE
Adds missing `;` terminating signature definitions

### DIFF
--- a/proposed/http-handlers/request-handlers.md
+++ b/proposed/http-handlers/request-handlers.md
@@ -95,7 +95,7 @@ interface RequestHandlerInterface
      *
      * @return ResponseInterface
      */
-    public function handle(ServerRequestInterface $request): ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface;
 }
 ```
 
@@ -125,6 +125,6 @@ interface MiddlewareInterface
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface;
 }
 ```


### PR DESCRIPTION
PR #950 updated the interfaces to use PHP 7 return type hints; however, in doing so, it accidentally dropped the tailing semi-colons in the interface method signatures. This patch simply adds them back.