### PR TITLE
PSR-17: Incorporate interface changes proposed within working group

### DIFF
--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -128,7 +128,7 @@ that create a resource from a file path.
 - [`Request`][slim-request] Requires `string $method`, `UriInterface $uri`,
   `HeadersInterface $headers`, `array $cookies`, `array $serverParams`, and
   `StreamInterface $body`. Contains a factory method `createFromEnvironment(Environment $environment)`
-  that is framework specific but analogous to the proposed `createServerRequestFromGlobals`.
+  that is framework specific but analogous to the proposed `createServerRequestFromArray`.
 - [`Response`][slim-response] No required parameters, status code defaults to `200`.
 - [`Stream`][slim-stream] Requires `resource $stream` for the body.
 - [`UploadedFile`][slim-uploaded-file] Requires `string $file` for the source file.

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -122,7 +122,7 @@ that create a resource from a file path.
 
 #### 4.2.3 Slim
 
-Slim is a popular micro-framework that makes use of HTTP Messages from version
+[Slim][slim] is a popular micro-framework that makes use of HTTP Messages from version
 3.0 forward.
 
 - [`Request`][slim-request] Requires `string $method`, `UriInterface $uri`,
@@ -142,6 +142,7 @@ Slim is a popular micro-framework that makes use of HTTP Messages from version
 _Being geared towards server usage only, Slim does not contain an implementation
 of `Request`. The implementation listed above is an implementation of `ServerRequest`._
 
+[slim]: https://www.slimframework.com/
 [slim-request]: https://github.com/slimphp/Slim/blob/30cfe3c07dac28ec1129c0577e64b90ba11a54c4/Slim/Http/Request.php#L170-L178
 [slim-response]: https://github.com/slimphp/Slim/blob/30cfe3c07dac28ec1129c0577e64b90ba11a54c4/Slim/Http/Response.php#L123
 [slim-stream]: https://github.com/slimphp/Slim/blob/30cfe3c07dac28ec1129c0577e64b90ba11a54c4/Slim/Http/Stream.php#L96

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -95,7 +95,7 @@ The proposed uploaded file factory allows for size and error status to be option
 
 #### 4.2.2 Guzzle
 
-Guzzle is currently the most popular HTTP Messages implementation for client usage.
+[Guzzle][guzzle] is currently the most popular HTTP Messages implementation for client usage.
 
 - [`Request`][guzzle-request] Requires both `string $method` and `string|UriInterface $uri`.
 - [`Response`][guzzle-response] No required parameters, status code defaults to `200`.
@@ -105,6 +105,7 @@ Guzzle is currently the most popular HTTP Messages implementation for client usa
 _Being geared towards client usage, Guzzle does not contain a `ServerRequest` or
 `UploadedFile` implementation._
 
+[guzzle]: https://github.com/guzzle/psr7
 [guzzle-request]: https://github.com/guzzle/psr7/blob/58828615f7bb87013ce6365e9b1baa08580c7fc8/src/Request.php#L32-L38
 [guzzle-response]: https://github.com/guzzle/psr7/blob/58828615f7bb87013ce6365e9b1baa08580c7fc8/src/Response.php#L88-L94
 [guzzle-stream]: https://github.com/guzzle/psr7/blob/58828615f7bb87013ce6365e9b1baa08580c7fc8/src/Stream.php#L51

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -161,7 +161,39 @@ As there is no clear declaration in PSR-7 as to what values are explicitly
 required, the properties that are read-only must be inferred based on whether
 the interfaces have methods to copy-and-modify the object.
 
-## 5. People
+## 5. Design Decisions
+
+### 6.1 Why multiple interfaces?
+
+Each proposed interface is (primarily) responsible for producing one PSR-7 type.
+This allows consumers to typehint on exactly what they need: if they need a
+response, they typehint on `ResponseFactoryInterface`; if they need a URI, they
+typehint on `UriFactoryInterface`. In this way, users can be granular about what
+they need.
+
+Doing so also allows application developers to provide anonymous implementations
+based on the PSR-7 implementation they are using, producing only the instances
+they need for the specific context. This reduces boilerplate; developers do not
+need to write stubs for unused methods.
+
+### 6.2 Why does `ServerRequestFactoryInterface::createServerRequestFromArray()` exist?
+
+One element of `Psr\Http\Message\ServerRequestInterface` has no corresponding
+"mutator"-cum-cloning method: `getServerParams()`. These are meant to represent
+environment parameters created by the Server API (SAPI) in current use.
+Generally speaking those parameters can be used to create all _required_ aspects
+of a server-side request as well, and, specifically, the request URI and HTTP
+method (e.g., via `$_SERVER['REQUEST_URI']` and `$_SERVER['REQUEST_METHOD'` when
+using mod_php under Apache or when using php-fpm via a FastCGI process).
+Creating the server request using that array allows you to minimally populate
+the instance, while simultaneously providing the SAPI environment.
+
+In SAPI environments that do not populate `$_SERVER` with this information
+(e.g., async application runners that run via the CLI environment), the
+`ServerRequestFactoryInterface::createServerRequest()` method exists, allowing
+you to create a minimal server request instance with the request method and URI.
+
+## 6. People
 
 This PSR was produced by a FIG Working Group with the following members:
 
@@ -180,14 +212,14 @@ The working group would also like to acknowledge the contributions of:
 * Rasmus Schultz, <rasmus@mindplay.dk>
 * Roman Tsjupa, <draconyster@gmail.com>
 
-## 6. Votes
+## 7. Votes
 
 * [Entrance Vote](https://groups.google.com/forum/#!topic/php-fig/6rZPZ8VglIM)
 * [Working Group Formation](https://groups.google.com/d/msg/php-fig/A5mZYTn5Jm8/j0FN6eZtBAAJ)
 * Review Period Initiation _(not yet begun)_
 * Acceptance Vote _(not yet taken)_
 
-## 7. Relevant Links
+## 8. Relevant Links
 
 _**Note:** Order descending chronologically._
 

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -25,10 +25,17 @@ condition in which the body has already been written to.
 
 This scenario can be avoided by providing a factory to create new streams. Due to
 the lack of formal standard for HTTP object factories, a developer must rely on
-a specific vendor implementation in order to create these objects. Creating a
-formal standard for factories will allow developers to avoid dependencies on
-specific implementations while having the ability to create new objects when
-necessary.
+a specific vendor implementation in order to create these objects.
+
+Another pain point is when writing re-usable middleware or request handlers. In
+such cases, package authors may need to create and return a response. However,
+creating discrete instances then ties the package to a specific PSR-7
+implementation. If these packages rely on a request factory instead, they can
+remain agnostic of the PSR-7 implementation.
+
+Creating a formal standard for factories will allow developers to avoid
+dependencies on specific implementations while having the ability to create new
+objects when necessary.
 
 ## 3. Scope
 

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -68,7 +68,7 @@ factory methods.
 
 #### 4.2.1 Diactoros
 
-Zend Diactoros is currently the most popular HTTP Messages implementation for
+[Diactoros][zend-diactoros] is currently the most popular HTTP Messages implementation for
 server usage.
 
 - [`Request`][diactoros-request] No required parameters, method and URI default to `null`.
@@ -80,6 +80,7 @@ server usage.
   `int $errorStatus`. Error status must be a PHP upload constant.
 - [`Uri`][diactoros-uri] No required parameters, `string $uri` is empty by default.
 
+[zend-diactoros]: https://docs.zendframework.com/zend-diactoros/
 [diactoros-request]: https://github.com/zendframework/zend-diactoros/blob/b4e7758556c97b5bb9a5260d898e9788ee800538/src/Request.php#L33)
 [diactoros-response]: https://github.com/zendframework/zend-diactoros/blob/b4e7758556c97b5bb9a5260d898e9788ee800538/src/Response.php#L114
 [diactoros-server-request]: https://github.com/zendframework/zend-diactoros/blob/b4e7758556c97b5bb9a5260d898e9788ee800538/src/ServerRequest.php#L78-L89

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -13,9 +13,9 @@ create [PSR-7][psr7] objects.
 The current specification for PSR-7 allows for most objects to be modified by
 creating immutable copies. However, there are two notable exceptions:
 
-* `StreamInterface` is a mutable object based on a resource that only allows
+- `StreamInterface` is a mutable object based on a resource that only allows
   the resource to be written to when the resource is writable.
-* `UploadedFileInterface` is a read-only object based on a resource that offers
+- `UploadedFileInterface` is a read-only object based on a resource that offers
   no modification capabilities.
 
 The former is a significant pain point for PSR-7 middleware, as it can leave
@@ -41,11 +41,11 @@ objects when necessary.
 
 ### 3.1 Goals
 
-* Provide a set of interfaces that define methods to create PSR-7 compatible objects.
+- Provide a set of interfaces that define methods to create PSR-7 compatible objects.
 
 ### 3.2 Non-Goals
 
-* Provide a specific implementation of PSR-7 factories.
+- Provide a specific implementation of PSR-7 factories.
 
 ## 4. Approaches
 
@@ -197,37 +197,37 @@ you to create a minimal server request instance with the request method and URI.
 
 This PSR was produced by a FIG Working Group with the following members:
 
-* Woody Gilk (editor), <woody.gilk@gmail.com>
-* Matthew Weier O'Phinney (sponsor), <mweierophinney@gmail.com>
-* Stefano Torresi
-* Matthieu Napoli
-* Korvin Szanto
-* Glenn Eggleton
-* Oscar Otero
-* Tobias Nyholm
+- Woody Gilk (editor), <woody.gilk@gmail.com>
+- Matthew Weier O'Phinney (sponsor), <mweierophinney@gmail.com>
+- Stefano Torresi
+- Matthieu Napoli
+- Korvin Szanto
+- Glenn Eggleton
+- Oscar Otero
+- Tobias Nyholm
 
 The working group would also like to acknowledge the contributions of:
 
-* Paul M. Jones, <pmjones88@gmail.com>
-* Rasmus Schultz, <rasmus@mindplay.dk>
-* Roman Tsjupa, <draconyster@gmail.com>
+- Paul M. Jones, <pmjones88@gmail.com>
+- Rasmus Schultz, <rasmus@mindplay.dk>
+- Roman Tsjupa, <draconyster@gmail.com>
 
 ## 7. Votes
 
-* [Entrance Vote](https://groups.google.com/forum/#!topic/php-fig/6rZPZ8VglIM)
-* [Working Group Formation](https://groups.google.com/d/msg/php-fig/A5mZYTn5Jm8/j0FN6eZtBAAJ)
-* Review Period Initiation _(not yet begun)_
-* Acceptance Vote _(not yet taken)_
+- [Entrance Vote](https://groups.google.com/forum/#!topic/php-fig/6rZPZ8VglIM)
+- [Working Group Formation](https://groups.google.com/d/msg/php-fig/A5mZYTn5Jm8/j0FN6eZtBAAJ)
+- Review Period Initiation _(not yet begun)_
+- Acceptance Vote _(not yet taken)_
 
 ## 8. Relevant Links
 
 _**Note:** Order descending chronologically._
 
-* [PSR-7 Middleware Proposal](https://github.com/php-fig/fig-standards/pull/755)
-* [PHP-FIG mailing list discussion of middleware](https://groups.google.com/forum/#!topic/php-fig/vTtGxdIuBX8)
-* [ircmaxwell All About Middleware](http://blog.ircmaxell.com/2016/05/all-about-middleware.html)
-* [shadowhand All About PSR-7 Middleware](http://shadowhand.me/all-about-psr-7-middleware/)
-* [AndrewCarterUK PSR-7 Objects Are Not Immutable](http://andrewcarteruk.github.io/programming/2016/05/22/psr-7-is-not-immutable.html)
-* [shadowhand Dependency Inversion and PSR-7 Bodies](http://shadowhand.me/dependency-inversion-and-psr-7-bodies/)
-* [PHP-FIG mailing list thread discussing factories](https://groups.google.com/d/msg/php-fig/G5pgQfQ9fpA/UWeM1gm1CwAJ)
-* [PHP-FIG mailing list thread feedback on proposal](https://groups.google.com/d/msg/php-fig/piRtB2Z-AZs/8UIwY1RtDgAJ)
+- [PSR-7 Middleware Proposal](https://github.com/php-fig/fig-standards/pull/755)
+- [PHP-FIG mailing list discussion of middleware](https://groups.google.com/forum/#!topic/php-fig/vTtGxdIuBX8)
+- [ircmaxwell All About Middleware](http://blog.ircmaxell.com/2016/05/all-about-middleware.html)
+- [shadowhand All About PSR-7 Middleware](http://shadowhand.me/all-about-psr-7-middleware/)
+- [AndrewCarterUK PSR-7 Objects Are Not Immutable](http://andrewcarteruk.github.io/programming/2016/05/22/psr-7-is-not-immutable.html)
+- [shadowhand Dependency Inversion and PSR-7 Bodies](http://shadowhand.me/dependency-inversion-and-psr-7-bodies/)
+- [PHP-FIG mailing list thread discussing factories](https://groups.google.com/d/msg/php-fig/G5pgQfQ9fpA/UWeM1gm1CwAJ)
+- [PHP-FIG mailing list thread feedback on proposal](https://groups.google.com/d/msg/php-fig/piRtB2Z-AZs/8UIwY1RtDgAJ)

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -163,7 +163,7 @@ the interfaces have methods to copy-and-modify the object.
 
 ## 5. Design Decisions
 
-### 6.1 Why multiple interfaces?
+### 5.1 Why multiple interfaces?
 
 Each proposed interface is (primarily) responsible for producing one PSR-7 type.
 This allows consumers to typehint on exactly what they need: if they need a

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -163,18 +163,22 @@ the interfaces have methods to copy-and-modify the object.
 
 ## 5. People
 
-### 5.1 Editor(s)
+This PSR was produced by a FIG Working Group with the following members:
 
-* Woody Gilk, <woody.gilk@gmail.com>
+* Woody Gilk (editor), <woody.gilk@gmail.com>
+* Matthew Weier O'Phinney (sponsor), <mweierophinney@gmail.com>
+* Stefano Torresi
+* Matthieu Napoli
+* Korvin Szanto
+* Glenn Eggleton
+* Oscar Otero
+* Tobias Nyholm
 
-### 5.2 Sponsors
+The working group would also like to acknowledge the contributions of:
 
-* Roman Tsjupa, <draconyster@gmail.com> (Coordinator)
 * Paul M. Jones, <pmjones88@gmail.com>
-
-### 5.3 Contributors
-
 * Rasmus Schultz, <rasmus@mindplay.dk>
+* Roman Tsjupa, <draconyster@gmail.com>
 
 ## 6. Votes
 

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -183,7 +183,9 @@ The working group would also like to acknowledge the contributions of:
 ## 6. Votes
 
 * [Entrance Vote](https://groups.google.com/forum/#!topic/php-fig/6rZPZ8VglIM)
-* **Acceptance Vote:** _(not yet taken)_
+* [Working Group Formation](https://groups.google.com/d/msg/php-fig/A5mZYTn5Jm8/j0FN6eZtBAAJ)
+* Review Period Initiation _(not yet begun)_
+* Acceptance Vote _(not yet taken)_
 
 ## 7. Relevant Links
 

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -4,7 +4,9 @@ HTTP Factories Meta
 ## 1. Summary
 
 The purpose of this PSR is to provide factory interfaces that define methods to
-create PSR-7 objects.
+create [PSR-7][psr7] objects.
+
+[psr7]: https://www.php-fig.org/psr/psr-7/
 
 ## 2. Why Bother?
 

--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -176,23 +176,6 @@ based on the PSR-7 implementation they are using, producing only the instances
 they need for the specific context. This reduces boilerplate; developers do not
 need to write stubs for unused methods.
 
-### 6.2 Why does `ServerRequestFactoryInterface::createServerRequestFromArray()` exist?
-
-One element of `Psr\Http\Message\ServerRequestInterface` has no corresponding
-"mutator"-cum-cloning method: `getServerParams()`. These are meant to represent
-environment parameters created by the Server API (SAPI) in current use.
-Generally speaking those parameters can be used to create all _required_ aspects
-of a server-side request as well, and, specifically, the request URI and HTTP
-method (e.g., via `$_SERVER['REQUEST_URI']` and `$_SERVER['REQUEST_METHOD'` when
-using mod_php under Apache or when using php-fpm via a FastCGI process).
-Creating the server request using that array allows you to minimally populate
-the instance, while simultaneously providing the SAPI environment.
-
-In SAPI environments that do not populate `$_SERVER` with this information
-(e.g., async application runners that run via the CLI environment), the
-`ServerRequestFactoryInterface::createServerRequest()` method exists, allowing
-you to create a minimal server request instance with the request method and URI.
-
 ## 6. People
 
 This PSR was produced by a FIG Working Group with the following members:

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -166,7 +166,6 @@ resources from strings. The RECOMMENDED method for doing so is:
 
 ```php
 $resource = fopen('php://temp', 'r+');
-fwrite($resource, $body);
 ```
 
 ### 2.5 UploadedFileFactoryInterface

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -192,17 +192,14 @@ interface UploadedFileFactoryInterface extends StreamFactoryInterface
     /**
      * Create a new uploaded file.
      *
-     * If a string is used to create the file, a temporary resource will be
-     * created with the content of the string.
-     *
      * If a size is not provided it will be determined by checking the size of
      * the file.
      *
      * @see http://php.net/manual/features.file-upload.post-method.php
      * @see http://php.net/manual/features.file-upload.errors.php
      *
-     * @param string|resource|StreamInterface $file Underlying file, PHP stream
-     *     resource, or StreamInterface representing the uploaded file content.
+     * @param StreamInterface $stream Underlying stream representing the
+     *     uploaded file content.
      * @param int $size in bytes
      * @param int $error PHP file upload error
      * @param string $clientFilename Filename as provided by the client, if any.
@@ -213,7 +210,7 @@ interface UploadedFileFactoryInterface extends StreamFactoryInterface
      * @throws \InvalidArgumentException If the file resource is not readable.
      */
     public function createUploadedFile(
-        $file,
+        StreamInterface $stream,
         int $size = null,
         int $error = \UPLOAD_ERR_OK,
         string $clientFilename = null,
@@ -222,12 +219,8 @@ interface UploadedFileFactoryInterface extends StreamFactoryInterface
 }
 ```
 
-Implementations of this interface SHOULD use a temporary file when creating
-resources from strings. The RECOMMENDED method for doing so is:
-
-```php
-$resource = fopen('php://temp', 'r+');
-```
+The interface extends `StreamFactoryInterface`, which CAN be used to create the
+`$stream` argument for the `createUploadedFile()` method.
 
 ### 2.6 UriFactoryInterface
 

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -48,12 +48,14 @@ interface RequestFactoryInterface extends
     /**
      * Create a new request.
      *
-     * @param string $method
-     * @param UriInterface|string $uri
+     * @param string $method The HTTP method associated with the request.
+     * @param UriInterface|string $uri The URI associated with the request. If
+     *     the value is a string, the factory MUST create a UriInterface
+     *     instance based on it.
      *
      * @return RequestInterface
      */
-    public function createRequest($method, $uri);
+    public function createRequest(string $method, $uri): RequestInterface;
 }
 ```
 
@@ -131,11 +133,11 @@ interface StreamFactoryInterface
      *
      * The stream SHOULD be created with a temporary resource.
      *
-     * @param string $content
+     * @param string $content String content with which to populate the stream.
      *
      * @return StreamInterface
      */
-    public function createStream($content = '');
+    public function createStream(string $content = ''): StreamInterface;
 
     /**
      * Create a stream from an existing file.
@@ -145,23 +147,23 @@ interface StreamFactoryInterface
      *
      * The `$filename` MAY be any string supported by `fopen()`.
      *
-     * @param string $filename
-     * @param string $mode
+     * @param string $filename Filename or stream URI to use as basis of stream.
+     * @param string $mode Mode with which to open the underlying filename/stream.
      *
      * @return StreamInterface
      */
-    public function createStreamFromFile($filename, $mode = 'r');
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface;
 
     /**
      * Create a new stream from an existing resource.
      *
      * The stream MUST be readable and may be writable.
      *
-     * @param resource $resource
+     * @param resource $resource PHP resource to use as basis of stream.
      *
      * @return StreamInterface
      */
-    public function createStreamFromResource($resource);
+    public function createStreamFromResource($resource): StreamInterface;
 }
 ```
 
@@ -197,24 +199,24 @@ interface UploadedFileFactoryInterface extends StreamFactoryInterface
      * @see http://php.net/manual/features.file-upload.post-method.php
      * @see http://php.net/manual/features.file-upload.errors.php
      *
-     * @param string|resource|StreamInterface $file
+     * @param string|resource|StreamInterface $file Underlying file, PHP stream
+     *     resource, or StreamInterface representing the uploaded file content.
      * @param int $size in bytes
      * @param int $error PHP file upload error
-     * @param string $clientFilename
-     * @param string $clientMediaType
+     * @param string $clientFilename Filename as provided by the client, if any.
+     * @param string $clientMediaType Media type as provided by the client, if any.
      *
      * @return UploadedFileInterface
      *
-     * @throws \InvalidArgumentException
-     *  If the file resource is not readable.
+     * @throws \InvalidArgumentException If the file resource is not readable.
      */
     public function createUploadedFile(
         $file,
-        $size = null,
-        $error = \UPLOAD_ERR_OK,
-        $clientFilename = null,
-        $clientMediaType = null
-    );
+        int $size = null,
+        int $error = \UPLOAD_ERR_OK,
+        string $clientFilename = null,
+        string $clientMediaType = null
+    ): UploadedFileInterface;
 }
 ```
 
@@ -243,9 +245,8 @@ interface UriFactoryInterface
      *
      * @return UriInterface
      *
-     * @throws \InvalidArgumentException
-     *  If the given URI cannot be parsed.
+     * @throws \InvalidArgumentException If the given URI cannot be parsed.
      */
-    public function createUri($uri = '');
+    public function createUri(string $uri = '') : UriInterface;
 }
 ```

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -37,9 +37,13 @@ Has the ability to create client requests.
 namespace Psr\Http\Message;
 
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
-interface RequestFactoryInterface
+interface RequestFactoryInterface extends
+    StreamFactoryInterface,
+    UriFactoryInterface,
 {
     /**
      * Create a new request.
@@ -61,8 +65,9 @@ Has the ability to create responses.
 namespace Psr\Http\Message;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
-interface ResponseFactoryInterface
+interface ResponseFactoryInterface extends StreamFactoryInterface
 {
     /**
      * Create a new response.
@@ -83,9 +88,15 @@ Has the ability to create server requests.
 namespace Psr\Http\Message;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
-interface ServerRequestFactoryInterface
+interface ServerRequestFactoryInterface extends
+    StreamFactoryInterface,
+    UploadedFileFactoryInterface,
+    UriFactoryInterface
 {
     /**
      * Create a new server request.

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -175,9 +175,11 @@ Has the ability to create streams for uploaded files.
 ```php
 namespace Psr\Http\Message;
 
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-interface UploadedFileFactoryInterface
+interface UploadedFileFactoryInterface extends StreamFactoryInterface
 {
     /**
      * Create a new uploaded file.
@@ -191,7 +193,7 @@ interface UploadedFileFactoryInterface
      * @see http://php.net/manual/features.file-upload.post-method.php
      * @see http://php.net/manual/features.file-upload.errors.php
      *
-     * @param string|resource $file
+     * @param string|resource|StreamInterface $file
      * @param int $size in bytes
      * @param int $error PHP file upload error
      * @param string $clientFilename
@@ -217,7 +219,6 @@ resources from strings. The RECOMMENDED method for doing so is:
 
 ```php
 $resource = fopen('php://temp', 'r+');
-fwrite($resource, $body);
 ```
 
 ### 2.6 UriFactoryInterface

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -15,8 +15,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][rfc2119].
 
-[psr7]: http://www.php-fig.org/psr/psr-7/
-[rfc2119]: http://tools.ietf.org/html/rfc2119
+[psr7]: https://www.php-fig.org/psr/psr-7/
+[rfc2119]: https://tools.ietf.org/html/rfc2119
 
 ## 1. Specification
 

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -104,24 +104,14 @@ interface ServerRequestFactoryInterface extends
     /**
      * Create a new server request.
      *
-     * @param string $method
-     * @param UriInterface|string $uri
+     * @param string $method The HTTP method associated with the request.
+     * @param UriInterface|string $uri The URI associated with the request. If
+     *     the value is a string, the factory MUST create a UriInterface
+     *     instance based on it.
      *
      * @return ServerRequestInterface
      */
-    public function createServerRequest($method, $uri);
-
-    /**
-     * Create a new server request from server variables.
-     *
-     * @param array $server Typically $_SERVER or similar structure.
-     *
-     * @return ServerRequestInterface
-     *
-     * @throws \InvalidArgumentException
-     *  If no valid method or URI can be determined.
-     */
-    public function createServerRequestFromArray(array $server);
+    public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface;
 }
 ```
 

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -72,11 +72,14 @@ interface ResponseFactoryInterface extends StreamFactoryInterface
     /**
      * Create a new response.
      *
-     * @param int $code HTTP status code
+     * @param int $code HTTP status code; defaults to 200
+     * @param string $reasonPhrase Reason phrase to associate with status code
+     *     in generated response; if none is provided implementations MAY use
+     *     the defaults as suggested in the HTTP specification.
      *
      * @return ResponseInterface
      */
-    public function createResponse($code = 200);
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface;
 }
 ```
 

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -161,7 +161,7 @@ interface StreamFactoryInterface
 }
 ```
 
-Implementations of this interface SHOULD use a temporary file when creating
+Implementations of this interface SHOULD use a temporary stream when creating
 resources from strings. The RECOMMENDED method for doing so is:
 
 ```php

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -110,6 +110,8 @@ interface ServerRequestFactoryInterface extends
      * @param UriInterface|string $uri The URI associated with the request. If
      *     the value is a string, the factory MUST create a UriInterface
      *     instance based on it.
+     * @param array $serverParams Array of SAPI parameters with which to seed
+     *     the generated request instance.
      *
      * @return ServerRequestInterface
      */


### PR DESCRIPTION
This patch provides changes based on discussion within the working group following a review I performed.

### Interface changes

First, it makes the following substance changes to the interfaces:

- All interface methods now use PHP 7 scalar type hints where appropriate, as well as return type hints.
- `ResponseFactoryInterface::createResponse()` adds an optional string argument, `$reasonPhrase`. This is done to mimic `ResponseInterface::withStatus()`, as the only way to set a reason phrase is to pass it with the associated status code to that method. If we want to provide a way to generate a complete initial response, we need to allow passing the reason phrase.
- `ServerRequestFactoryInterface` removes the `createServerRequestFromArray()` method, but adds an optional array `$serverParams` argument to `createServerRequest()`. The `ServerRequestInterface` does not have a mutator for the server params, so the only way to provide them is at initial creation. Additionally, the structure of server params varies based on SAPI, and may or may not contain the data necessary to generate a URI and/or HTTP method for the request. As such, as a working group, we feel it makes sense to have a single factory method that includes the three required data (HTTP method, URI, and server params) for a complete and valid server request.
- Any factory generating an instance that has collaborators has been updated to extend the factory interfaces for those collaborators. These include:
  - Each of `RequestFactory`, `ResponseFactory`, `ServerRequestFactoryInterface`, and `UploadedFileFactoryInterface` extends `StreamFactoryInterface`, as the factory may need to generate a stream and/or the consumer may need to do so in order to provide it to the factory.
  - Each of `RequestFactoryInterface` and `ServerRequestFactoryInterface` extend `UriFactoryInterface`, as the factory may need to generate a `UriInterface` instance and/or the consumer may need to do so in order to provide it to the factory.
  - `ServerRequestFactoryInterface` extends `UploadedFileFactoryInterface` as the factory may need to generate `UploadedFileInterface` instances and/or the consumer may need to do so in order to provide them to the factory.

The rationale for extending collaborator factories is as follows: these factories in essence already require the other factories in order to produce the dependencies. Having them explicitly extend those factories ensures the required methods are present, and those artifacts may be produced. Doing otherwise would be encouraging a lot of code duplication (and thus potential for bugs), and would also require that middleware and request handlers require multiple factories to produce individual instances.

### Content changes

- Updated the "People" section of the metadocument to detail the working group.
- Updated the "Votes" section to detail the WG formation, and add a placeholder for the review period.
- Added a "Design Decisions" section, with six initial items:
  - Why multiple interfaces? and why createServerRequestFromArray()?

### Editorial changes

On the editorial side of the spectrum, I've made the following changes:

- Use SSL-enable links where possible.
- Added more links.
- Removed a few code examples that were confusing. In particular, two of those that talked about stream creation had the line `fwrite($resource, $body)`, which made no sense given the context of each.
- Use consistent markup for bullet points (`-` instead of `*` everywhere).