### PR TITLE
Fix code example in PSR-14 example

### DIFF
--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -103,7 +103,7 @@ class B extends A {}
 
 $b = new B();
 
-function listener(A $event) {}
+function listener(A $event): void {};
 ```
 
 A Listener Provider MUST treat `listener()` as an applicable listener for `$b`, as it is type compatible, unless some other criteria prevents it from doing so.


### PR DESCRIPTION
Add a `void` type hint to the listener example, as the listener SHOULD have a type hint and we want to show the best practice.