### PR TITLE
Use non-hypothetical formulation

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -191,7 +191,7 @@ use Vendor\Package\SomeNamespace\{
 };
 ~~~
 
-And the following would not be allowed:
+And the following is not allowed:
 ~~~php
 <?php
 


### PR DESCRIPTION
Using "be" instead of "would be" make it absolutely clear that it is unconditionally not allowed, in any and all situation