### PR TITLE
[PSR-15] Provide middleware dispatch examples

### DIFF
--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -276,6 +276,13 @@ and a request handler and must return a response. The middleware may:
 - Create and return a response without passing the request to the request handler,
   thereby handling the request itself.
 
+When delegating from one middleware to another in a sequence, one approach for
+dispatching systems is to use an intermediary request handler composing the
+middleware sequence as a way to link middleware together. The final or innermost
+middleware will act as a gateway to application code and generate a response
+from its results; alternately, the middleware MAY delegate this responsibility
+to a dedicated request handler.
+
 #### Why doesn't middleware use `__invoke`?
 
 Doing so would conflict with existing middleware that implements the double-pass

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -276,9 +276,11 @@ and a request handler and must return a response. The middleware may:
 - Create and return a response without passing the request to the request handler,
   thereby handling the request itself.
 
-It is expected that a middleware dispatching system will use the request handler
-to delegate response creation to the next available middleware. The last middleware
-would then act as a domain gateway to execute application code.
+When delegating from one middleware to the next in a sequence, a dispatching
+system should use an intermediary request handler as a way to link middleware
+together. The final or innermost middleware will act as a gateway to application
+code and generate a response from its results; alternately, the middleware may
+delegate this responsibility to a _request handler_.
 
 #### Why doesn't middleware use `__invoke`?
 

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -455,7 +455,7 @@ instance and a fallback request handler to pass to it. The application is built
 from the outside-in, passing each request handler "layer" to the next outer one.
 
 ```php
-class DecoratedRequestHandler implements RequestHandlerInterface
+class DecoratingRequestHandler implements RequestHandlerInterface
 {
     private $middleware;
     private $nextHandler;
@@ -489,8 +489,8 @@ $innerHandler = new class ($responsePrototype) implements RequestHandlerInterfac
     }
 };
 
-$layer1 = new DecoratedRequestHandler(new RoutingMiddleware(), $innerHandler);
-$layer2 = new DecoratedRequestHandler(new AuthorizationMiddleware(), $layer1);
+$layer1 = new DecoratingRequestHandler(new RoutingMiddleware(), $innerHandler);
+$layer2 = new DecoratingRequestHandler(new AuthorizationMiddleware(), $layer1);
 
 $response = $layer2->handle(ServerRequestFactory::fromGlobals());
 ```

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -535,24 +535,20 @@ The `AuthorizationMiddleware` is one that will exercise all three of these guide
 class AuthorizationMiddleware implements MiddlewareInterface
 {
     private $authorizationMap;
-    private $responsePrototype;
 
-    public function __construct(
-        AuthorizationMap $authorizationMap,
-        ResponseInterface $responsePrototype
-    ) {
+    public function __construct(AuthorizationMap $authorizationMap)
+    {
         $this->authorizationMap = $authorizationMap;
-        $this->responsePrototype = $responsePrototype;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (! $authorizationMap->requestRequiresAuthorization($request)) {
+        if (! $authorizationMap->needsAuthorization($request)) {
             return $handler->handle($request);
         }
 
         if (! $authorizationMap->isAuthorized($request)) {
-            return $authorizationMap->prepareUnauthorizedResponse($this->responsePrototype);
+            return $authorizationMap->prepareUnauthorizedResponse();
         }
 
         $response = $handler->handle($request);
@@ -561,12 +557,9 @@ class AuthorizationMiddleware implements MiddlewareInterface
 }
 ```
 
-Note the use of a "response prototype" in the above example; this approach
-allows the middleware to be agnostic of which PSR-7 implementation is in use,
-and yet still return a response in cases where it determines it should not
-delegate to the handler. Similarly, it is not concerned with how the request
-handler is implemented; it merely uses it to produce a response when
-pre-conditions have been met.
+Note that the middleware is not concerned with how the request handler is
+implemented; it merely uses it to produce a response when pre-conditions have
+been met.
 
 The `RoutingMiddleware` implementation described below follows a similar
 process: it analyzes the request to see if it matches known routes. In this

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -514,7 +514,8 @@ In the examples above, we have two middleware composed in each. In order for
 these to work in either situation, we need to write them such that they interact
 appropriately.
 
-Generally speaking, implementors of middleware should follow these guidelines:
+Implementors of middleware striving for maximum interoperability may want to
+consider the following guidelines:
 
 - Test the request for a required condition. If it does not satisfy that
   condition, use a composed prototype response or a composed response factory

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -276,12 +276,6 @@ and a request handler and must return a response. The middleware may:
 - Create and return a response without passing the request to the request handler,
   thereby handling the request itself.
 
-When delegating from one middleware to the next in a sequence, a dispatching
-system should use an intermediary request handler as a way to link middleware
-together. The final or innermost middleware will act as a gateway to application
-code and generate a response from its results; alternately, the middleware may
-delegate this responsibility to a dedicated request handler.
-
 #### Why doesn't middleware use `__invoke`?
 
 Doing so would conflict with existing middleware that implements the double-pass

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -389,6 +389,7 @@ The working group would also like to acknowledge the contributions of:
 ## 8. Votes
 
 * [Working Group Formation](https://groups.google.com/d/msg/php-fig/rPFRTa0NODU/tIU9BZciAgAJ)
+* [Review Period Initiation](https://groups.google.com/d/msg/php-fig/mfTrFinTvEM/PiYvU2S6BAAJ)
 
 ## 9. Relevant Links
 

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -371,11 +371,9 @@ be used in conjunction with middleware queues and stacks.)
 ### 6.3 Example Interface Interactions
 
 The two interfaces, `RequestHandlerInterface` and `MiddlewareInterface`, were
-designed to work in conjunction with one another. While a
-`RequestHandlerInterface` can feasibly be used in isolation, it gains more power
-when used as a part of a middleware dispatch system. Middleware gains more
-flexibility by being de-coupled from any over-arching application layer, and
-instead only relying on the provided request handler to produce a response.
+designed to work in conjunction with one another. Middleware gains flexibility
+when de-coupled from any over-arching application layer, and instead only
+relying on the provided request handler to produce a response.
 
 Two approaches to middleware dispatch systems that the Working Group observed
 and/or implemented are demonstrated below. Additionally, examples of re-usable

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -478,6 +478,9 @@ class DecoratedRequestHandler implements RequestHandlerInterface
     }
 }
 
+// Create a response prototype to return if no middleware can produce a response
+// on its own. This could be a 404, 500, or default page.
+$responsePrototype = (new Response())->withStatus(404);
 $innerHandler = new class ($responsePrototype) implements RequestHandlerInterface {
     private $responsePrototype;
 

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -447,7 +447,7 @@ This approach has the following benefits:
 
 - Middleware does not need to know anything about any other middleware or how it
   is composed in the application.
-- The `QueueRequestHandler` is agnostic of the PSR-7 implementation in use
+- The `QueueRequestHandler` is agnostic of the PSR-7 implementation in use.
 - Middleware is executed in the order it is added to the application, making the
   code explicit.
 
@@ -565,7 +565,7 @@ class CorsMiddleware implements MiddlewareInterface
 Note the use of a "response prototype" in the above example; this approach
 allows the middleware to be agnostic of which PSR-7 implementation is in use,
 and yet still return a response in cases where it determines it should not
-delegate to the handler.Similarly, it is not concerned with how the request
+delegate to the handler. Similarly, it is not concerned with how the request
 handler is implemented; it merely uses it to produce a response when
 pre-conditions have been met.
 

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -280,7 +280,7 @@ When delegating from one middleware to the next in a sequence, a dispatching
 system should use an intermediary request handler as a way to link middleware
 together. The final or innermost middleware will act as a gateway to application
 code and generate a response from its results; alternately, the middleware may
-delegate this responsibility to a _request handler_.
+delegate this responsibility to a dedicated request handler.
 
 #### Why doesn't middleware use `__invoke`?
 

--- a/proposed/http-handlers/request-handlers-meta.md
+++ b/proposed/http-handlers/request-handlers-meta.md
@@ -402,7 +402,7 @@ class QueueRequestHandler implements RequestHandlerInterface
         $this->middleware[] = $middleware;
     }
     
-    public function handle(ServerRequestInterface $request) : ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         // Last middleware in the queue has called on the request handler.
         if (0 === count($this->middleware)) {
@@ -466,7 +466,7 @@ class DecoratedRequestHandler implements RequestHandlerInterface
         $this->nextHandler = $nextHandler;
     }
 
-    public function handle(ServerRequestInterface $request) : ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return $this->middleware->process($request, $this->nextHandler);
     }
@@ -483,7 +483,7 @@ $innerHandler = new class ($responsePrototype) implements RequestHandlerInterfac
         $this->responsePrototype = $responsePrototype;
     }
 
-    public function handle(ServerRequestInterface $request) : ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return $this->responsePrototype;
     }
@@ -545,7 +545,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
         $this->responsePrototype = $responsePrototype;
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (! $authorizationMap->requestRequiresAuthorization($request)) {
             return $handler->handle($request);
@@ -585,7 +585,7 @@ class RoutingMiddleware implements MiddlewareInterface
         $this->router = $router;
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $result = $this->router->match($request);
 

--- a/proposed/http-handlers/request-handlers.md
+++ b/proposed/http-handlers/request-handlers.md
@@ -112,8 +112,8 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Participant in processing a server request and response
  *
- * An HTTP middleware component participates in processing an HTTP message,
- * either by acting on the request, generating the response, or forwarding the
+ * An HTTP middleware component participates in processing an HTTP message;
+ * for example, by acting on the request, generating the response, or forwarding the
  * request to a subsequent middleware and possibly acting on its response.
  */
 interface MiddlewareInterface

--- a/proposed/http-handlers/request-handlers.md
+++ b/proposed/http-handlers/request-handlers.md
@@ -112,8 +112,8 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Participant in processing a server request and response
  *
- * An HTTP middleware component participates in processing an HTTP message;
- * for example, by acting on the request, generating the response, or forwarding the
+ * An HTTP middleware component participates in processing an HTTP message:
+ * by acting on the request, generating the response, or forwarding the
  * request to a subsequent middleware and possibly acting on its response.
  */
 interface MiddlewareInterface

--- a/proposed/http-handlers/request-handlers.md
+++ b/proposed/http-handlers/request-handlers.md
@@ -52,6 +52,12 @@ the creation of a resulting response, as defined by PSR-7.
 A middleware component MAY create and return a response without delegating to
 a request handler, if sufficient conditions are met.
 
+When delegating from one middleware to the next in a sequence, a dispatching
+system should use an intermediary request handler as a way to link middleware
+together. The final or innermost middleware will act as a gateway to application
+code and generate a response from its results; alternately, the middleware may
+delegate this responsibility to a dedicated request handler.
+
 Middleware using this standard MUST implement the following interface:
 
 - `Psr\Http\Server\MiddlewareInterface`

--- a/proposed/http-handlers/request-handlers.md
+++ b/proposed/http-handlers/request-handlers.md
@@ -52,12 +52,6 @@ the creation of a resulting response, as defined by PSR-7.
 A middleware component MAY create and return a response without delegating to
 a request handler, if sufficient conditions are met.
 
-When delegating from one middleware to the next in a sequence, a dispatching
-system should use an intermediary request handler as a way to link middleware
-together. The final or innermost middleware will act as a gateway to application
-code and generate a response from its results; alternately, the middleware may
-delegate this responsibility to a dedicated request handler.
-
 Middleware using this standard MUST implement the following interface:
 
 - `Psr\Http\Server\MiddlewareInterface`


### PR DESCRIPTION
Per discussions on #987, on the mailing list, and in the PSR-15 working group, this patch builds on #987 to add a new section 6.3 to the meta document, detailing "Example Interface Interactions".

The section covers the following:

- A queue-based request handler that aggregates and dispatches middleware.
- A decorator-based request handler for building a layered dispatch mechanism.
- Two examples of re-usable middleware to demonstrate de-coupling from the application and the request handler.
  
This patch incorporates feedback made on #987, but not incorporated there.
  