### PR TITLE
Add return type rule for closures

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -904,6 +904,10 @@ $closureWithArgs = function ($arg1, $arg2) {
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     // body
 };
+
+$closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
+    // body
+};
 ~~~
 
 Argument lists and variable lists MAY be split across multiple lines, where

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -887,6 +887,10 @@ comma, and there MUST be one space after each comma.
 Closure arguments with default values MUST go at the end of the argument
 list.
 
+If a return type is present, it MUST follow the same rules as with normal
+functions and methods; if the `use` keyword is present, the colon MUST follow
+the `use` list closing parentheses with no spaces between the two characters.
+
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 


### PR DESCRIPTION
As [suggested on Twitter](https://twitter.com/BackEndTea/status/1049992124463292416), we should explicitly state how the return type of a closure should be formatted. I've followed (and cited) the same rule as for normal functions/methods.