### PR TITLE
PSR-1: fix example

### DIFF
--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -89,7 +89,7 @@ function foo()
 }
 
 // conditional declaration is *not* a side effect
-if (! function_exists('bar')) {
+if ( ! function_exists('bar')) {
     function bar()
     {
         // function body


### PR DESCRIPTION
Current example may be confusing because not backward compatible with psr-12:
> requires adherence to PSR-1
> All binary arithmetic, comparison, assignment, bitwise, logical, string, and type operators MUST be preceded and followed by at least one space