### PR TITLE
add missing requirements for internal file pointers

### DIFF
--- a/accepted/PSR-17-http-factory-meta.md
+++ b/accepted/PSR-17-http-factory-meta.md
@@ -268,6 +268,28 @@ the time this proposal was developed allowed a string URI when creating a
 `UriInterface` implementation they provided. As such, accepting a string is
 expedient and follows existing semantics.
 
+### 5.7 Why are Streams created with the read/write pointer at the beginning?
+
+The primary use case of `StreamFactoryInterface::createStream()` and
+`StreamFactoryInterface::createStreamFromFile()` is to create streams for the
+body of a `ResponseInterface` instance to be emitted as an HTTP response.
+
+An emitter can make no assumptions about streams (or their internal resource
+handles) being repeatable, and therefore can't simply `rewind()` the stream.
+
+Even in the case where a stream returns `true` for `isSeekable()`, rewinding
+the stream could have unacceptable performance implications. Similarly, the
+`__toString()` method results in unacceptable memory overhead for large streams.
+
+Consequently, to efficiently emit the body stream of a `ResponseInterface`
+instance as body of an HTTP response, we must be able to make an assumption
+about the stream pointer being positioned at the beginning of the stream.
+
+As for `StreamFactoryInterface::createStreamFromResource()`, the caller is
+responsible for the creation of the PHP resource to use as the basis for the
+stream, and therefore also assumes responsibility for the read/write pointer
+state of the resource and resulting stream.
+
 ## 6. People
 
 This PSR was produced by a FIG Working Group with the following members:

--- a/accepted/PSR-17-http-factory.md
+++ b/accepted/PSR-17-http-factory.md
@@ -117,6 +117,9 @@ interface StreamFactoryInterface
      * Create a new stream from a string.
      *
      * The stream SHOULD be created with a temporary resource.
+     * 
+     * The stream MUST be created with the current position of the file read/write
+     * pointer at the beginning of the stream.
      *
      * @param string $content String content with which to populate the stream.
      */
@@ -130,6 +133,9 @@ interface StreamFactoryInterface
      *
      * The `$filename` MAY be any string supported by `fopen()`.
      *
+     * The stream MUST be created with the current position of the file read/write
+     * pointer at the beginning of the stream.
+     *
      * @param string $filename The filename or stream URI to use as basis of stream.
      * @param string $mode The mode with which to open the underlying filename/stream.
      *
@@ -142,6 +148,8 @@ interface StreamFactoryInterface
      * Create a new stream from an existing resource.
      *
      * The stream MUST be readable and may be writable.
+     *
+     * The current read/write position of the given PHP resource MUST NOT be modified.
      *
      * @param resource $resource The PHP resource to use as the basis for the stream.
      */


### PR DESCRIPTION
I am proposing the following amendment to PSR-17.

I am aware of the [amendments clause of the bylaws](https://www.php-fig.org/bylaws/psr-amendments/):

> Following the rules of the workflow bylaw, once a PSR has been “Accepted” the PSR meaning cannot change, backwards compatibility must remain at 100%, and any confusion that arises from original wording can be clarified through errata.
> 
> The rules for errata are covered in the workflow bylaw, and only allow non-backwards compatible clarification to be added to the meta document. Sometimes, modifications will be necessary in PSR document itself, and this document outlines those cases.

The question here is what exactly is implied by "backwards compatibility".

In the usual sense of "backwards compatibility" with regards to a class, for example, the addition of a new feature (such as a new method or optional argument) maintains "backwards compatibility", in the sense that it doesn't *change* something that already exists.

In the same sense, the omission of this important detail in the specification doesn't *change* something that already exists, but rather adds something that was missing and thereby addresses a problem with the existing specification.

While this will render some existing implementations "buggy", these were already "buggy", in the sense that they can't actually be used with existing emitters or with predictable results, as per the circumstances described in proposed section 5.7 of `PSR-17-http-factory-meta.md`.

---

The issue was debated on the forum here:

https://groups.google.com/forum/#!topic/php-fig/S5YIw-Pu1yM
