### PR TITLE
[PSR-18] Removes `Exception` subnamespace

### DIFF
--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -96,9 +96,8 @@ interface ClientException extends \Throwable
 ### RequestException
 
 ```php
-namespace Psr\Http\Client\Exception;
+namespace Psr\Http\Client;
 
-use Psr\Http\Client\ClientException;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -124,9 +123,8 @@ interface RequestException extends ClientException
 ### NetworkException
 
 ```php
-namespace Psr\Http\Client\Exception;
+namespace Psr\Http\Client;
 
-use Psr\Http\Client\ClientException;
 use Psr\Http\Message\RequestInterface;
 
 /**


### PR DESCRIPTION
Prior to this change, the spec defined `Psr\Http\Client\ClientException`, but then provided additional exception interfaces under `Psr\Http\Client\Exception`. I noted to @Nyholm in a private conversation that this is confusing: why is `ClientException` treated differently than the other interfaces?

The argument was that it is the base exception interface.

I in turn argued that this can be true while it's still in the same namespace as the other extending interfaces, and that most libraries do exactly that.

With that in mind, we had two options:

- Put all exceptions under the `Exception` subnamespace.
- Have all exceptions in the root namespace.

We decided on the latter, as there are so few interfaces defined in the spec.