### PR TITLE
Fix minor formatting in headlines + lists

### DIFF
--- a/proposed/event-dispatcher-meta.md
+++ b/proposed/event-dispatcher-meta.md
@@ -188,14 +188,14 @@ The Event Manager Working Group consisted of:
 
 ### 5.2 Sponsor
 
-Cees-Jan Kiewiet
+* Cees-Jan Kiewiet
 
-### Working Group Members
+### 5.3 Working Group Members
 
-Benjamin Mack
-Elizabeth Smith
-Ryan Weaver
-Matthew Weier O'Phinney
+* Benjamin Mack
+* Elizabeth Smith
+* Ryan Weaver
+* Matthew Weier O'Phinney
 
 ## 6. Votes
 


### PR DESCRIPTION
This is in line with the rest of the headlines and lists, the lower section of the metadoc is adapted.