### PR TITLE
Final passthrough on PSR-14

### DIFF
--- a/proposed/event-dispatcher-meta.md
+++ b/proposed/event-dispatcher-meta.md
@@ -3,7 +3,7 @@ Event Dispatcher Meta Document
 
 ## 1. Summary
 
-The purpose of this document is to describe the rationale and logic behind the Event Dispatcher PSR.
+The purpose of this document is to describe the rationale and logic behind the Event Dispatcher specification.
 
 ## 2. Why Bother?
 
@@ -16,15 +16,15 @@ This is a well-established model, but a standard mechanism by which libraries do
 ### 3.1 Goals
 
 * Simplify and standardize the process by which libraries and components may expose themselves to extension via "events" so that they may be more easily incorporated into applications and frameworks.
-* Simplify and standardize the process by which libraries and components may register an interest in responding to an event so that they may be more easily incorporated into arbitrary applications and frameworks.
+* Simplify and standardize the process by which libraries and components may register an interest in responding to an Event so that they may be more easily incorporated into arbitrary applications and frameworks.
 * To the extent feasible, ease the process for existing code bases to transition toward this specification.
 
 ### 3.2 Non-Goals
 
 * Asynchronous systems often have a concept of an "event loop" to manage interleaving coroutines.  That is an unrelated matter and explicitly irrelevant to this specification.
-* Storage systems implementing an "Event Source" pattern also have a concept of an "event".  That is unrelated to the events discussed here and explicitly out of scope.
+* Storage systems implementing an "Event Source" pattern also have a concept of an "event".  That is unrelated to the Events discussed here and explicitly out of scope.
 * Strict backward compatibility with existing event systems is not a priority and is not expected.
-* While this specification will undoubtedly suggest implementation patterns, it does not seek to define One True Event Dispatcher Implementation, only how callers and listeners communicate with that dispatcher.
+* While this specification will undoubtedly suggest implementation patterns, it does not seek to define One True Event Dispatcher Implementation, only how callers and Listeners communicate with that Dispatcher.
 
 ## 4. Approaches
 
@@ -39,11 +39,11 @@ The Working Group identified four possible workflows for event passing, based on
 
 On further review, the Working Goup determined that:
 
-* Collection was a special case of Object enhancement (the collection being the object that is enhanced)
-* Alternative chain is similarly a special case of Object enhancement, as the signature is identical and the dispatch workflow is nearly identical, albeit with an extra check included.
+* Collection was a special case of object enhancement (the collection being the object that is enhanced).
+* Alternative chain is similarly a special case of object enhancement, as the signature is identical and the dispatch workflow is nearly identical, albeit with an extra check included.
 * One-way notification is a degenerate case of the others, or can be represented as such.
 
-Although in concept one-way notification can be done asynchronously (including delaying it through a queue), in practice few explicit implementations of that model exist.  That provides fewer places from which to draw guidance on details such as proper error handling.  After much consideration the Working Group elected to not provide an explicitly separate workflow for one-way notification as it could be adequately represented as a degenerate case of the others.
+Although in concept one-way notification can be done asynchronously (including delaying it through a queue), in practice, few explicit implementations of that model exist, providing fewer places from which to draw guidance on details (such as proper error handling).  After much consideration, the Working Group elected not to provide an explicitly separate workflow for one-way notification as it could be adequately represented as a degenerate case of the others.
 
 ### 4.2 Example applications
 
@@ -51,36 +51,36 @@ Although in concept one-way notification can be done asynchronously (including d
 * Passing an object to a series of Listeners to allow it to be modified before it is saved to a persistence system.
 * Passing a collection to a series of Listeners to allow them to register values with it or modify existing values so that the Emitter may act on all of the collected information.
 * Passing some contextual information to a series of Listeners so that all of them may "vote" on what action to take, with the Emitter deciding based on the aggregate information provided.
-* Passing an object to a series of listeners and allowing any listener to terminate the process early before other listeners have completed.
+* Passing an object to a series of Listeners and allowing any Listener to terminate the process early before other Listeners have completed.
 
 ### 4.3 Immutable events
 
-Initially the Working Group wished to define all Events as immutable message objects, similar to PSR-7.  However, that proved problematic in all but the one-way notification case.  In the other scenarios Listeners needed a way to return data to the caller.  In concept there were three possible avenues:
+Initially the Working Group wished to define all Events as immutable message objects, similar to PSR-7.  However, that proved problematic in all but the one-way notification case.  In the other scenarios, Listeners needed a way to return data to the caller.  In concept, there were three possible avenues:
 
-* Make the event mutable and modify it in place.
-* Require that events be evolvable (immutable but with `with*()` methods like PSR-7 and PSR-13) and that listeners return the event to pass along.
-* Make the Event immutable but aggregate and return the return value from each Listener.
+* Make the Event mutable and modify it in place.
+* Require that Events be evolvable (immutable but with `with*()` methods like PSR-7 and PSR-13) and that Listeners return the Event to pass along.
+* Make the Event immutable, but aggregate and return the return value from each Listener.
 
-However, Stoppable Events (the alternative chain case) also needed to have a channel by which to indicate that further listeners should not be called.  That could be done either by:
+However, Stoppable Events (the alternative chain case) also needed to have a channel by which to indicate that further Listeners should not be called.  That could be done either by:
 
 * Modifying the Event (e.g., calling a `stopPropagation()` method)
-* Returning a sentinel value from the listener (`true` or `false`) to indicate that propagation should terminate.
+* Returning a sentinel value from the Listener (`true` or `false`) to indicate that propagation should terminate.
 * Evolving the Event to be stopped (`withPropagationStopped()`)
 
-Each of these alternatives have drawbacks. The first means that, at least for the purposes of indicating propagation status, events must be mutable. The second requires that listeners return a value, at least when they intend to halt event propagation; this could have ramifications with existing libraries, and potential issues in terms of documentation. The third requires that listeners return the event or mutated event in all cases, and would require dispatchers to test to ensure that the returned value is of the same type as the value passed to the listener; it effectively puts an onus both on consumers and implementers, and thus raising more potential integration issues.
+Each of these alternatives have drawbacks. The first means that, at least for the purposes of indicating propagation status, Events must be mutable. The second requires that Listeners return a value, at least when they intend to halt event propagation; this could have ramifications with existing libraries, and potential issues in terms of documentation. The third requires that Listeners return the Event or mutated Event in all cases, and would require Dispatchers to test to ensure that the returned value is of the same type as the value passed to the Listener; it effectively puts an onus both on consumers and implementers, thus raising more potential integration issues.
 
-Additionally, a desired feature was the ability to derive whether or not to stop propagation based on some values collected from the listeners.  (For example, to stop when one of them has provided a certain value, or after at least three of them have indicated a "reject this request" flag, or similar.)  While technically possible to implement as an evolvable object, such behavior is intrinsically stateful so would be highly cumbersome for both implementers and users.
+Additionally, a desired feature was the ability to derive whether or not to stop propagation based on values collected from the Listeners.  (For example, to stop when one of them has provided a certain value, or after at least three of them have indicated a "reject this request" flag, or similar.)  While technically possible to implement as an evolvable object, such behavior is intrinsically stateful, so would be highly cumbersome for both implementers and users.
 
-Having listeners return evolvable events also posed a challenge.  That pattern is not used by any known implementations in PHP or elsewhere.  It also relies on the listener to remember to return the Event (additional work for the listener author) and to not return some other, new object that might not be fully compatible with later listeners (such as a subclass or superclass of the Event).
+Having Listeners return evolvable Events also posed a challenge.  That pattern is not used by any known implementations in PHP or elsewhere.  It also relies on the Listener to remember to return the Event (additional work for the Listener author) and to not return some other, new object that might not be fully compatible with later Listeners (such as a subclass or superclass of the Event).
 
-Immutable events also rely on the event definer to respect the admonition to be immutable.  Events are, by nature, very loosely designed and the potential for implementers to ignore that part of the spec, even inadvertently, is high.
+Immutable Events also rely on the Event author to respect the admonition to be immutable.  Events are, by nature, very loosely designed, and the potential for implementers to ignore that part of the spec, even inadvertently, is high.
 
 That left two possible options:
 
-* Allow events to be mutable.
-* Require, but be unable to enforce, immutable objects with a high-ceremony interface, more work for listener authors, and a higher potential for breakage that may not be detectable at compile time.
+* Allow Events to be mutable.
+* Require, but be unable to enforce, immutable Events with a high-ceremony interface, more work for Listener authors, and a higher potential for breakage that may not be detectable at compile time.
 
-By "high-ceremony", we imply that verbose syntax and/or implementations would be required.  In the former case, listener authors would need to (a) create a new instance with the propagation flag toggled, and (b) return the new instance so that the dispatcher could examine it:
+By "high-ceremony", we imply that verbose syntax and/or implementations would be required.  In the former case, Listener authors would need to (a) create a new Event instance with the propagation flag toggled, and (b) return the new Event instance so that the Dispatcher could examine it:
 
 ```php
 function (SomeEvent $event) : SomeEvent
@@ -90,7 +90,7 @@ function (SomeEvent $event) : SomeEvent
 }
 ```
 
-In the latter case, dispatcher implementations, checks on the return value would be required:
+The latter case, Dispatcher implementations, would require checks on the return value:
 
 ```php
 foreach ($provider->getListenersForEvent($event) as $listener) {
@@ -127,13 +127,13 @@ foreach ($provider->getListenersForEvent($event) as $listener) {
 
 In both situations, we would be introducing more potential edge cases, with little benefit, and few language-level mechanisms to guide developers to correct implementation.
 
-Given these options the Working Group felt mutable events were the safer alternative.
+Given these options, the Working Group felt mutable Events were the safer alternative.
 
 That said, *there is no requirement that an Event be mutable*.  Implementers should provide mutator methods on an Event object *if and only if it is necessary* and appropriate to the use case at hand.
 
 ### 4.4 Listener registration
 
-Experimentation during development of the specification determined that there were a wide range of viable, legitimate means by which a Dispatcher could be informed of a listener.  A listener:
+Experimentation during development of the specification determined that there were a wide range of viable, legitimate means by which a Dispatcher could be informed of a Listener.  A Listener:
 
 * could be registered explicitly;
 * could be the registered explicitly based on reflection of its signature;
@@ -141,24 +141,24 @@ Experimentation during development of the specification determined that there we
 * could be registered using a before/after mechanism to control ordering more precisely;
 * could be registered from a service container;
 * could use a pre-compile step to generate code;
-* could be based on method names on objects in the event itself;
+* could be based on method names on objects in the Event itself;
 * could be limited to certain situations or contexts based on arbitrarily complex logic (only for certain users, only on certain days, only if certain system settings are present, etc).
 
-These and other mechanisms all exist in the wild today in PHP, all are valid use cases worth supporting, and few if any can be conveniently represented as a special case of another.  That is, standardizing one way, or even a small set of ways, to inform the system of a listener turned out to be impractical if not impossible without cutting off many use cases that should be supported.
+These and other mechanisms all exist in the wild today in PHP, all are valid use cases worth supporting, and few if any can be conveniently represented as a special case of another.  That is, standardizing one way, or even a small set of ways, to inform the system of a Listener turned out to be impractical if not impossible without cutting off many use cases that should be supported.
 
-The Working Group therefore chose to encapsulate the registration of listeners behind the `ListenerProviderInterface`.  A provider object may have an explicit registration mechanism available, or multiple such mechanisms, or none.  It could also be generated code produced by some compile step.  That is up to the implementer.  However, that also splits the responsibility of managing the process of dispatching an event from the process of mapping an event to listeners.  That way different implementations may be mixed-and-matched with different provider mechanisms as needed.
+The Working Group therefore chose to encapsulate the registration of Listeners behind the `ListenerProviderInterface`.  A Provider object may have an explicit registration mechanism available, or multiple such mechanisms, or none.  It could also be generated code produced by some compile step.  However, that also splits the responsibility of managing the process of dispatching an Event from the process of mapping an Event to Listeners.  That way different implementations may be mixed-and-matched with different Provider mechanisms as needed.
 
-It is even possible, and potentially advisable, to allow libraries to include their own Providers that get aggregated into a common provider that aggregates their listeners to return to the Dispatcher.  That is one possible way to handle arbitrary listener registration within an arbitrary framework, although the Working Group is clear that is not the only option.
+It is even possible, and potentially advisable, to allow libraries to include their own Providers that get aggregated into a common Provider that aggregates their Listeners to return to the Dispatcher.  That is one possible way to handle arbitrary Listener registration within an arbitrary framework, although the Working Group is clear that is not the only option.
 
-While combining the Dispatcher and Provider into a single object is a valid and permissible degenerate case, it is NOT RECOMMENDED as it reduces the flexibility of system integrators.  Instead, the provider SHOULD be composed as a dependent object.
+While combining the Dispatcher and Provider into a single object is a valid and permissible degenerate case, it is NOT RECOMMENDED as it reduces the flexibility of system integrators.  Instead, the Provider SHOULD be composed as a dependent object.
 
 ### 4.5 Deferred listeners
 
-The specification requires that the callables returned by a Provider MUST all be invoked (unless propagation is explicitly stopped) before the Dispatcher returns.  However, the specification also explicitly states that Listeners may enqueue events for later processing rather than taking immediate action.  It is also entirely permissible for a Provider to accept registration of a callable, but then wrap it in another callable before returning it to the Dispatcher.  (In that case, the wrapper is the Listener from the Dispatcher's point of view.)  That allows all of the following behaviors to be legal:
+The specification requires that the callables returned by a Provider MUST all be invoked (unless propagation is explicitly stopped) before the Dispatcher returns.  However, the specification also explicitly states that Listeners may enqueue Events for later processing rather than taking immediate action.  It is also entirely permissible for a Provider to accept registration of a callable, but then wrap it in another callable before returning it to the Dispatcher.  (In that case, the wrapper is the Listener from the Dispatcher's point of view.)  That allows all of the following behaviors to be legal:
 
-* Providers return callable listeners that were provided to them.
-* Providers return callables that create an entry in a queue that will react to the event with another callable at some later point in time.
-* Listeners may themselves create an entry in a queue that will react to the event at some later point in time.
+* Providers return callable Listeners that were provided to them.
+* Providers return callables that create an entry in a queue that will react to the Event with another callable at some later point in time.
+* Listeners may themselves create an entry in a queue that will react to the Event at some later point in time.
 * Listeners or Providers may trigger an asynchronous task, if running in an environment with support for asynchronous behavior (assuming that the result of the asynchronous task is not needed by the Emitter.)
 * Providers may perform such delay or wrapping on Listeners selectively based on arbitrary logic.
 
@@ -168,7 +168,7 @@ While technically a side effect of the design, it is essentially the same approa
 
 ### 4.6 Return values
 
-Per the spec, a Dispatcher MUST return the event it was passed to the Emitter.  That is done to provide a more ergonomic experience for users.  That is, it allows short-hands similar to the following:
+Per the spec, a Dispatcher MUST return the Event passed by the Emitter.  This is specified to provide a more ergonomic experience for users, allowing short-hands similar to the following:
 
 ```php
 $event = $dispatcher->dispatch(new SomeEvent('some context'));
@@ -199,12 +199,18 @@ Matthew Weier O'Phinney
 
 ## 6. Votes
 
-* [Entrance vote](https://groups.google.com/d/topic/php-fig/6kQFX-lhuk4/discussion)
+* [Entrance vote][]
 
-7. Relevant Links
------------------
+[Entrance vote]: https://groups.google.com/d/topic/php-fig/6kQFX-lhuk4/discussion
 
-* [Inspiration Mailing List Thread](https://groups.google.com/forum/#!topic/php-fig/-EJOStgxAwY)
-* [Entrance vote](https://groups.google.com/d/topic/php-fig/6kQFX-lhuk4/discussion)
-* [Informal poll on package structure](https://docs.google.com/forms/d/1fvhYUH6xvPgJ1UW9I-3pMGPUtxkt5_Ph6_x_3qXHIuM/edit#responses)
-* [Informal poll on naming structure](https://docs.google.com/forms/d/1Rs6APuwNx4k2VzJbTgieeNvN48kLu7CG8qn6Dd2FhTw/edit#responses)
+## 7. Relevant Links
+
+* [Inspiration Mailing List Thread][]
+* [Entrance vote][]
+* [Informal poll on package structure][]
+* [Informal poll on naming structure][]
+
+[Inspiration Mailing List Thread]: https://groups.google.com/forum/#!topic/php-fig/-EJOStgxAwY
+[Entrance vote]: https://groups.google.com/d/topic/php-fig/6kQFX-lhuk4/discussion
+[Informal poll on package structure]: https://docs.google.com/forms/d/1fvhYUH6xvPgJ1UW9I-3pMGPUtxkt5_Ph6_x_3qXHIuM/edit#responses
+[Informal poll on naming structure]: https://docs.google.com/forms/d/1Rs6APuwNx4k2VzJbTgieeNvN48kLu7CG8qn6Dd2FhTw/edit#responses

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -11,75 +11,77 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Goal
 
-Having common interfaces for dispatching and handling events, allows developers to create libraries that can interact with many frameworks and other libraries in a common fashion.
+Having common interfaces for dispatching and handling events allows developers to create libraries that can interact with many frameworks and other libraries in a common fashion.
 
 Some examples:
 
 * A security framework that will prevent saving/accessing data when a user doesn't have permission.
 * A common full page caching system.
-* Libraries that extent other specific libraries, regardless of what framework they are both integrated into.
+* Libraries that extend other libraries, regardless of what framework they are both integrated into.
 * A logging package to track all actions taken within the application
 
 ## Definitions
 
 * **Event** - An Event is a message produced by an *Emitter*.  It may be any arbitrary PHP object.
 * **Listener** - A Listener is any PHP callable that expects to be passed an Event.  Zero or more Listeners may be passed the same Event.  A Listener MAY enqueue some other asynchronous behavior if it so chooses.
-* **Emitter** - An Emitter is any arbitrary code that wishes to send an Event.  This is also known as the "calling code".  It is not represented by any particular data structure but refers to the use case.
+* **Emitter** - An Emitter is any arbitrary code that wishes to dispatch an Event.  This is also known as the "calling code".  It is not represented by any particular data structure but refers to the use case.
 * **Dispatcher** - A Dispatcher is a service object that is given an Event object by an Emitter.  The Dispatcher is responsible for ensuring that the Event is passed to all relevant Listeners, but MUST defer determining the responsible listeners to a Listener Provider.
 * **Listener Provider** - A Listener Provider is responsible for determining what Listeners are relevant for a given Event, but MUST NOT call the Listeners itself.  A Listener Provider may specify zero or more relevant Listeners.
 
 ## Events
 
-Events are objects that act as the unit of communication between an Emitter and appropriate listeners.
+Events are objects that act as the unit of communication between an Emitter and appropriate Listeners.
 
-All Events are identified primarily by their PHP type, that is, their class and any interfaces they implement.  Events SHOULD NOT have any other identifier, such as an arbitrary string ID.
+All Events are identified primarily by their PHP type: i.e., their class and any interfaces they implement.  Events SHOULD NOT have any other identifier, such as an arbitrary string ID.
 
-Event objects MAY be mutable should the use case call for listeners providing information back to the Emitter.  However, if no such bidirectional communication is needed then it is RECOMMENDED that the event be defined as immutable, that is, that it lacks mutator methods.
+Event objects MAY be mutable should the use case call for listeners providing information back to the Emitter.  However, if no such bidirectional communication is needed then it is RECOMMENDED that the event be defined as immutable; i.e., defined such that it lacks mutator methods.
 
-Implementers MUST assume that the same object will be passed to all listeners.
+Implementers MUST assume that the same object will be passed to all Listeners.
 
-It is RECOMMENDED, but NOT REQUIRED, that Event objects support lossless serialization and deserialization.  That is, `$event == unserialize(serialize($event))` SHOULD hold true.  Objects MAY leverage PHP’s Serializable interface, `__sleep()` or `__wakeup()` magic methods, or similar language functionality if appropriate.
+It is RECOMMENDED, but NOT REQUIRED, that Event objects support lossless serialization and deserialization.  That is, `$event == unserialize(serialize($event))` SHOULD hold true.  Objects MAY leverage PHP’s `Serializable` interface, `__sleep()` or `__wakeup()` magic methods, or similar language functionality if appropriate.
 
 ## Stoppable Events
 
 A **Stoppable Event** is a special case of Event that contains additional ways to prevent further Listeners from being called.  It is indicated by implementing the `StoppableEventInterface`.
 
-An Event that implements `StoppableEventInterface` MUST return `true` from `isPropagationStopped()` when whatever Event it represents has been completed.  It is up to the implementer of the class to determine when that is.  For example, an Event that is asking for a PSR-7 `RequestInterface` object to be matched with a corresponding `ResponseInterface` object MAY have a `setResponse(ResponseInterface $res)` method for a Listener to call, which sets an internal flag that `isPropagationStopped()` will use to return `true` once the response has been set.
+An Event that implements `StoppableEventInterface` MUST return `true` from `isPropagationStopped()` when whatever Event it represents has been completed.  It is up to the implementer of the class to determine when that is.  For example, an Event that is asking for a PSR-7 `RequestInterface` object to be matched with a corresponding `ResponseInterface` object MAY have a `setResponse(ResponseInterface $res)` method for a Listener to call, which causes `isPropagationStopped()` to return `true`.
 
 ## Listeners
 
-A Listener may be any PHP callable.  A Listener MUST have one and only one parameter, which is the Event to which it responds.  Listeners SHOULD type hint that parameter as specifically as is relevant for their use case; that is, a Listener MAY type hint against an interface to indicate it is compatible with any Event type that implements that interface.
+A Listener may be any PHP callable.  A Listener MUST have one and only one parameter, which is the Event to which it responds.  Listeners SHOULD type hint that parameter as specifically as is relevant for their use case; that is, a Listener MAY type hint against an interface to indicate it is compatible with any Event type that implements that interface, or to a specific implementation of that interface.
 
-A Listener MUST have a `void` return, and SHOULD type hint that return explicitly.
+A Listener SHOULD have a `void` return, and SHOULD type hint that return explicitly.
 
-A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around retrieving an object from a service container that contains the actual business logic to run, or other similar forms of indirection.  In that case the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
+A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around retrieving an object from a service container that contains the actual business logic to run, or other similar forms of indirection.  In that case, the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
 
-A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so, however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.  Additionally, the `isPropagationStopped()` method will not be called in this case and thus the Event is effectively unstoppable.
+A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so; however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.
 
 ## Dispatcher
 
-A Dispatcher is a service object implementing `EventDispatcherInterface`.  It is responsible for invoking listeners provided by a Listener Provider on an Event.
+A Dispatcher is a service object implementing `EventDispatcherInterface`.  It is responsible for invoking listeners supplied by a Listener Provider for the Event dispatched.
 
-A Dispatcher
+A Dispatcher:
 
 * MUST call Listeners synchronously in the order they are returned from a ListenerProvider.
 * MUST return the same Event object it was passed after it is done invoking Listeners.
 * MUST NOT return to the Emitter until all Listeners have executed.
-* As an exception to the previous point, if the Event is a [Promise object](https://promisesaplus.com/) then the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
+* As an exception to the previous point, if the Event is a [Promise object][] then the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
 
 If passed a Stoppable Event, a Dispatcher
 
-* MUST call `isPropagationStopped()` on the Event before each Listener has been called.  If that method returns `true` it MUST return the Event to the Emitter immediately and MUST NOT call any further Listeners.  That is, if an Event is passed to the Dispatcher that always returns `true` from `isPropagationStopped()`, zero listeners will be called.
+* MUST call `isPropagationStopped()` on the Event before each Listener has been called.  If that method returns `true` it MUST return the Event to the Emitter immediately and MUST NOT call any further Listeners.  This implies that if an Event is passed to the Dispatcher that always returns `true` from `isPropagationStopped()`, zero listeners will be called.
+
+[Promise object]: https://promisesaplus.com/
 
 ### Error handling
 
-An Exception or Error thrown by a Listener MUST block the execution of any further Listeners.  An Error or Exception thrown by a Listener MUST be allowed to propagate back up to the caller.
+An Exception or Error thrown by a Listener MUST block the execution of any further Listeners.  An Error or Exception thrown by a Listener MUST be allowed to propagate back up to the Emitter.
 
 A Dispatcher MAY catch a thrown object to log it, allow additional action to be taken, etc., but then MUST rethrow the original throwable.
 
 ## Listener Provider
 
-A Listener Provider is a service object responsible for determining what Listeners are relevant to and should be call for a given Event.  It may determine both what Listeners are relevant and the order in which to return them by whatever means it chooses.  That MAY include
+A Listener Provider is a service object responsible for determining what Listeners are relevant to and should be called for a given Event.  It may determine both what Listeners are relevant and the order in which to return them by whatever means it chooses.  That MAY include:
 
 * Allowing for some form of registration mechanism so that implementers may assign a Listener to an Event in a fixed order.
 * Deriving a list of applicable Listeners through reflection based on the type and implemented interfaces of the Event.
@@ -88,11 +90,11 @@ A Listener Provider is a service object responsible for determining what Listene
 * Extracting some information from an object referenced by the Event, such as an Entity, and calling pre-defined lifecycle methods on that object.
 * Delegating its responsibility to one or more other Listener Providers using some arbitrary logic.
 
-Or some combination of those, or some other mechanism as desired.
+Any combination of the above, or other mechanisms, MAY be used as desired.
 
-All Listeners returned by a Listener Provider MUST be type-compatible with the Event.  That is, calling `$listener($event)` MUST NOT produce a `TypeError`.
+All Listeners returned by a Listener Provider MUST be type-compatible with the Event; calling `$listener($event)` MUST NOT produce a `TypeError`.
 
-Listener Providers MUST treat parent types identically to the Event's own type when determining listener applicability.  That is, in the following case:
+Listener Providers MUST treat parent types identically to the Event's own type when determining listener applicability.  In the following case:
 
 ```php
 class A {}


### PR DESCRIPTION
This is my final passthrough on PSR-14 before we prepare our review readiness vote. In particular, I looked for the following:

- consistent casing of defined terms. In a few cases, they were left lower-case when it was clear they were referring to a broader definition.
- removal of "that is" phrases. These are a weird idiom, and better phrasing exists in almost every case, even if just dropping to the latin `i.e.`.
- rephrasing where the language was actively getting in the way of understanding.

I plan to do a review of the patch to detail some of the decisions before asking for a review by a WG member.