### PR TITLE
Editing: Re-word lead sentence

### DIFF
--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -156,7 +156,7 @@ methods that are included are generally similar with the proposed factories.
 
 ### 4.3 Potential Issues
 
-The most difficult part is defining the method signatures for the interfaces.
+The most difficult task in establishing this standard will be defining the method signatures for the interfaces.
 As there is no clear declaration in PSR-7 as to what values are explicitly
 required, the properties that are read-only must be inferred based on whether
 the interfaces have methods to copy-and-modify the object.

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -156,10 +156,11 @@ methods that are included are generally similar with the proposed factories.
 
 ### 4.3 Potential Issues
 
-The most difficult task in establishing this standard will be defining the method signatures for the interfaces.
-As there is no clear declaration in PSR-7 as to what values are explicitly
-required, the properties that are read-only must be inferred based on whether
-the interfaces have methods to copy-and-modify the object.
+The most difficult task in establishing this standard will be defining the
+method signatures for the interfaces. As there is no clear declaration in PSR-7
+as to what values are explicitly required, the properties that are read-only
+must be inferred based on whether the interfaces have methods to copy-and-modify
+the object.
 
 ## 5. Design Decisions
 


### PR DESCRIPTION
For reviewing purposes, this PR is in two commits:

632dea0 has the proposed wording change
a0cf0c0 reflows the text post change and is simply a whitespace commit


As it stands the lead sentence in the 'Potential Issues' section
is both a fragment and not clear.