### PR TITLE
Fixed coding style for "foreach" control structure

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -155,7 +155,7 @@ interpreted as described in [RFC 2119][RFC2119].
 
   ```php
   /** @var \Sqlite3 $sqlite */
-  foreach($connections as $sqlite) {
+  foreach ($connections as $sqlite) {
       // there should be no docblock here
       $sqlite->open('/my/database/path');
       <...>
@@ -1779,7 +1779,7 @@ use this information to help you with auto-completion:
 
 ```php
 /** @var \Sqlite3 $sqlite */
-foreach($connections as $sqlite) {
+foreach ($connections as $sqlite) {
     // there should be no docblock here
     $sqlite->open('/my/database/path');
     <...>


### PR DESCRIPTION
According to PSR-2 , for control structure: "There MUST be one space after the control structure keyword". So, there must be one after "foreach"