### PR TITLE
Add statement about compound statements

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -921,7 +921,7 @@ The @var tag MUST contain the name of the element it documents. An exception
 to this is when property declarations only refer to a single property. In this
 case the name of the property MAY be omitted.
 
-This is used when compound statements are used to define a series of Constants
+`element_name` is used when compound statements are used to define a series of Constants
 or Properties. Such a compound statement can only have one DocBlock while several
 items are represented.
 

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -109,7 +109,7 @@ interpreted as described in [RFC 2119][RFC2119].
   }
   ```
 
-  It is NOT RECOMMENDED to use compound definitions for Constants or Properties. Since the
+  It is NOT RECOMMENDED to use compound definitions for Constants or Properties, since the
   handling of DocBlocks in these situations can lead to unexpected results. If compound statement is
   used each element SHOULD have a preceding DocBlock.
 

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -109,6 +109,27 @@ interpreted as described in [RFC 2119][RFC2119].
   }
   ```
 
+  It is NOT RECOMMENDED to use compound definitions for Constants or Properties. Since the
+  handling of DocBlocks in these situations can lead to unexpected results. If compound statement is
+  used each element SHOULD have a preceding DocBlock.
+
+  Example:
+
+  ```php
+    class Foo
+    {
+      protected
+        /**
+         * @var string Should contain a description
+         */
+        $name,
+        /**
+         * @var string Should contain a description
+         */
+        $description;
+    }
+  ```
+
   An example of use that falls beyond the scope of this Standard is to document
   the variable in a foreach explicitly; several IDEs use this information to
   assist their auto-completion functionality.


### PR DESCRIPTION
Compound statements can lead to very unclear behavior in IDE's
and api-doc generators. Thus they should be avoided.