### PR TITLE
Removed statement on method of enforcement of line length limits

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -90,8 +90,7 @@ The closing `?>` tag MUST be omitted from files containing only PHP.
 
 There MUST NOT be a hard limit on line length.
 
-The soft limit on line length MUST be 120 characters; automated style checkers
-MUST warn but MUST NOT error at the soft limit.
+The soft limit on line length MUST be 120 characters.
 
 Lines SHOULD NOT be longer than 80 characters; lines longer than that SHOULD
 be split into multiple subsequent lines of no more than 80 characters each.


### PR DESCRIPTION
First of all, I know that it is specifically stated as a non-goal of this PSR to change anything in PSR-2. However, I think this statement is a mistake, and since PSR-2 is accepted and cannot be modified, this is the place to do it.

I and my colleagues don't think it should be the place of this PSR to dictate how the standards within it are enforced - only to define those standards. We believe that outputting warnings for items which aren't fully enforced is harmful, in that it creates noise amongst the real errors and warnings, and trains people to ignore warnings when they occur.

I don't know if this is the right way to approach this issue, or to start a discussion on it, but feel free to move or close this down if it's the wrong place.