### PR TITLE
Add previous PSR-5 contributors to meta doc

### DIFF
--- a/proposed/phpdoc-meta.md
+++ b/proposed/phpdoc-meta.md
@@ -94,6 +94,15 @@ Cons:
 
 Most of the relevant links are mentioned in the PSR itself as support for individual chapters.
 
+## 8. Past contributors
+
+Since this document stems from the work of a lot of people in previous years, we should recognize their effort:
+
+ * Mike van Riel (previous Editor)
+ * Phil Sturgeon (previous sponsor)
+ * Donald Gilbert (previous sponsor)
+ * Gary Jones (contributor)
+
 _**Note:** Order descending chronologically._
 
 * [Original draft](https://github.com/phpDocumentor/phpDocumentor2/commit/0dbdbfa318d197279b414e5c0d1ffb142b31a528#docs/PSR.md)


### PR DESCRIPTION
After 382f21ae385689519509ad66a5afbc3cc83c8522, I inadvertently wiped out the names of previous contributors to PSR-5. Since the doc was worked on a lot in the past, I think it's fair to recognize their effort, even if the working group is largely different now.

Please review the form, since I'm not a native speaker, thanks.