### PR TITLE
Enforce `elseif` instead of  `else if`

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -678,7 +678,7 @@ if ($expr1) {
 }
 ~~~
 
-The keyword `elseif` SHOULD be used instead of `else if` so that all control
+The keyword `elseif` MUST be used instead of `else if` so that all control
 keywords look like single words.
 
 Expressions in parentheses MAY be split across multiple lines, where each


### PR DESCRIPTION
This has a very low visual impact and is trivial to apply to existing code. So instead of leaving the specification opened to preferences, it is more beneficial to enforce our choice.

This also remove the only `SHOULD` that is not about line length, making the specification less about possibilities and more about enforced rules.