### PR TITLE
Removals of Old-Deprecated and Too-New-To-Be-In-Use things

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -16,27 +16,26 @@ PSR-19: PHPDoc tags
 - [5. Tags](#5-tags)
   - [5.1.  @api](#51-api)
   - [5.2.  @author](#52-author)
-  - [5.3.  @category [deprecated]](#53-category-deprecated)
-  - [5.4.  @copyright](#54-copyright)
-  - [5.5.  @deprecated](#55-deprecated)
-  - [5.6.  @example](#56-example)
-  - [5.7.  @global](#57-global)
-  - [5.8.  @internal](#58-internal)
-  - [5.9.  @license](#59-license)
-  - [5.10. @link](#510-link)
-  - [5.11. @method](#511-method)
-  - [5.12. @package](#512-package)
-  - [5.13. @param](#513-param)
-  - [5.14. @property](#514-property)
-  - [5.15. @return](#515-return)
-  - [5.16. @see](#516-see)
-  - [5.17. @since](#517-since)
-  - [5.18. @subpackage [deprecated]](#518-subpackage-deprecated)
-  - [5.19. @throws](#519-throws)
-  - [5.20. @todo](#520-todo)
-  - [5.21. @uses](#521-uses)
-  - [5.22. @var](#522-var)
-  - [5.23. @version](#523-version)
+  - [5.3.  @copyright](#53-copyright)
+  - [5.4.  @deprecated](#54-deprecated)
+  - [5.5.  @example](#55-example)
+  - [5.6.  @global](#56-global)
+  - [5.7.  @internal](#57-internal)
+  - [5.8.  @license](#58-license)
+  - [5.9.  @link](#59-link)
+  - [5.10. @method](#510-method)
+  - [5.11. @package](#511-package)
+  - [5.12. @param](#512-param)
+  - [5.13. @property](#513-property)
+  - [5.14. @return](#514-return)
+  - [5.15. @see](#515-see)
+  - [5.16. @since](#516-since)
+  - [5.17. @subpackage [deprecated]](#517-subpackage-deprecated)
+  - [5.18. @throws](#518-throws)
+  - [5.19. @todo](#519-todo)
+  - [5.20. @uses](#520-uses)
+  - [5.21. @var](#521-var)
+  - [5.22. @version](#522-version)
 
 ## 1. Introduction
 
@@ -292,42 +291,7 @@ adhere to the syntax defined in RFC 2822.
  */
 ```
 
-### 5.3. @category [deprecated]
-
-The @category tag is used to organize groups of packages together but is
-deprecated in favour of occupying the top-level with the @package tag.
-As such, usage of this tag is NOT RECOMMENDED.
-
-#### Syntax
-
-    @category [description]
-
-#### Description
-
-The @category tag was meant in the original de-facto Standard to group several
-@packages into one category. These categories could then be used to aid
-in the generation of API documentation.
-
-This was necessary since the @package tag as defined in the original Standard did
-not contain more then one hierarchy level; since this has changed this tag SHOULD
-NOT be used.
-
-Please see the documentation for `@package` for details of its usage.
-
-This tag MUST NOT occur more than once in a "DocBlock".
-
-#### Examples
-
-```php
-/**
- * File-Level DocBlock
- *
- * @category MyCategory
- * @package  MyPackage
- */
-```
-
-### 5.4. @copyright [WG++]
+### 5.3. @copyright [WG++]
 
 The @copyright tag is used to document the copyright information of any
 "Structural element".
@@ -354,7 +318,7 @@ covered by this copyright and the organization involved.
  */
 ```
 
-### 5.5. @deprecated
+### 5.4. @deprecated
 
 The @deprecated tag is used to indicate which 'Structural elements' are
 deprecated and are to be removed in a future version.
@@ -414,7 +378,7 @@ If the associated element is superseded by another it is RECOMMENDED to add a
  */
 ```
 
-### 5.6. @example
+### 5.5. @example
 
 The @example tag is used to link to an external source code file which contains
 an example of use for the current "Structural element". An inline variant exists
@@ -488,7 +452,7 @@ function count()
 }
 ```
 
-### 5.7. @global
+### 5.6. @global
 
 TODO: The definition of this item should be discussed and whether it may or
 may not be superseded in part or in whole by the @var tag.
@@ -529,7 +493,7 @@ variable and a variable documented in the project.
 
 (TODO: Examples for this tag should be added)
 
-### 5.8. @internal
+### 5.7. @internal
 
 The @internal tag is used to denote that the associated "Structural Element" is
 a structure internal to this application or library. It may also be used inside
@@ -599,7 +563,7 @@ function count()
 }
 ```
 
-### 5.9. @license
+### 5.8. @license
 
 The @license tag is used to indicate which license is applicable for the
 associated 'Structural Elements'.
@@ -639,7 +603,7 @@ license.
  */
 ```
 
-### 5.10. @link
+### 5.9. @link
 
 The @link tag indicates a custom relation between the associated
 "Structural Element" and a website, which is identified by an absolute URI.
@@ -689,7 +653,7 @@ function count()
 }
 ```
 
-### 5.11. @method
+### 5.10. @method
 
 The @method allows a class to know which 'magic' methods are callable.
 
@@ -739,7 +703,7 @@ class Child extends Parent
 }
 ```
 
-### 5.12. @package
+### 5.11. @package
 
 The @package tag is used to categorize "Structural Elements" into logical
 subdivisions.
@@ -788,7 +752,7 @@ This tag MUST NOT occur more than once in a "DocBlock".
  */
 ```
 
-### 5.13. @param
+### 5.12. @param
 
 The @param tag is used to document a single parameter of a function or method.
 
@@ -828,7 +792,7 @@ function count(array $items)
 }
 ```
 
-### 5.14. @property
+### 5.13. @property
 
 The `@property` tag is used to declare which "magic" properties are supported.
 
@@ -877,7 +841,7 @@ class User
 }
 ```
 
-### 5.15. @return
+### 5.14. @return
 
 The @return tag is used to document the return value of functions or methods.
 
@@ -926,7 +890,7 @@ function getLabel()
 }
 ```
 
-### 5.16. @see
+### 5.15. @see
 
 The @see tag indicates a reference from the associated "Structural Elements" to
 a website or other "Structural Elements".
@@ -968,7 +932,7 @@ function count()
 }
 ```
 
-### 5.17. @since
+### 5.16. @since
 
 The @since tag is used to denote _when_ an element was introduced or modified,
 using some description of "versioning" to that element.
@@ -1018,7 +982,7 @@ class Foo
 }
 ```
 
-### 5.18. @subpackage [deprecated]
+### 5.17. @subpackage [deprecated]
 
 The @subpackage tag is used to categorize "Structural Elements" into logical
 subdivisions.
@@ -1052,7 +1016,7 @@ DocBlock.
  */
 ```
 
-### 5.19. @throws
+### 5.18. @throws
 
 The @throws tag is used to indicate whether "Structural Elements" throw a
 specific type of Throwable (exception or error).
@@ -1095,7 +1059,7 @@ function count($items)
 }
 ```
 
-### 5.20. @todo [WG++]
+### 5.19. @todo [WG++]
 
 The @todo tag is used to indicate whether any development activities should
 still be executed on associated "Structural Elements".
@@ -1127,7 +1091,7 @@ function count()
 }
 ```
 
-### 5.21. @uses
+### 5.20. @uses
 
 Indicates whether the current "Structural Element" consumes the
 "Structural Element", or project file, that is provided as target.
@@ -1180,7 +1144,7 @@ function executeMyView()
 }
 ```
 
-### 5.22. @var
+### 5.21. @var
 
 You may use the @var tag to document the "Type" of the following
 "Structural Elements":
@@ -1284,7 +1248,7 @@ class Foo
 }
 ```
 
-### 5.23. @version
+### 5.22. @version
 
 The @version tag is used to denote some description of "versioning" to an
 element.

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -70,9 +70,9 @@ parts if that part is absent:
 * [Summary]([PHPDOC_PSR]#51-summary)
 * [Description]([PHPDOC_PSR]#52-description) and
 * A specific subset of [Tags]([PHPDOC_PSR]#53-tags):
-  * [@version](#525-version)
+  * [@version](#519-version)
   * [@author](#52-author)
-  * [@copyright](#54-copyright)
+  * [@copyright](#53-copyright)
 
 The PHPDoc for each type of "Structural Element" MUST also inherit a
 specialized subset of tags depending on which "Structural Element" is
@@ -171,23 +171,23 @@ combination of the Description of the super-element, indicated by the
 In addition to the inherited descriptions and tags as defined in this chapter's
 root, a class or interface MUST inherit the following tags:
 
-* [@package](#512-package)
+* [@package](#59-package)
 
 ### 4.3.2. Function Or Method
 
 In addition to the inherited descriptions and tags as defined in this chapter's
 root, a function or method in a class or interface MUST inherit the following tags:
 
-* [@param](#513-param)
-* [@return](#515-return)
-* [@throws](#520-throws)
+* [@param](#510-param)
+* [@return](#512-return)
+* [@throws](#515-throws)
 
 ### 4.3.3. Constant Or Property
 
 In addition to the inherited descriptions and tags as defined in this chapter's
 root, a constant or property in a class MUST inherit the following tags:
 
-* [@var](#522-type)
+* [@var](#518-type)
 
 ## 5. Tags
 

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -290,33 +290,13 @@ deprecated and are to be removed in a future version.
 
 #### Syntax
 
-    @deprecated [<"Semantic Version">][:<"Semantic Version">] [<description>]
+    @deprecated [<"Semantic Version">] [<description>]
 
 #### Description
 
 The @deprecated tag declares that the associated 'Structural elements' will
 be removed in a future version as it has become obsolete or its usage is
 otherwise not recommended.
-
-This tag MAY specify up to two version numbers in the sense of a version number
-range:
-
-The first version number, referred to as the 'starting version', denotes the
-version in which the associated element has been deprecated.
-
-The second version number, referred to as the 'ending version', denotes the
-version in which the associated element is scheduled for removal.
-
-If an 'ending version' has been specified, the associated 'Structural elements'
-MAY no longer exist in the 'ending version' and MAY be removed without further
-notice in that version or a later version, but MUST exist in all prior versions.
-
-It is RECOMMENDED to specify both a 'starting version' and an 'ending version'.
-In this case, the two version numbers MUST be separated by a colon (`:`) without
-white-space in between.
-
-The 'starting version' MAY be omitted. In this case, the 'ending version' MUST
-be preceded by a colon.
 
 This tag MAY provide an additional description stating why the associated
 element is deprecated.
@@ -330,12 +310,7 @@ If the associated element is superseded by another it is RECOMMENDED to add a
 /**
  * @deprecated
  *
- * @deprecated 1.0.0:2.0.0
- * @see \New\Recommended::method()
- *
  * @deprecated 1.0.0
- *
- * @deprecated :2.0.0
  *
  * @deprecated No longer used by internal code and not recommended.
  *

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -19,23 +19,22 @@ PSR-19: PHPDoc tags
   - [5.3.  @copyright](#53-copyright)
   - [5.4.  @deprecated](#54-deprecated)
   - [5.5.  @example](#55-example)
-  - [5.6.  @global](#56-global)
-  - [5.7.  @internal](#57-internal)
-  - [5.8.  @license](#58-license)
-  - [5.9.  @link](#59-link)
-  - [5.10. @method](#510-method)
-  - [5.11. @package](#511-package)
-  - [5.12. @param](#512-param)
-  - [5.13. @property](#513-property)
-  - [5.14. @return](#514-return)
-  - [5.15. @see](#515-see)
-  - [5.16. @since](#516-since)
-  - [5.17. @subpackage [deprecated]](#517-subpackage-deprecated)
-  - [5.18. @throws](#518-throws)
-  - [5.19. @todo](#519-todo)
-  - [5.20. @uses](#520-uses)
-  - [5.21. @var](#521-var)
-  - [5.22. @version](#522-version)
+  - [5.6.  @internal](#56-internal)
+  - [5.7.  @license](#57-license)
+  - [5.8.  @link](#58-link)
+  - [5.9.  @method](#59-method)
+  - [5.10. @package](#510-package)
+  - [5.11. @param](#511-param)
+  - [5.12. @property](#512-property)
+  - [5.13. @return](#513-return)
+  - [5.14. @see](#514-see)
+  - [5.15. @since](#515-since)
+  - [5.16. @subpackage [deprecated]](#516-subpackage-deprecated)
+  - [5.17. @throws](#517-throws)
+  - [5.18. @todo](#518-todo)
+  - [5.19. @uses](#519-uses)
+  - [5.20. @var](#520-var)
+  - [5.21. @version](#521-version)
 
 ## 1. Introduction
 
@@ -452,48 +451,7 @@ function count()
 }
 ```
 
-### 5.6. @global
-
-TODO: The definition of this item should be discussed and whether it may or
-may not be superseded in part or in whole by the @var tag.
-
-The @global tag is used to denote a global variable or its usage.
-
-#### Syntax
-
-    @global ["Type"] [name]
-    @global ["Type"] [description]
-
-#### Description
-
-Since there is no standard way to declare global variables, a @global tag MAY
-be used in a DocBlock preceding a global variable's definition. To support
-previous usages of @global, there is an alternate syntax that applies to
-DocBlocks preceding a function, used to document usage of global
-variables. In other words, there are two usages of @global: definition and
-usage.
-
-##### Syntax for the Global's Definition
-
-Only one @global tag MAY be allowed per global variable DocBlock. A global
-variable DocBlock MUST be followed by the global variable's definition before
-any other element or DocBlock occurs.
-
-The name MUST be the exact name of the global variable as it is declared in
-the source.
-
-##### Syntax for the Global's Usage
-
-The function/method @global syntax MAY be used to document usage of global
-variables in a function, and MUST NOT have a $ starting the third word. The
-"Type" will be ignored if a match is made between the declared global
-variable and a variable documented in the project.
-
-#### Examples
-
-(TODO: Examples for this tag should be added)
-
-### 5.7. @internal
+### 5.6. @internal
 
 The @internal tag is used to denote that the associated "Structural Element" is
 a structure internal to this application or library. It may also be used inside
@@ -563,7 +521,7 @@ function count()
 }
 ```
 
-### 5.8. @license
+### 5.7. @license
 
 The @license tag is used to indicate which license is applicable for the
 associated 'Structural Elements'.
@@ -603,7 +561,7 @@ license.
  */
 ```
 
-### 5.9. @link
+### 5.8. @link
 
 The @link tag indicates a custom relation between the associated
 "Structural Element" and a website, which is identified by an absolute URI.
@@ -653,7 +611,7 @@ function count()
 }
 ```
 
-### 5.10. @method
+### 5.9. @method
 
 The @method allows a class to know which 'magic' methods are callable.
 
@@ -703,7 +661,7 @@ class Child extends Parent
 }
 ```
 
-### 5.11. @package
+### 5.10. @package
 
 The @package tag is used to categorize "Structural Elements" into logical
 subdivisions.
@@ -752,7 +710,7 @@ This tag MUST NOT occur more than once in a "DocBlock".
  */
 ```
 
-### 5.12. @param
+### 5.11. @param
 
 The @param tag is used to document a single parameter of a function or method.
 
@@ -792,7 +750,7 @@ function count(array $items)
 }
 ```
 
-### 5.13. @property
+### 5.12. @property
 
 The `@property` tag is used to declare which "magic" properties are supported.
 
@@ -841,7 +799,7 @@ class User
 }
 ```
 
-### 5.14. @return
+### 5.13. @return
 
 The @return tag is used to document the return value of functions or methods.
 
@@ -890,7 +848,7 @@ function getLabel()
 }
 ```
 
-### 5.15. @see
+### 5.14. @see
 
 The @see tag indicates a reference from the associated "Structural Elements" to
 a website or other "Structural Elements".
@@ -932,7 +890,7 @@ function count()
 }
 ```
 
-### 5.16. @since
+### 5.15. @since
 
 The @since tag is used to denote _when_ an element was introduced or modified,
 using some description of "versioning" to that element.
@@ -982,7 +940,7 @@ class Foo
 }
 ```
 
-### 5.17. @subpackage [deprecated]
+### 5.16. @subpackage [deprecated]
 
 The @subpackage tag is used to categorize "Structural Elements" into logical
 subdivisions.
@@ -1016,7 +974,7 @@ DocBlock.
  */
 ```
 
-### 5.18. @throws
+### 5.17. @throws
 
 The @throws tag is used to indicate whether "Structural Elements" throw a
 specific type of Throwable (exception or error).
@@ -1059,7 +1017,7 @@ function count($items)
 }
 ```
 
-### 5.19. @todo [WG++]
+### 5.18. @todo [WG++]
 
 The @todo tag is used to indicate whether any development activities should
 still be executed on associated "Structural Elements".
@@ -1091,7 +1049,7 @@ function count()
 }
 ```
 
-### 5.20. @uses
+### 5.19. @uses
 
 Indicates whether the current "Structural Element" consumes the
 "Structural Element", or project file, that is provided as target.
@@ -1144,7 +1102,7 @@ function executeMyView()
 }
 ```
 
-### 5.21. @var
+### 5.20. @var
 
 You may use the @var tag to document the "Type" of the following
 "Structural Elements":
@@ -1248,7 +1206,7 @@ class Foo
 }
 ```
 
-### 5.22. @version
+### 5.21. @version
 
 The @version tag is used to denote some description of "versioning" to an
 element.

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -20,20 +20,19 @@ PSR-19: PHPDoc tags
   - [5.4.  @deprecated](#54-deprecated)
   - [5.5.  @example](#55-example)
   - [5.6.  @internal](#56-internal)
-  - [5.7.  @license](#57-license)
-  - [5.8.  @link](#58-link)
-  - [5.9.  @method](#59-method)
-  - [5.10. @package](#510-package)
-  - [5.11. @param](#511-param)
-  - [5.12. @property](#512-property)
-  - [5.13. @return](#513-return)
-  - [5.14. @see](#514-see)
-  - [5.15. @since](#515-since)
-  - [5.16. @throws](#516-throws)
-  - [5.17. @todo](#517-todo)
-  - [5.18. @uses](#518-uses)
-  - [5.19. @var](#519-var)
-  - [5.20. @version](#520-version)
+  - [5.7.  @link](#57-link)
+  - [5.8.  @method](#58-method)
+  - [5.9.  @package](#59-package)
+  - [5.10. @param](#510-param)
+  - [5.11. @property](#511-property)
+  - [5.12. @return](#512-return)
+  - [5.13. @see](#513-see)
+  - [5.14. @since](#514-since)
+  - [5.15. @throws](#515-throws)
+  - [5.16. @todo](#516-todo)
+  - [5.17. @uses](#517-uses)
+  - [5.18. @var](#518-var)
+  - [5.19. @version](#519-version)
 
 ## 1. Introduction
 
@@ -488,47 +487,7 @@ function count()
 }
 ```
 
-### 5.7. @license
-
-The @license tag is used to indicate which license is applicable for the
-associated 'Structural Elements'.
-
-#### Syntax
-
-    @license [<SPDX identifier>|URI] [name]
-
-#### Description
-
-The @license tag provides licensing information to the user, which is applicable
-to 'Structural Elements' and their child elements.
-
-The first parameter MUST be either a 'SPDX identifier', as defined by the
-[SPDX Open Source License Registry][SPDX], or a URL to a document containing
-the full license text.
-
-The second parameter MAY be the official name of the applicable license.
-
-It is RECOMMENDED to only specify an 'SPDX identifier' and to apply @license
-tags to file-level 'PHPDoc' only, since multiple varying licenses within a
-single file may cause confusion with regard to which license applies at which
-time.
-
-In case multiple licenses apply, there MUST be one @license tag per applicable
-license.
-
-#### Examples
-
-```php
-/**
- * @license MIT
- *
- * @license GPL-2.0-or-later
- *
- * @license http://www.spdx.org/licenses/MIT MIT License
- */
-```
-
-### 5.8. @link
+### 5.7. @link
 
 The @link tag indicates a custom relation between the associated
 "Structural Element" and a website, which is identified by an absolute URI.
@@ -578,7 +537,7 @@ function count()
 }
 ```
 
-### 5.9. @method
+### 5.8. @method
 
 The @method allows a class to know which 'magic' methods are callable.
 
@@ -628,7 +587,7 @@ class Child extends Parent
 }
 ```
 
-### 5.10. @package
+### 5.9. @package
 
 The @package tag is used to categorize "Structural Elements" into logical
 subdivisions.
@@ -677,7 +636,7 @@ This tag MUST NOT occur more than once in a "DocBlock".
  */
 ```
 
-### 5.11. @param
+### 5.10. @param
 
 The @param tag is used to document a single parameter of a function or method.
 
@@ -717,7 +676,7 @@ function count(array $items)
 }
 ```
 
-### 5.12. @property
+### 5.11. @property
 
 The `@property` tag is used to declare which "magic" properties are supported.
 
@@ -766,7 +725,7 @@ class User
 }
 ```
 
-### 5.13. @return
+### 5.12. @return
 
 The @return tag is used to document the return value of functions or methods.
 
@@ -815,7 +774,7 @@ function getLabel()
 }
 ```
 
-### 5.14. @see
+### 5.13. @see
 
 The @see tag indicates a reference from the associated "Structural Elements" to
 a website or other "Structural Elements".
@@ -857,7 +816,7 @@ function count()
 }
 ```
 
-### 5.15. @since
+### 5.14. @since
 
 The @since tag is used to denote _when_ an element was introduced or modified,
 using some description of "versioning" to that element.
@@ -907,7 +866,7 @@ class Foo
 }
 ```
 
-### 5.16. @throws
+### 5.15. @throws
 
 The @throws tag is used to indicate whether "Structural Elements" throw a
 specific type of Throwable (exception or error).
@@ -950,7 +909,7 @@ function count($items)
 }
 ```
 
-### 5.17. @todo [WG++]
+### 5.16. @todo [WG++]
 
 The @todo tag is used to indicate whether any development activities should
 still be executed on associated "Structural Elements".
@@ -982,7 +941,7 @@ function count()
 }
 ```
 
-### 5.18. @uses
+### 5.17. @uses
 
 Indicates whether the current "Structural Element" consumes the
 "Structural Element", or project file, that is provided as target.
@@ -1035,7 +994,7 @@ function executeMyView()
 }
 ```
 
-### 5.19. @var
+### 5.18. @var
 
 You may use the @var tag to document the "Type" of the following
 "Structural Elements":
@@ -1139,7 +1098,7 @@ class Foo
 }
 ```
 
-### 5.20. @version
+### 5.19. @version
 
 The @version tag is used to denote some description of "versioning" to an
 element.

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -29,12 +29,11 @@ PSR-19: PHPDoc tags
   - [5.13. @return](#513-return)
   - [5.14. @see](#514-see)
   - [5.15. @since](#515-since)
-  - [5.16. @subpackage [deprecated]](#516-subpackage-deprecated)
-  - [5.17. @throws](#517-throws)
-  - [5.18. @todo](#518-todo)
-  - [5.19. @uses](#519-uses)
-  - [5.20. @var](#520-var)
-  - [5.21. @version](#521-version)
+  - [5.16. @throws](#516-throws)
+  - [5.17. @todo](#517-todo)
+  - [5.18. @uses](#518-uses)
+  - [5.19. @var](#519-var)
+  - [5.20. @version](#520-version)
 
 ## 1. Introduction
 
@@ -174,38 +173,6 @@ In addition to the inherited descriptions and tags as defined in this chapter's
 root, a class or interface MUST inherit the following tags:
 
 * [@package](#512-package)
-
-A class or interface SHOULD inherit the following deprecated tags if supplied:
-
-* [@subpackage](#519-subpackage-deprecated)
-
-The @subpackage MUST NOT be inherited if the @package name of the
-super-class (or interface) is not the same as the @package of the child class
-(or interface).
-
-Example:
-
-```php
-/**
- * @package    Framework
- * @subpackage Controllers
- */
-class Framework_ActionController
-{
-    <...>
-}
-
-/**
- * @package My
- */
-class My_ActionController extends Framework_ActionController
-{
-    <...>
-}
-```
-
-In the example above the My_ActionController MUST NOT inherit the subpackage
-_Controllers_.
 
 ### 4.3.2. Function Or Method
 
@@ -940,41 +907,7 @@ class Foo
 }
 ```
 
-### 5.16. @subpackage [deprecated]
-
-The @subpackage tag is used to categorize "Structural Elements" into logical
-subdivisions.
-
-#### Syntax
-
-    @subpackage [name]
-
-#### Description
-
-The @subpackage tag MAY be used as a counterpart or supplement to Namespaces.
-Namespaces provide a functional subdivision of "Structural Elements" where
-the @subpackage tag can provide a *logical* subdivision in which way the
-elements can be grouped with a different hierarchy.
-
-If, across the board, both logical and functional subdivisions are equal it is
-NOT RECOMMENDED to use the @subpackage tag, to prevent maintenance overhead.
-
-The @subpackage tag MUST only be used in a specific series of DocBlocks, as is
-described in the documentation for the @package tag.
-
-This tag MUST accompany a @package tag and MUST NOT occur more than once per
-DocBlock.
-
-#### Examples
-
-```php
-/**
- * @package PSR
- * @subpackage Documentation\API
- */
-```
-
-### 5.17. @throws
+### 5.16. @throws
 
 The @throws tag is used to indicate whether "Structural Elements" throw a
 specific type of Throwable (exception or error).
@@ -1017,7 +950,7 @@ function count($items)
 }
 ```
 
-### 5.18. @todo [WG++]
+### 5.17. @todo [WG++]
 
 The @todo tag is used to indicate whether any development activities should
 still be executed on associated "Structural Elements".
@@ -1049,7 +982,7 @@ function count()
 }
 ```
 
-### 5.19. @uses
+### 5.18. @uses
 
 Indicates whether the current "Structural Element" consumes the
 "Structural Element", or project file, that is provided as target.
@@ -1102,7 +1035,7 @@ function executeMyView()
 }
 ```
 
-### 5.20. @var
+### 5.19. @var
 
 You may use the @var tag to document the "Type" of the following
 "Structural Elements":
@@ -1206,7 +1139,7 @@ class Foo
 }
 ```
 
-### 5.21. @version
+### 5.20. @version
 
 The @version tag is used to denote some description of "versioning" to an
 element.

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -610,21 +610,9 @@ Each level in the logical hierarchy MUST separated with a backslash (`\`) to
 be familiar to Namespaces. A hierarchy MAY be of endless depth but it is
 RECOMMENDED to keep the depth at less or equal than six levels.
 
-Please note that the @package applies to different "Structural Elements"
-depending where it is defined.
-
-1. If the @package is defined in the *file-level* DocBlock then it only applies
-   to the following elements in the applicable file:
-    * global functions
-    * global constants
-    * global variables
-    * requires and includes
-
-2. If the @package is defined in a *namespace-level* or *class-level* DocBlock
-   then the package applies to that namespace, class or interface and their
-   contained elements.
-   This means that a function which is contained in a namespace with the
-   @package tag assumes that package.
+The package applies to that namespace, class or interface and their contained
+elements. This means that a function which is contained in a namespace with the
+@package tag assumes that package.
 
 This tag MUST NOT occur more than once in a "DocBlock".
 

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -14,8 +14,7 @@ PSR-5: PHPDoc
     - [5.3.1. Tag Name](#531-tag-name)
     - [5.3.2. Tag Specialization](#532-tag-specialization)
     - [5.3.3. Tag Signature](#533-tag-signature)
-  - [5.4. Inline PHPDoc](#54-inline-phpdoc)
-  - [5.5. Examples](#55-examples)
+  - [5.4. Examples](#54-examples)
 - [Appendix A. Types](#appendix-a-types)
   - [ABNF](#abnf)
   - [Details](#details)
@@ -156,9 +155,6 @@ interpreted as described in [RFC 2119][RFC2119].
 * "Tag" is a single piece of meta information regarding a "Structural Element"
   or a component thereof.
 
-* "Inline PHPDoc" is a "PHPDoc" that is related to a "Tag" instead of a
-  "Structural element". It replaces the description part of the "Tag".
-
 * "Type" is the determination of what type of data is associated with an element.
   This is commonly used when determining the exact values of arguments, constants,
   properties and more.
@@ -207,7 +203,6 @@ The PHPDoc format has the following [ABNF][RFC5234]
 definition:
 
     PHPDoc             = [summary] [description] [tags]
-    inline-phpdoc      = "{" *SP PHPDoc *SP "}"
     summary            = *CHAR (2*CRLF)
     description        = 1*(CHAR / inline-tag) 1*CRLF ; any amount of characters
                                                      ; with inline tags inside
@@ -216,7 +211,7 @@ definition:
     tag                = "@" tag-name [":" tag-specialization] [tag-details]
     tag-name           = (ALPHA / "\") *(ALPHA / DIGIT / "\" / "-" / "_")
     tag-specialization = 1*(ALPHA / DIGIT / "-")
-    tag-details        = *SP (SP tag-description / tag-signature / inline-phpdoc)
+    tag-details        = *SP (SP tag-description / tag-signature )
     tag-description    = 1*(CHAR / CRLF)
     tag-signature      = "(" *tag-argument ")"
     tag-argument       = *SP 1*CHAR [","] *SP
@@ -265,7 +260,7 @@ Common uses for the Description are (amongst others):
 Tags provide a way for authors to supply concise meta-data regarding the
 succeeding "Structural Element". Each tag starts on a new line, followed
 by an at-sign (@) and a tag-name, followed by white-space and meta-data
-(including a description) or Inline PHPDoc.
+(including a description).
 
 If meta-data is provided, it MAY span multiple lines and COULD follow a
 strict format, and as such provide parameters, as dictated by the type of tag.
@@ -384,49 +379,7 @@ The contents of a signature are to be determined by the tag type (as described
 in the tag-name) and fall beyond the scope of this specification. However, a
 tag-signature MUST NOT be followed by a description or other form of meta-data.
 
-### 5.4. Inline PHPDoc
-
-Specific Tags MAY have an "Inline PHPDoc" section at the end of the "Tag"
-definition. An "Inline PHPDoc" is a "PHPDoc" element enclosed in braces and is
-only present at the end of a "Tag" sequence, unless specified otherwise in a
-"Tag" definition. The "Inline PHPDoc" element MUST replace any description that
-COULD have been provided.
-
-An example is the `@method` tag. This tag can be augmented using an
-"Inline PHPDoc" to provide additional information regarding the parameters,
-return value or any other tag supported by functions and methods.
-
-An example of this is:
-
-```php
-/**
- * @method int MyMagicMethod(string $argument1) {
- *     This is the summary for MyMagicMethod.
- *
- *     @param string $argument1 Description for argument 1.
- *
- *     @return int
- * }
- */
-class MyMagicClass
-{
-    ...
-}
-```
-
-This example shows how the `@method` tag for the Magic Method
-`MyMagicMethod` has a complete PHPDoc definition associated with it. In this
-definition, all constraints, constructs and tags that apply to a normal usage of
-PHPDoc also apply.
-
-The meaning of an "Inline PHPDoc" element differs based on the context in which
-it is provided. In the example above the "Inline PHPDoc" provides a regular
-PHPDoc definition as would precede a method.
-
-To prevent confusion regarding the function of "Inline PHPDoc" elements, their usage
-MUST be restricted to tags and locations that are documented.
-
-### 5.5. Examples
+### 5.4. Examples
 
 The following examples serve to illustrate the basic use of DocBlocks; it is
 advised to read through the list of tags in the [Tag Catalog PSR][TAG_PSR].
@@ -493,24 +446,6 @@ A DocBlock may also span a single line:
 ```php
 /** @var \ArrayObject $array */
 public $array = null;
-```
-
-Some tags may even feature an "Inline PHPDoc":
-
-```php
-/**
- * @method int MyMagicMethod(string $argument1) {
- *     This is the summary for MyMagicMethod.
- *
- *     @param string $argument1 Description for argument 1.
- *
- *     @return int
- * }
- */
-class MyMagicClass
-{
-    ...
-}
 ```
 
 ## Appendix A. Types

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -59,7 +59,6 @@ interpreted as described in [RFC 2119][RFC2119].
 * "Structural Element" is a collection of Programming Constructs which MAY be
   preceded by a DocBlock. The collection contains the following constructs:
 
-  * file
   * require(_once)
   * include(_once)
   * class
@@ -201,42 +200,6 @@ interpreted as described in [RFC 2119][RFC2119].
   two is called a "DocBlock".
 
 * A DocBlock MUST directly precede a "Structural Element"
-
-  > An exception to this principle is the File-level DocBlock which MUST be
-  > placed at the top of a PHP source code file as the first DocBlock in a
-  > file.
-  >
-  > To prevent ambiguity when a Structural Element comes directly after a
-  > File-level DocBlock, that element MUST have its own DocBlock in
-  > addition to the File-level DocBlock.
-  >
-  > Example of a valid File-level DocBlock:
-  >
-  > ```
-  > <?php
-  > /**
-  >  * This is a file-level DocBlock
-  >  */
-  >
-  > /**
-  >  * This is a class DocBlock
-  >  */
-  > class MyClass
-  > {
-  > }
-  > ```
-  >
-  > Example of an invalid File-level DocBlock
-  >
-  > ```
-  > <?php
-  > /**
-  >  * This is a class DocBlock
-  >  */
-  > class MyClass
-  > {
-  > }
-  > ```
 
 ## 5. The PHPDoc Format
 


### PR DESCRIPTION
Removed these tags altogether, rather than specify them and immediately deprecate them:  category, subpackage, global.

Removed specification of File-Level DocBlock.  Without these, the license tag doesn't have much use, so removed it as well.

Removed specification of Inline PHPDoc, since it's not something that was ever implemented.

Removed Ending Version portion of deprecated tag, since it was a new addition that was also never implemented.