### PR TITLE
Remove reference to interface inheritance

### DIFF
--- a/accepted/PSR-17-http-factory.md
+++ b/accepted/PSR-17-http-factory.md
@@ -196,9 +196,6 @@ interface UploadedFileFactoryInterface
 }
 ```
 
-The interface extends `StreamFactoryInterface`, which CAN be used to create the
-`$stream` argument for the `createUploadedFile()` method.
-
 ### 2.6 UriFactoryInterface
 
 Has the ability to creates URIs for client and server requests.


### PR DESCRIPTION
I think this statement should had been removed in cd3ffe3f3ea17c2f0874a3b184651f839edefaea.

The `UploadedFileFactoryInterface` does not extend `StreamFactoryInterface`.