### PR TITLE
PSR-19: Change GPL-2.0+ to GPL-2.0-or-later

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -624,7 +624,7 @@ license.
 /**
  * @license MIT
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  *
  * @license http://www.spdx.org/licenses/MIT MIT License
  */


### PR DESCRIPTION
The SPDX identifier `GPL-2.0+` was deprecated. See https://spdx.org/news/news/2018/01/license-list-30-released