### PR TITLE
Clarity on unary operator spacing in PSR-1 example

### DIFF
--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -90,6 +90,7 @@ function foo()
 
 // conditional declaration is *not* a side effect
 if (! function_exists('bar')) {
+    // note: the space proceeding the unary operator above is *not* part of the standard.
     function bar()
     {
         // function body


### PR DESCRIPTION
Added comment to PSR-1 example making it clear that the white-space proceeding the unary operator is not part of the standard.