### PR TITLE
[PSR-12] Multiple small impact updates:

### DIFF
--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -76,7 +76,7 @@ class Foo extends Bar implements FooInterface
 
 Code MUST follow all rules outlined in [PSR-1].
 
-The term 'StudlyCaps' in PSR-1 MUST be interpreted as PascalCase where the first letter of
+The term '*StudlyCaps*' in PSR-1 MUST be interpreted as *PascalCase* where the first letter of
 each word is capitalized including the very first letter.
 
 ### 2.2 Files
@@ -85,7 +85,7 @@ All PHP files MUST use the Unix LF (linefeed) line ending only.
 
 All PHP files MUST end with a non-blank line, terminated with a single LF.
 
-The closing `?>` tag MUST be omitted from files containing only PHP.
+The closing `?>` tag MUST be omitted from files containing only PHP code.
 
 ### 2.3 Lines
 
@@ -96,7 +96,8 @@ The soft limit on line length MUST be 120 characters.
 Lines SHOULD NOT be longer than 80 characters; lines longer than that SHOULD
 be split into multiple subsequent lines of no more than 80 characters each.
 
-There MUST NOT be trailing whitespace at the end of lines.
+There MUST NOT be trailing whitespace at the end of lines, with the exception 
+of HEREDOC/NOWDOC syntax.
 
 Blank lines MAY be added to improve readability and to indicate related
 blocks of code except where explicitly forbidden.
@@ -114,8 +115,8 @@ All PHP reserved keywords and types [[1]][keywords][[2]][types] MUST be in lower
 
 Any new types and keywords added to future PHP versions MUST be in lower case.
 
-Short form of type keywords MUST be used i.e. `bool` instead of `boolean`,
-`int` instead of `integer` etc.
+Short form of type keywords MUST be used, i.e., `bool` instead of `boolean`,
+`int` instead of `integer`, etc.
 
 ## 3. Declare Statements, Namespace, and Import Statements
 
@@ -124,14 +125,14 @@ each of the blocks below MUST be separated by a single blank line, and MUST NOT 
 a blank line. Each block MUST be in the order listed below, although blocks that are
 not relevant may be omitted.
 
-* Opening `<?php` tag.
-* File-level docblock.
-* One or more declare statements.
-* The namespace declaration of the file.
-* One or more class-based `use` import statements.
-* One or more function-based `use` import statements.
-* One or more constant-based `use` import statements.
-* The remainder of the code in the file.
+1. Opening `<?php` tag.
+2. File-level docblock.
+3. One or more `declare` statements.
+4. The `namespace` declaration of the file.
+5. One or more class-based `use` import statements.
+6. One or more function-based `use` import statements.
+7. One or more constant-based `use` import statements.
+8. The remainder of the code in the file.
 
 When a file contains a mix of HTML and PHP, any of the above sections may still
 be used. If so, they MUST be present at the top of the file, even if the
@@ -180,6 +181,7 @@ class FooBar
 
 Compound namespaces with a depth of more than two MUST NOT be used. Therefore the
 following is the maximum compounding depth allowed:
+
 ~~~php
 <?php
 
@@ -191,7 +193,8 @@ use Vendor\Package\SomeNamespace\{
 };
 ~~~
 
-And the following would not be allowed:
+And the following would *not* be allowed:
+
 ~~~php
 <?php
 
@@ -207,6 +210,7 @@ opening and closing tags, the declaration MUST be on the first line of the file
 and include an opening PHP tag, the strict types declaration and closing tag.
 
 For example:
+
 ~~~php
 <?php declare(strict_types=1) ?>
 <html>
@@ -236,7 +240,7 @@ The term "class" refers to all classes, interfaces, and traits.
 Any closing brace MUST NOT be followed by any comment or statement on the
 same line.
 
-When instantiating a new class, parentheses MUST always be present even when
+When instantiating a new class, parentheses MUST always be present, even when
 there are no arguments passed to the constructor.
 
 ~~~php
@@ -298,7 +302,8 @@ class ClassName extends ParentClass implements
 ### 4.2 Using traits
 
 The `use` keyword used inside the classes to implement traits MUST be
-declared on the next line after the opening brace.
+declared on the next line after the first opening brace of the item 
+implementing it.
 
 ~~~php
 <?php
@@ -333,8 +338,8 @@ class ClassName
 }
 ~~~
 
-When the class has nothing after the `use` import statement, the class
-closing brace MUST be on the next line after the `use` import statement.
+When the class has nothing after the `use` import statements, the class
+closing brace MUST be on the next line after the last `use` import statement.
 
 ~~~php
 <?php
@@ -349,7 +354,7 @@ class ClassName
 }
 ~~~
 
-Otherwise, it MUST have a blank line after the `use` import statement.
+Otherwise, it MUST have a blank line after the last `use` import statement.
 
 ~~~php
 <?php
@@ -366,7 +371,7 @@ class ClassName
 }
 ~~~
 
-When using the `insteadof` and `as` operators they must be used as follows taking
+When using the `insteadof` and `as` operators, they MUST be used as follows taking
 note of indentation, spacing, and new lines.
 
 ~~~php
@@ -387,7 +392,7 @@ class Talker
 Visibility MUST be declared on all properties.
 
 Visibility MUST be declared on all constants if your project PHP minimum
-version supports constant visibilities (PHP 7.1 or later).
+version supports constant visibilities (PHP 7.1.0 or later).
 
 The `var` keyword MUST NOT be used to declare a property.
 
@@ -436,7 +441,7 @@ namespace Vendor\Package;
 
 class ClassName
 {
-    public function fooBarBaz($arg1, &$arg2, $arg3 = [])
+    public function fooBarBaz($arg1, &$arg2, $arg3 = [], &...$arg4)
     {
         // method body
     }
@@ -449,7 +454,7 @@ parentheses, commas, spaces, and braces:
 ~~~php
 <?php
 
-function fooBarBaz($arg1, &$arg2, $arg3 = [])
+function fooBarBaz($arg1, &$arg2, $arg3 = [], &...$arg4)
 {
     // function body
 }
@@ -461,7 +466,7 @@ In the argument list, there MUST NOT be a space before each comma, and there
 MUST be one space after each comma.
 
 Method and function arguments with default values MUST go at the end of the argument
-list.
+list, before the variable length argument lists.
 
 ~~~php
 <?php
@@ -470,7 +475,7 @@ namespace Vendor\Package;
 
 class ClassName
 {
-    public function foo(int $arg1, &$arg2, $arg3 = [])
+    public function foo(int $arg1, &$arg2, $arg3 = [], &...$arg4)
     {
         // method body
     }
@@ -551,10 +556,10 @@ class ReturnTypeVariations
 ~~~
 
 When using the reference operator `&` before an argument, there MUST NOT be
-a space after it, like in the previous example.
+a space after it, like in the previous examples.
 
 There MUST NOT be a space between the variadic three dot operator and the argument
-name:
+name, like in the examples above:
 
 ```php
 public function process(string $algorithm, ...$parts)
@@ -564,7 +569,7 @@ public function process(string $algorithm, ...$parts)
 ```
 
 When combining both the reference operator and the variadic three dot operator,
-there MUST NOT be any space between the two of them:
+there MUST NOT be any space between the two of them, like in the examples above:
 
 ```php
 public function process(string $algorithm, &...$parts)
@@ -611,6 +616,7 @@ each comma, and there MUST be one space after each comma.
 <?php
 
 bar();
+bar(...['foo','bar']);
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
 ~~~
@@ -647,14 +653,14 @@ $app->get('/hello/{name}', function ($name) use ($app) {
 
 The general style rules for control structures are as follows:
 
-- There MUST be one space after the control structure keyword
-- There MUST NOT be a space after the opening parenthesis
-- There MUST NOT be a space before the closing parenthesis
+- There MUST be one space after the control structure keyword.
+- There MUST NOT be a space after the opening parenthesis.
+- There MUST NOT be a space before the closing parenthesis.
 - There MUST be one space between the closing parenthesis and the opening
-  brace
-- The structure body MUST be indented once
-- The body MUST be on the next line after the opening brace
-- The closing brace MUST be on the next line after the body
+  brace.
+- The structure body MUST be indented once.
+- The body MUST be on the next line after the opening brace.
+- The closing brace MUST be on the next line after the body.
 
 The body of each structure MUST be enclosed by braces. This standardizes how
 the structures look and reduces the likelihood of introducing errors as new
@@ -686,7 +692,7 @@ subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. Boolean
 operators between conditions MUST always be at the beginning or at the end of
-the line, not a mix of both.
+the line, but not a mix of both.
 
 ~~~php
 <?php
@@ -769,7 +775,7 @@ subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. Boolean
 operators between conditions MUST always be at the beginning or at the end of
-the line, not a mix of both.
+the line, but not a mix of both.
 
 ~~~php
 <?php
@@ -796,7 +802,7 @@ do {
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. Boolean operators between conditions MUST
-always be at the beginning or at the end of the line, not a mix of both.
+always be at the beginning or at the end of the line, but not a mix of both.
 
 ~~~php
 <?php
@@ -882,10 +888,19 @@ All operators not described here are left undefined.
 
 ### 6.1. Unary operators
 
-The increment/decrement operators MUST NOT have any space between
-the operator and operand.
+The increment/decrement operators, the logical not operator, the conversion 
+and negation operators MUST NOT have any space between the operator and operand.
+
+~~~php
+$value++;
+--$value;
+$a = !$b;
+$c = +$d;
+$e = -$f;
+~~~
 
 Type casting operators MUST NOT have any space within the parentheses:
+
 ~~~php
 $intValue = (int) $input;
 ~~~
@@ -895,11 +910,14 @@ $intValue = (int) $input;
 All binary [arithmetic][], [comparison][], [assignment][], [bitwise][],
 [logical][], [string][], and [type][] operators MUST be preceded and
 followed by at least one space:
+
 ~~~php
 if ($a === $b) {
     $foo = $bar ?? $a ?? $b;
 } elseif ($a > $b) {
     $foo = $a + $b * $c;
+} elseif ($a <=> $c) {
+    $foo += $bar % $a & $b ** $c;
 }
 ~~~
 
@@ -908,12 +926,14 @@ if ($a === $b) {
 The conditional operator, also known simply as the ternary operator, MUST be
 preceded and followed by at least one space around both the `?`
 and `:` characters:
+
 ~~~php
 $variable = $foo ? 'foo' : 'bar';
 ~~~
 
 When the middle operand of the conditional operator is omitted, the operator
 MUST follow the same style rules as other binary [comparison][] operators:
+
 ~~~php
 $variable = $foo ?: 'bar';
 ~~~
@@ -1034,9 +1054,9 @@ $foo->bar(
 );
 ~~~
 
-## 8. Anonymous Classes
+## 8. Anonymous classes
 
-Anonymous Classes MUST follow the same guidelines and principles as closures
+Anonymous classes MUST follow the same guidelines and principles as closures
 in the above section.
 
 ~~~php


### PR DESCRIPTION
- wording/grammar
- new lines coherence
- examples enrichment matching given enumerated domains of application
- italics for word reference quoting
- added exceptions for HEREDOC/NOWDOC to trailing spaces
- switched to ordered list for PHP header file order listing to better reflect ordering
- updated wording to better reflect internal references
- added proposed complements for unary operators needing clarification (especially regarding the ambigous "- $a" / "-$a")