### PR TITLE
Update extended-coding-style-guide.md

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -272,7 +272,7 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 }
 ~~~
 
-Lists of `implements` and, in the case of interfaces, `extends` MAY be split
+Lists of `implements`, in the case of interfaces, and `extends` MAY be split
 across multiple lines, where each subsequent line is indented once. When doing
 so, the first item in the list MUST be on the next line, and there MUST be only
 one interface per line.


### PR DESCRIPTION
Previous text makes it look like `interfaces` references `extends`.

Sorry if PRs like these are not allowed. If that's the case, maybe the group can take the suggestion internally and decide whether it makes sense to change or not.