### PR TITLE
PSR-14 edits

### DIFF
--- a/proposed/event-dispatcher-meta.md
+++ b/proposed/event-dispatcher-meta.md
@@ -136,7 +136,7 @@ That said, *there is no requirement that an Event be mutable*.  Implementers sho
 Experimentation during development of the specification determined that there were a wide range of viable, legitimate means by which a Dispatcher could be informed of a Listener.  A Listener:
 
 * could be registered explicitly;
-* could be the registered explicitly based on reflection of its signature;
+* could be registered explicitly based on reflection of its signature;
 * could be registered with a numeric priority order;
 * could be registered using a before/after mechanism to control ordering more precisely;
 * could be registered from a service container;

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -42,7 +42,7 @@ It is RECOMMENDED, but NOT REQUIRED, that Event objects support lossless seriali
 
 A **Stoppable Event** is a special case of Event that contains additional ways to prevent further Listeners from being called.  It is indicated by implementing the `StoppableEventInterface`.
 
-An Event that implements `StoppableEventInterface` MUST return `true` from `isPropagationStopped()` when whatever Event it represents has been completed.  It is up to the implementer of the class to determine when that is.  For example, an Event that is asking for a PSR-7 `RequestInterface` object to be matched with a corresponding `ResponseInterface` object MAY have a `setResponse(ResponseInterface $res)` method for a Listener to call, which causes `isPropagationStopped()` to return `true`.
+An Event that implements `StoppableEventInterface` MUST return `true` from `isPropagationStopped()` when whatever Event it represents has been completed.  It is up to the implementer of the class to determine when that is.  For example, an Event that is asking for a PSR-7 `RequestInterface` object to be matched with a corresponding `ResponseInterface` object could have a `setResponse(ResponseInterface $res)` method for a Listener to call, which causes `isPropagationStopped()` to return `true`.
 
 ## Listeners
 


### PR DESCRIPTION
The extraneous 'the' shouldn't require much thought.

The `MAY` usage, though... the sentence sounds to me like it's solely describing an example to help illustrate the point.  But by using `MAY`, it implies a specific _spec-powerful_ meaning.  I didn't think that was the intent here.