### PR TITLE
Corrected return type

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -526,7 +526,7 @@ namespace Vendor\Package;
 
 class ReturnTypeVariations
 {
-    public function functionName(?string $arg1, ?int $arg2): ?bool
+    public function functionName(?string $arg1, ?int $arg2): ?string
     {
         return 'foo';
     }


### PR DESCRIPTION
This return type hint was bool, but the method returns a string