### PR TITLE
Extend Exception, not Throwable

### DIFF
--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -90,7 +90,7 @@ namespace Psr\Http\Client;
 /**
  * Every HTTP client related Exception MUST implement this interface.
  */
-interface ClientException extends \Throwable
+interface ClientException extends \Exception
 {
 }
 ```


### PR DESCRIPTION
Per the [PHP Manual](http://php.net/Throwable), PHP classes cannot extend `Throwable`, but must instead extend `Exception`.