### PR TITLE
Add rule for increment/decrement operator

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -852,6 +852,9 @@ one space; multiple spaces MAY be used for readabiliy purpose. This includes all
 [string concatenation][], [type][] operators, trait operators (`insteadof` and `as`),
 and the single pipe operator (e.g. `ExceptionType1 | ExceptionType2 $e`).
 
+There MUST NOT be any whitespace between the increment/decrement operators and the variable 
+being incremented/decremented.
+
 Other operators are left undefined.
 
 For example:


### PR DESCRIPTION
As suggested by @MarkBaker [on the ML](https://groups.google.com/d/topic/php-fig/eGClHHNj0JM/discussion), it's reasonable to ask for no whitspace in the case of increment / decrement operators.