### PR TITLE
[PSR-17] Updates ServerRequestFactoryInterface to sync with WG changes

### DIFF
--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -106,6 +106,10 @@ interface ServerRequestFactoryInterface extends
     /**
      * Create a new server request.
      *
+     * Note that server-params are taken precisely as given - no parsing/processing
+     * of the given values is performed, and, in particular, no attempt is made to
+     * determine the HTTP method or URI, which must be provided explicitly.
+     *
      * @param string $method The HTTP method associated with the request.
      * @param UriInterface|string $uri The URI associated with the request. If
      *     the value is a string, the factory MUST create a UriInterface


### PR DESCRIPTION
Updates to match http-interop/http-factory#40, directing that server params should NOT be used to determine URI or HTTP method.