### PR TITLE
Adding return types

### DIFF
--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -78,7 +78,7 @@ interface ClientInterface
      *
      * @throws \Psr\Http\Client\Exception If an error happens during processing the request.
      */
-    public function sendRequest(RequestInterface $request): Response;
+    public function sendRequest(RequestInterface $request): ResponseInterface;
 }
 ```
 

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -78,7 +78,7 @@ interface ClientInterface
      *
      * @throws \Psr\Http\Client\Exception If an error happens during processing the request.
      */
-    public function sendRequest(RequestInterface $request);
+    public function sendRequest(RequestInterface $request): Response;
 }
 ```
 
@@ -121,7 +121,7 @@ interface RequestException extends ClientException
      *
      * @return RequestInterface
      */
-    public function getRequest();
+    public function getRequest(): RequestInterface;
 }
 ```
 
@@ -149,7 +149,7 @@ interface NetworkException extends ClientException
      *
      * @return RequestInterface
      */
-    public function getRequest();
+    public function getRequest(): RequestInterface;
 }
 ```
 


### PR DESCRIPTION
We are already PHP7 only be using `\Throwable`. This should be a no-brainer. =)