### PR TITLE
Clarify Scope

### DIFF
--- a/proposed/phpdoc-meta.md
+++ b/proposed/phpdoc-meta.md
@@ -83,7 +83,7 @@ Cons:
 
 ### 5.1 Editor
 
- * Chuck Burgess
+ * Chuck Burgess - [PEAR](https://pear.php.net)
 
 ### 5.2 Sponsor
 
@@ -91,7 +91,7 @@ Cons:
 
 ### 5.3 Working group members
 
- * Alexey Gopachenko
+ * Alexey Gopachenko - [PhpStorm](https://www.jetbrains.com/phpstorm)
  * Matthew Brown - [Psalm](https://github.com/vimeo/psalm)
  * Ondrej Mirtes - [PHPStan](https://github.com/phpstan/phpstan)
 

--- a/proposed/phpdoc-meta.md
+++ b/proposed/phpdoc-meta.md
@@ -46,16 +46,17 @@ Cons:
 ### 3.1 Goals
 
 * Provide a complete technical definition, or schema, of the PHPDoc notation.
-* Introduce new concepts matching best practices or design patterns in use today and in the foreseeable future.
-* Deprecate old concepts that are replaced by newer concepts or are no longer in use in today's PHP landscape.
+* Introduce new concepts matching best practices or design patterns in use today.
 
 ### 3.2 Non-Goals
 
-* This PSR does not provide a recommendation on how and when to use the concepts described in this document,
-  so it is not a coding standard.
+* This PSR does not introduce new concepts that guess at matching best practices or design patterns in the foreseeable
+  future.
+* This PSR does not provide a recommendation on how and when to use the concepts described in this document, so it is
+  not a coding standard.
 * This PSR facilitates the creation of annotations by allowing the notation needed for Symfony/Doctrine style
-  annotations, but does not describe a style of annotations or which "defined annotations" exist in use. The concept of annotations is only
-  alluded to and is out of scope for this PSR.
+  annotations, but does not describe a style of annotations or which "defined annotations" exist in use. The concept of
+  annotations is only alluded to and is out of scope for this PSR.
 
 ## 4. Approaches
 


### PR DESCRIPTION
This limits PSR scope to specifically not make guesses at future doc patterns.