### PR TITLE
[PSR-12] Proposed alternative to function keyword arrangements

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -63,7 +63,7 @@ class Foo extends Bar implements FooInterface
         }
     }
 
-    final public static function bar()
+    final static public function bar()
     {
         // method body
     }

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -575,11 +575,11 @@ public function process(string $algorithm, &...$parts)
 
 ### 4.6 `abstract`, `final`, and `static`
 
-When present, the `abstract` and `final` declarations MUST precede the
-visibility declaration.
+When present, optional keywords (`abstract` or `final` and `static`) MUST precede the visibility declaration.
 
-When present, the `static` declaration MUST come after the visibility
-declaration.
+When present, `static` directly precedes visibility.
+
+When `static` is NOT present, `abstract` or `final` directly precedes visibility. If `static` IS present, `abstract` or `final` directly precedes `static`.
 
 ~~~php
 <?php
@@ -588,11 +588,11 @@ namespace Vendor\Package;
 
 abstract class ClassName
 {
-    protected static $foo;
+    static protected $foo;
 
     abstract protected function zim();
 
-    final public static function bar()
+    final static public function bar()
     {
         // method body
     }


### PR DESCRIPTION
First time, apologies if over explaining and for the bumps.

Functions *require* three things (to the best of my knowledge) `function` keyword, name of function, and a parenthetical marking argument collection in that order. (Default visibility of `public`.)

PSR 12 states that optional arguments within the function MUST come last; establishing a left-right relationship between required-optional, respectively. Agreed and already a good convention from the standard library.

PSR 12 makes visibility a required keyword (`private`, `protected`, `public`) to make the implicit explicit. 

This PR suggests that visibility remain closest to the center of gravity with the other *required* elements in all instances (break from PSR-1 & 2), which is not the case as of this writing as `static` can be placed *between* visibility and `function` keywords.

Further, this PR suggests that linguistically the hierarchy reads "better" when answering the following questions in turn:

1. Does it have an implementation or not (`abstract`)?
2. Can it be overridden (`final`)?
3. Is it a class function or an instance method (`static`)?
4. How can I access it, if at all?

From left to right.