### PR TITLE
[PSR11] Fix heading format bugs

### DIFF
--- a/accepted/PSR-11-container-meta.md
+++ b/accepted/PSR-11-container-meta.md
@@ -301,8 +301,7 @@ try {
 }
 ```
 
-8. Implementations
-------------------
+## 8. Implementations
 
 At the time of writing, the following projects already implement and/or consume the `container-interop` version of the interface.
 
@@ -335,8 +334,8 @@ At the time of writing, the following projects already implement and/or consume 
 
 This list is not comprehensive and should be only taken as an example showing that there is considerable interest in the PSR.
 
-9. People
----------
+## 9. People
+
 ### 9.1 Editors
 
 * [Matthieu Napoli](https://github.com/mnapoli)


### PR DESCRIPTION
Section 8 and 9 rendered as list items, including a weird indentation bug
affecting section 9.1, due to use of `N.` syntax instead of `##`. The other
sections already used `##` and render fine.

Before:

```
## 7. Interface methods
```
<img width="347" alt="section 7 is fine" src="https://user-images.githubusercontent.com/156867/39666960-3f7f53e6-50a4-11e8-9648-749b15a3b155.png">


```
8. Implementations
-------------------

At the time of writing
```
<img width="325" alt="section 8 has bugs" src="https://user-images.githubusercontent.com/156867/39666965-5a5dac8a-50a4-11e8-8b2e-5aae9cdc7063.png">


```
9. People
---------
### 9.1 Editors
```

<img width="280" alt="sec-9-bugs" src="https://user-images.githubusercontent.com/156867/39666984-90ab7736-50a4-11e8-8379-7b9447967da4.png">
