### PR TITLE
[PSR-19] @throws - also include subtypes of Throwable

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -1061,7 +1061,7 @@ DocBlock.
 ### 5.19. @throws
 
 The @throws tag is used to indicate whether "Structural Elements" throw a
-specific type of exception.
+specific type of Throwable (exception or error).
 
 #### Syntax
 
@@ -1072,7 +1072,7 @@ specific type of exception.
 The @throws tag MAY be used to indicate that "Structural Elements" throw a
 specific type of error.
 
-The type provided with this tag MUST represent an object of the class Exception, or any subclass thereof, or an object that is a subtype of Throwable.
+The type provided with this tag MUST represent an object that is a subtype of Throwable.
 
 This tag is used to present in your documentation which error COULD occur and
 under which circumstances. It is RECOMMENDED to provide a description that

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -1072,8 +1072,7 @@ specific type of exception.
 The @throws tag MAY be used to indicate that "Structural Elements" throw a
 specific type of error.
 
-The type provided with this tag MUST represent an object of the class Exception
-or any subclass thereof.
+The type provided with this tag MUST represent an object of the class Exception, or any subclass thereof, or an object that is a subtype of Throwable.
 
 This tag is used to present in your documentation which error COULD occur and
 under which circumstances. It is RECOMMENDED to provide a description that


### PR DESCRIPTION
Previous wording excluded interfaces that extend Throwable and also instances of TypError etc.

We could leave in only the expression of being "subtype of Throwable" but I think that might be less clear for someone.