### PR TITLE
*Exception Implements Throwable

### DIFF
--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -416,7 +416,7 @@ namespace Psr\Cache;
 /**
  * Exception interface for all exceptions thrown by an Implementing Library.
  */
-interface CacheException implements \Throwable
+interface CacheException extends \Throwable
 {
 }
 ~~~

--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -416,7 +416,7 @@ namespace Psr\Cache;
 /**
  * Exception interface for all exceptions thrown by an Implementing Library.
  */
-interface CacheException
+interface CacheException implements \Throwable
 {
 }
 ~~~


### PR DESCRIPTION
Hello guys,

Why not implementing the Throwable interface for each exception interfaces defined by the PSRs? As you can see, it works very well: https://3v4l.org/Pf2SA. Is there any reason not doing so (except compatibility with PHP5)?

For now, each PSRs breaks all the different static analysis tools. Each of them state that a non-throwable interface can't be thrown. That's damn true and it breaks the interoperability promise IMHO. Doing so will even enforce a proper implementation of the PSR exceptions at the langage level itself.

The PHP5 compatibility seems to be the only valid argument against this and PHP 5.6 (7.0 as well) version is now [EOL](https://www.php.net/supported-versions.php). Maybe its time to propose a global update? Compatibility with old versions can still be achieved with composer using a specific version constraint. WDYT?