### PR TITLE
remove promise exception line

### DIFF
--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -63,7 +63,6 @@ A Dispatcher:
 * MUST call Listeners synchronously in the order they are returned from a ListenerProvider.
 * MUST return the same Event object it was passed after it is done invoking Listeners.
 * MUST NOT return to the Emitter until all Listeners have executed.
-* As an exception to the previous point, if the Event is a [Promise object][] then the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
 
 If passed a Stoppable Event, a Dispatcher
 


### PR DESCRIPTION
If the Event is a Promise, Listeners would probably attach logic to be run when the Promise will be resolved. But this would be exactly like the normal flow.
The only case where the Dispatcher could return the promise before executing all Listeners is if the Dispatcher would attach the Listeners execution logic to be run when the Promise would be resolved. But the only reason for this would be if the Listeners would be called with the event resolved Value, contradicting the main phrase of the Dispatcher section: 

> invoking each Listener with that Event

.
Also 

> the Promise MUST NOT be treated as fulfilled until all Listeners have executed

 would be hard to implement with current libraries. If I'm not wrong a promise would fulfill in regards to the initial async fulfillment logic and, if one wants to have this behavior (adding more rules to fulfillment), it would create a new Promise object based on the previous one and the Listener execution calls.

So I guess we should remove the exception case.