### PR TITLE
[PSR-17] Removed comment about UriInterface

### DIFF
--- a/proposed/http-factory/http-factory-meta.md
+++ b/proposed/http-factory/http-factory-meta.md
@@ -244,6 +244,30 @@ implementation-specfic.
 [swoole]: https://www.swoole.co.uk/
 [reactphp]: https://reactphp.org/
 
+### 5.6 Why does RequestFactoryInterface::createRequest allow a string URI?
+
+The primary use case of `RequestFactoryInterface` is to create a request, and
+the only required values for any request are the request method and a URI. While
+`RequestFactoryInterface::createRequest()` can accept a `UriInterface` instance,
+it also allows a string.
+
+The rationale is two-fold. First, the majority use case is to create a request
+instance; creation of the URI instance is secondary. Requiring a `UriInterface`
+means users would either need to also have access to a `UriFactoryInterface`, or
+the `RequestFactoryInterface` would have a hard requirement on a
+`UriFactoryInterface`. The first complicates usage for consumers of the factory,
+the second complicates usage for either developers of the factory, or those
+creating the factory instance.
+
+Second, `UriFactoryInterface` provides exactly one way to create a
+`UriInterface` instance, and that is from a string URI. If creation of the URI
+is based on a string, there's no reason for the `RequestFactoryInterface` not to
+allow the same semantics. Additionally, every PSR-7 implementation surveyed at
+the time this proposal was developed allowed a string URI when creating a
+`RequestInterface` instance, as the value was then passed to whatever
+`UriInterface` implementation they provided. As such, accepting a string is
+expedient and follows existing semantics.
+
 ## 6. People
 
 This PSR was produced by a FIG Working Group with the following members:

--- a/proposed/http-factory/http-factory.md
+++ b/proposed/http-factory/http-factory.md
@@ -45,9 +45,7 @@ interface RequestFactoryInterface
      * Create a new request.
      *
      * @param string $method The HTTP method associated with the request.
-     * @param UriInterface|string $uri The URI associated with the request. If
-     *     the value is a string, the factory MUST create a UriInterface
-     *     instance based on it.
+     * @param UriInterface|string $uri The URI associated with the request. 
      */
     public function createRequest(string $method, $uri): RequestInterface;
 }
@@ -96,9 +94,7 @@ interface ServerRequestFactoryInterface
      * determine the HTTP method or URI, which must be provided explicitly.
      *
      * @param string $method The HTTP method associated with the request.
-     * @param UriInterface|string $uri The URI associated with the request. If
-     *     the value is a string, the factory MUST create a UriInterface
-     *     instance based on it.
+     * @param UriInterface|string $uri The URI associated with the request. 
      * @param array $serverParams An array of Server API (SAPI) parameters with
      *     which to seed the generated request instance.
      */


### PR DESCRIPTION
I removed a section because I think it is not needed. Of course it is good to be extra clear but IMHO this is too much. 

A valid request object will always have an `UriOjbect` and of course it should use the input parameter to create that `UriObject`...

--------

There are (at least) two ways to create a `RequestFactory`.

### Method 1

```php
class RequestFactory implements RequestFactoryInterface 
{
    public function createRequest(
        string $method,
        $uri,
        array $headers = [],
        $body = null,
        $protocolVersion = '1.1'
    ): RequestInterface {
        // We let the request implementation create a URI object. 
        return new Request($method, $uri, $headers, $body, $protocolVersion);
    }
}
```

### Method 2

```php
class RequestFactory implements RequestFactoryInterface 
{
    private $uriFactory;
    
    // .. Constructor

    public function createRequest(
        string $method,
        $uri,
        array $headers = [],
        $body = null,
        $protocolVersion = '1.1'
    ): RequestInterface {
        if (is_string($uri)) {
            $uri = $this->uriFactory->createUri($uri);
        }
        return new Request($method, $uri, $headers, $body, $protocolVersion);
    }
}
```

You may read the comment that I'm removing as it is trying to control if you implement a request factory with method 1 or 2. I do not think the interface should try to control this as it is an implementation detail. 