### PR TITLE
Remove security PSRs from the abandoned bucket

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -31,8 +31,7 @@ groups:
         teams:
             - secretaries
         conditions:
-            files:
-                - "proposed/security-*"
+            files: []
     phpdoc:
         required: 1
         teams:


### PR DESCRIPTION
It looks like that the security PSRs are not abandoned anymore. I've kept the entry for future use.