### PR TITLE
[PSR-12] restructuring around operators

### DIFF
--- a/proposed/extended-coding-style-guide-meta.md
+++ b/proposed/extended-coding-style-guide-meta.md
@@ -160,8 +160,10 @@ specification for a full understanding of its contents.
 * Type hints - Section 4.5
 * Add finally block - Section 5.6
 * Operators - Section 6
+* Unary operators - Section 6.1
+* Binary operators - Section 6.2
+* Ternary operators - Section 6.3
 * Anonymous classes - Section 8
-* Type casting - Section 9
 
 ## 5.2. Clarifications and Errata
 

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -862,7 +862,7 @@ try {
     // try body
 } catch (FirstThrowableType $e) {
     // catch body
-} catch (OtherThrowableType $e) {
+} catch (OtherThrowableType | AnotherThrowableType $e) {
     // catch body
 } finally {
     // finally body
@@ -871,27 +871,43 @@ try {
 
 ## 6. Operators
 
-All binary and ternary operators MUST be preceded and followed by at least
-one space; multiple spaces MAY be used for readability purpose. This includes all [arithmetic][],
-[comparison][], [assignment][], [bitwise][], [logical][] (excluding `!` which is unary),
-[string concatenation][], [type][] operators, trait operators (`insteadof` and `as`),
-and the single pipe operator (e.g. `ExceptionType1 | ExceptionType2 $e`).
+Style rules for operators are grouped by arity (the number of operands they take).
 
-There MUST NOT be any whitespace between the increment/decrement operators and the variable 
-being incremented/decremented.
+When space is permitted around an operator, multiple spaces MAY be
+used for readability purposes.
 
-Other operators are left undefined.
+Any operators not described here are left undefined.
 
-For example:
+### 6.1. Unary operators
 
+The increment/decrement operators MUST NOT have any space between
+the operator and operand.
+
+Type casting operators MUST NOT have any space within the parentheses:
 ~~~php
-<?php
+$intValue = (int) $input;
+~~~
 
+### 6.2. Binary operators
+
+All binary [arithmetic][], [comparison][], [assignment][], [bitwise][],
+[logical][], [string][], and [type][] operators MUST be preceded and
+followed by at least one space:
+~~~php
 if ($a === $b) {
     $foo = $bar ?? $a ?? $b;
 } elseif ($a > $b) {
-    $variable = $foo ? 'foo' : 'bar';
+    $foo = $a + $b * $c;
 }
+~~~
+
+### 6.3. Ternary operators
+
+The conditional operator, also known simply as the ternary operator, MUST be
+preceded and followed by at least one space around both the `?`
+and `:` characters:
+~~~php
+$variable = $foo ? 'foo' : 'bar';
 ~~~
 
 ## 7. Closures
@@ -1044,22 +1060,14 @@ $instance = new class extends \Foo implements
 };
 ~~~
 
-## 9. Type Casting
-
-There MUST NOT be any spaces inside the type casting parentheses:
-
-~~~php
-$intValue = (int) $input;
-~~~
-
 [PSR-1]: http://www.php-fig.org/psr/psr-1/
 [PSR-2]: http://www.php-fig.org/psr/psr-2/
 [keywords]: http://php.net/manual/en/reserved.keywords.php
-[types]: https://secure.php.net/manual/en/reserved.other-reserved-words.php
+[types]: http://php.net/manual/en/reserved.other-reserved-words.php
 [arithmetic]: http://php.net/manual/en/language.operators.arithmetic.php
 [assignment]: http://php.net/manual/en/language.operators.assignment.php
 [comparison]: http://php.net/manual/en/language.operators.comparison.php
 [bitwise]: http://php.net/manual/en/language.operators.bitwise.php
 [logical]: http://php.net/manual/en/language.operators.logical.php
-[string concatenation]: http://php.net/manual/en/language.operators.string.php
+[string]: http://php.net/manual/en/language.operators.string.php
 [type]: http://php.net/manual/en/language.operators.type.php

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -911,8 +911,7 @@ $variable = $foo ? 'foo' : 'bar';
 ~~~
 
 When the middle operand of the conditional operator is omitted, the operator
-MUST be written as `?:` and MUST follow the same style rules as a binary
-[comparison][] operator:
+MUST follow the same style rules as other binary [comparison][] operators:
 ~~~php
 $variable = $foo ?: 'bar';
 ~~~

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -876,7 +876,7 @@ Style rules for operators are grouped by arity (the number of operands they take
 When space is permitted around an operator, multiple spaces MAY be
 used for readability purposes.
 
-Any operators not described here are left undefined.
+All operators not described here are left undefined.
 
 ### 6.1. Unary operators
 
@@ -908,6 +908,13 @@ preceded and followed by at least one space around both the `?`
 and `:` characters:
 ~~~php
 $variable = $foo ? 'foo' : 'bar';
+~~~
+
+When the middle operand of the conditional operator is omitted, the operator
+MUST be written as `?:` and MUST follow the same style rules as a binary
+[comparison][] operator:
+~~~php
+$variable = $foo ?: 'bar';
 ~~~
 
 ## 7. Closures


### PR DESCRIPTION
- removed "excluding `!` which is unary" - seemed unnecessary when `~`, `+` (identity), `-` (negation) are not listed 
- typecasting in PHP is a unary operation - relocating under operators
- removing `insteadof` and `as` from operators as they are not used within expressions.
  Similar to `as` and `=>` in `foreach ($array as $key => $value)`, `=` in `define(strict_types=1)`, etc.
  That is, they don't take one or more operands and yield a result. Additionally, styling around these
  symbols is already explained elsewhere.
- the pipe for multiple exceptions is a symbol that would be better explained under
  the `try-catch-finally` section instead of under operators (same reasoning as above)
- instead of "all binary operators MUST ..." followed by a separate list of which ones that includes, I joined the two statements to be more explicit. This also eliminates the possibility of other operators that may be classified as binary operators from being included, such as the scope resolution operator `::`, object operator `->`, etc. - as these are valid operators within expressions where both sides are operands (`($foo ? $a : $b)->{$bar ? "x" : "y"}`)
- simplified string concatenation operators to string operators. 
- restructuring operators section to be grouped by arity for readability and clarity
- minor fix of a link to be consistent with the others (http://php.net instead of https://secure.php.net)