### PR TITLE
[PSR-7] Adding throw exeception on `getParsedBody()`

### DIFF
--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1082,6 +1082,7 @@ interface ServerRequestInterface extends RequestInterface
      *
      * @return null|array|object The deserialized body parameters, if any.
      *     These will typically be an array or object.
+     * @throws \InvalidArgumentException if body cannot be deserialize.                           
      */
     public function getParsedBody();
 


### PR DESCRIPTION
It's an open discussion about how rely on deserialization failure when body is malformed. 

Today `null` is returned if body is incorrect (due to signature method) so the error is muted and the description say: 

> A null value indicates absence of body content so it's not the purpose. 

For example with json content, when `json_decode` fail because of invalid content, we should explicitly throw an exception. 

From controller side, `null` look's like empty or missing body rather than invalid content and need more check to indicate the correct issue to the end user. As developer in first hand, you didn't think of that case, you need experience to know that. 

Other point, this encourages developer to mute possible exception from deserializer to match method signature. 

What do you think ? 

