### PR TITLE
Fix CC terms

### DIFF
--- a/personnel.md
+++ b/personnel.md
@@ -17,10 +17,10 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 
 | Name                                  | Term                    |
 |---------------------------------------|-------------------------|
-| Beau Simensen ([@beausimensen])       | 2016-12-24 - 2019-04-30 |
-| Larry Garfield ([@Crell])             | 2016-12-24 - 2019-04-30 |
-| Matthew Weier O'Phinney ([@mwop])     | 2016-12-24 - 2019-04-30 |
-| Sara Golemon ([@SaraMG])              | 2016-12-24 - 2019-04-30 |
+| Beau Simensen ([@beausimensen])       | 2016-12-24 - 2019-05-31 |
+| Larry Garfield ([@Crell])             | 2016-12-24 - 2019-05-31 |
+| Matthew Weier O'Phinney ([@mwop])     | 2016-12-24 - 2019-05-31 |
+| Sara Golemon ([@SaraMG])              | 2016-12-24 - 2019-05-31 |
 | Cees-Jan Kiewiet ([@WyriHaximus])     | 2016-12-24 - 2020-08-31 |
 | Lukas Kahwe Smith ([@lsmith])         | 2016-12-24 - 2020-08-31 |
 | Samantha Quiñones ([@ieatkillerbees]) | 2016-12-24 - 2020-08-31 |


### PR DESCRIPTION
I've seen something strange in the terms on the personnel page: @mstaples' term is ending in may, the CC in April. The CC's are the wrong one, since, per [our bylaws](https://www.php-fig.org/bylaws/elections-and-vacancies/#election-calendar):.

> Both Secretaries and Core Committee members are elected for two year terms with votes staggered eight months apart. One election is held in January of even numbered years, one election is held in August of even numbered years, and **one election is held in May of odd numbered years**. For example there would be elections in January 2018, August 2018 and **May 2019**. Each regular election includes a single Secretary and four (4) Core Committee members, plus any potential unplanned vacancies.