### PR TITLE
`declare` must follow the rule for assignment operator

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -39,7 +39,7 @@ This example encompasses some of the rules below as a quick overview:
 ~~~php
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Vendor\Package;
 
@@ -152,7 +152,7 @@ The following example illustrates a complete list of all blocks:
  * This file contains an example of coding styles.
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Vendor\Package;
 
@@ -206,7 +206,7 @@ the strict types declaration and closing tag.
 
 For example:
 ~~~php
-<?php declare(strict_types=1) ?>
+<?php declare(strict_types = 1) ?>
 <html>
 <body>
     <?php
@@ -216,13 +216,13 @@ For example:
 </html>
 ~~~
 
-Declare statements MUST contain no spaces and MUST be exactly `declare(strict_types=1)`
+Declare statements MUST be exactly `declare(strict_types = 1)`
 (with an optional semi-colon terminator).
 
 Block declare statements are allowed and MUST be formatted as below. Note position of
 braces and spacing:
 ~~~php
-declare(ticks=1) {
+declare(ticks = 1) {
     //some code
 }
 ~~~
@@ -507,7 +507,7 @@ the two characters. The declaration keyword (e.g. string) MUST be lowercase.
 ~~~php
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Vendor\Package;
 
@@ -534,7 +534,7 @@ and the type.
 ~~~php
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Vendor\Package;
 


### PR DESCRIPTION
`declare` statements must follow the rule for assignment operator which dictates to have exactly 1 space around the operator.

There was no reason to make it an exception. It made the rule harder to explain, and harder to remember. By keeping a single rule for all cases everything is made simpler.