### PR TITLE
Propose `never` type

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -461,7 +461,7 @@ A Type has the following [ABNF][RFC5234] definition:
     class-name       = ["\"] label *("\" label)
     label            = (ALPHA / %x7F-FF) *(ALPHA / DIGIT / %x7F-FF)
     keyword          = "array" / "bool" / "callable" / "false" / "float" / "int" / "iterable" / "mixed" / "null" / "object" /
-    keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this" / "no-return"
+    keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this" / "never"
 
 ### Details
 
@@ -659,7 +659,7 @@ The following keywords are recognized by this PSR:
 
     This type is often used as return value for methods implementing the [Fluent Interface][FLUENT] design pattern.
 
-17. `no-return`: denotes that element isn't going to return anything and always throws exception or terminates
+17. `never`: denotes that element isn't going to return anything and always throws exception or terminates
     the program abnormally (such as by calling the library function `exit`).
 
 [RFC2119]:      https://tools.ietf.org/html/rfc2119

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -461,7 +461,7 @@ A Type has the following [ABNF][RFC5234] definition:
     class-name       = ["\"] label *("\" label)
     label            = (ALPHA / %x7F-FF) *(ALPHA / DIGIT / %x7F-FF)
     keyword          = "array" / "bool" / "callable" / "false" / "float" / "int" / "iterable" / "mixed" / "null" / "object" /
-    keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this"
+    keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this" / "no-return"
 
 ### Details
 
@@ -658,6 +658,9 @@ The following keywords are recognized by this PSR:
     of the same class but also the same instance.
 
     This type is often used as return value for methods implementing the [Fluent Interface][FLUENT] design pattern.
+
+17. `no-return`: denotes that element isn't going to return anything and always throws exception or terminates
+    the program abnormally (such as by calling the library function `exit`).
 
 [RFC2119]:      https://tools.ietf.org/html/rfc2119
 [RFC5234]:      https://tools.ietf.org/html/rfc5234


### PR DESCRIPTION
This type should be used mainly as a return type to designate a function/method as a never returning back.
It shows that the function/method will always throw an exception or will call `exit()` or will call `trigger_error()` or will stop program execution in any other available way.

I'm not a native speaker, so it probably needs some description extension/correction.

This return type is available in many languages/tools:
1. Kotlin — `Nothing` return type. See https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-nothing.html
2. Hack lang — `noreturn` return type. See https://docs.hhvm.com/hack/built-in-types/noreturn (examples: https://github.com/facebookarchive/hack-langspec/blob/master/tests/Functions/noreturn.php)
3. Vimeo Psalm — `@return no-return` PhpDoc type. See https://github.com/vimeo/psalm/issues/1155#issuecomment-451002822
Also, there is a config option, but it's only for functions/static methods and is going to be deprecated/removed in the future.
4. Phpstan has `@return never` PhpDoc type. See https://github.com/phpstan/phpstan/pull/1472
Also, there is a config option and it's possible to specify dynamic method calls there too.
5. Phan doesn't have this — see https://github.com/phan/phan/issues/2118, but they plan to add it.
6. PhpStorm doesn't have this feature, but they plan to add it and the PhpDoc tag is not decided yet. See https://youtrack.jetbrains.com/issue/WI-10673