### PR TITLE
PSR-12: minor clarification / object declarations

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -272,9 +272,10 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 }
 ~~~
 
-Lists of `implements` and `extends` MAY be split across multiple lines, where
-each subsequent line is indented once. When doing so, the first item in the
-list MUST be on the next line, and there MUST be only one interface per line.
+Lists of `implements` and, in the case of interfaces, `extends` MAY be split
+across multiple lines, where each subsequent line is indented once. When doing
+so, the first item in the list MUST be on the next line, and there MUST be only
+one interface per line.
 
 ~~~php
 <?php


### PR DESCRIPTION
This sentence - as it was - would appear to contradict the first statement in the same section `The extends and implements keywords MUST be declared on the same line as the class name.`

Adding the `, in the case of interfaces,` snippet, takes away the contradiction as interfaces cannot _implement_.