### PR TITLE
rephrase the delegate thin wrapper example

### DIFF
--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -50,7 +50,7 @@ A Listener may be any PHP callable.  A Listener MUST have one and only one param
 
 A Listener SHOULD have a `void` return, and SHOULD type hint that return explicitly.  A Dispatcher MUST ignore return values from Listeners.
 
-A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around retrieving an object from a service container that contains the actual business logic to run, or other similar forms of indirection.  In that case, the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
+A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around running the actual business logic on an object that was obtained from a service container, or other similar forms of indirection.  In that case, the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
 
 A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so; however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -50,7 +50,7 @@ A Listener may be any PHP callable.  A Listener MUST have one and only one param
 
 A Listener SHOULD have a `void` return, and SHOULD type hint that return explicitly.  A Dispatcher MUST ignore return values from Listeners.
 
-A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around running the actual business logic on an object that was obtained from a service container, or other similar forms of indirection.  In that case, the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
+A Listener MAY delegate actions to other code. That includes a Listener being a thin wrapper around running the actual business logic.
 
 A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so; however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -50,7 +50,7 @@ A Listener may be any PHP callable.  A Listener MUST have one and only one param
 
 A Listener SHOULD have a `void` return, and SHOULD type hint that return explicitly.  A Dispatcher MUST ignore return values from Listeners.
 
-A Listener MAY delegate actions to other code. That includes a Listener being a thin wrapper around running the actual business logic.
+A Listener MAY delegate actions to other code. That includes a Listener being a thin wrapper around an object that runs the actual business logic.
 
 A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so; however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.
 


### PR DESCRIPTION
If the example looks like this, I'm trying to rephrase it for better understanding:
```php
$thinWrapperListener = function(BusinessEvent $event) use ($container) {
    $businessService = $container->get(BusinessService::class);
    $businessService->process($event);
};
```