### PR TITLE
revert deprecation of link tag

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -23,7 +23,7 @@ PSR-19: PHPDoc tags
   - [5.7.  @global](#57-global)
   - [5.8.  @internal](#58-internal)
   - [5.9.  @license](#59-license)
-  - [5.10. @link ](#510-link)
+  - [5.10. @link](#510-link)
   - [5.11. @method](#511-method)
   - [5.12. @package](#512-package)
   - [5.13. @param](#513-param)

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -23,7 +23,7 @@ PSR-19: PHPDoc tags
   - [5.7.  @global](#57-global)
   - [5.8.  @internal](#58-internal)
   - [5.9.  @license](#59-license)
-  - [5.10. @link [deprecated]](#510-link-deprecated)
+  - [5.10. @link ](#510-link)
   - [5.11. @method](#511-method)
   - [5.12. @package](#512-package)
   - [5.13. @param](#513-param)
@@ -630,10 +630,7 @@ license.
  */
 ```
 
-### 5.10. @link [deprecated]
-
-*This tag is deprecated in favor of the `@see` tag, which since this
-specification may relate to URIs.*
+### 5.10. @link
 
 The @link tag indicates a custom relation between the associated
 "Structural Element" and a website, which is identified by an absolute URI.


### PR DESCRIPTION
Deprecating the `@link` tag (in deference to relying on `@see` for the same behavior) was a proposal in the early days of PSR-5 that received a negative response.  A decision *was* made back then (https://github.com/phpDocumentor/fig-standards/issues/104#issuecomment-138111143) to revert the deprecation, but the old draft was never updated.  This PR handles that.

This PR is solely to baseline the status of the `@link` tag back to normal.  A new discussion to restore the deprecation can be made if parties wish to bring it before the Working Group.