### PR TITLE
[PSR16] Fix broken formatting under "Expiration"

### DIFF
--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -50,21 +50,21 @@ below with whole-second granularity.
 when that item is stored and it is considered stale. The TTL is normally defined
 by an integer representing time in seconds, or a DateInterval object.
 
-*    **Expiration** - The actual time when an item is set to go stale. This is
-calculated by adding the TTL to the time when an object is stored.
+* **Expiration** - The actual time when an item is set to go stale. This is
+  calculated by adding the TTL to the time when an object is stored.
 
-    An item with a 300 second TTL stored at 1:30:00 will have an expiration of 1:35:00.
+  An item with a 300 second TTL stored at 1:30:00 will have an expiration of 1:35:00.
 
-    Implementing Libraries MAY expire an item before its requested Expiration Time,
-but MUST treat an item as expired once its Expiration Time is reached. If a calling
-library asks for an item to be saved but does not specify an expiration time, or
-specifies a null expiration time or TTL, an Implementing Library MAY use a configured
-default duration. If no default duration has been set, the Implementing Library
-MUST interpret that as a request to cache the item forever, or for as long as the
-underlying implementation supports.
+  Implementing Libraries MAY expire an item before its requested Expiration Time,
+  but MUST treat an item as expired once its Expiration Time is reached. If a calling
+  library asks for an item to be saved but does not specify an expiration time, or
+  specifies a null expiration time or TTL, an Implementing Library MAY use a configured
+  default duration. If no default duration has been set, the Implementing Library
+  MUST interpret that as a request to cache the item forever, or for as long as the
+  underlying implementation supports.
 
-    If a negative or zero TTL is provided, the item MUST be deleted from the cache
-if it exists, as it is expired already.
+  If a negative or zero TTL is provided, the item MUST be deleted from the cache
+  if it exists, as it is expired already.
 
 *    **Key** - A string of at least one character that uniquely identifies a
 cached item. Implementing libraries MUST support keys consisting of the


### PR DESCRIPTION
The previous syntax was causing most text under "Expiration"
to be rendered as pre-formatted (using `<pre>`).

In order for text to render normally, and in order for it to be
indented under the same list item, with empty lines in-between,
all additional lines must be indented with the same number of spaces,
specifically no more than two it seems (previously some indented with
four or more, which triggers `<pre>`, and makes the rest fallback
to regular paragraphs outside any list item, after which the next bullet
point would start a new list).

------

See <https://www.php-fig.org/psr/psr-16/>, current rendering:

<img width="888" alt="screen shot 2018-03-04 at 20 08 53" src="https://user-images.githubusercontent.com/156867/36957227-e01fa47e-1fe7-11e8-8bc8-de5c0b29171a.png">


And similarly broken rendering within GitHub, at <https://github.com/php-fig/fig-standards/blob/6d44cdf2f06ab2440212facbaa3f3e787b24875d/accepted/PSR-16-simple-cache.md>

<img width="1163" alt="screen shot 2018-03-04 at 20 09 10" src="https://user-images.githubusercontent.com/156867/36957246-f2e26c9a-1fe7-11e8-955f-b5574a58436b.png">
