### PR TITLE
Ease requirement for "closing brace of control structure"

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -653,7 +653,9 @@ The general style rules for control structures are as follows:
 - There MUST be one space between the closing parenthesis and the opening
   brace
 - The structure body MUST be indented once
-- The closing brace MUST be on the next line after the body
+- The closing brace MUST be on the next line after the body. In case of
+  an `if-elseif-else` or `try-catch-finally` structure having two or more
+  blocks this rule only applies to the last block
 
 The body of each structure MUST be enclosed by braces. This standardizes how
 the structures look and reduces the likelihood of introducing errors as new
@@ -669,9 +671,9 @@ closing brace from the earlier body.
 <?php
 
 if ($expr1) {
-    // if body
+    // if body; blank line MAY follow
 } elseif ($expr2) {
-    // elseif body
+    // elseif body; blank line MAY follow
 } else {
     // else body;
 }
@@ -860,11 +862,11 @@ parentheses, spaces, and braces.
 <?php
 
 try {
-    // try body
+    // try body; blank line MAY follow
 } catch (FirstThrowableType $e) {
-    // catch body
+    // catch body; blank line MAY follow
 } catch (OtherThrowableType $e) {
-    // catch body
+    // catch body; blank line MAY follow
 } finally {
     // finally body
 }


### PR DESCRIPTION
Based on discussion in https://groups.google.com/forum/#!topic/php-fig/p94Hef2_ymA

Current interpretation of PSR-2 and PSR-12 standards disallows adding blank lines to visually separate branches of `if-elseif-else` constructs:
~~~php
if ($foo) {
    doFoo();

} elseif ($bar) {
    doBar();

} else {
    doSomethingElse();
}
~~~
this IMO hurts internal consistency of a standard as it mostly allows using blank lines

> to improve readability and to indicate related blocks of code

and as blank lines are allowed in equivalent `switch` constructs:
~~~php
switch (true) {
    case $foo:
        doFoo();
        break;

    case $bar:
        doBar();
        break;

    default:
        doSomethingElse()
}
~~~

While it is possible to rewrite multi-branch `if-elseif-else` to `switch`, this often looks more like code obfuscation than an improvement, as was pointed in the above thread.

This proposal allows adding trailing blank lines to bodies of multi-block control structures except the last one (`else` in the above example).