### PR TITLE
Added EventInterface for correct overloading

### DIFF
--- a/accepted/PSR-14-event-dispatcher.md
+++ b/accepted/PSR-14-event-dispatcher.md
@@ -123,7 +123,6 @@ class EventInterface
 {
 
 }
-
 ```
 
 ```php
@@ -137,13 +136,13 @@ interface EventDispatcherInterface
     /**
      * Provide all relevant listeners with an event to process.
      *
-     * @param object $event
+     * @param EventInterface $event
      *   The object to process.
      *
-     * @return object
+     * @return EventInterface
      *   The Event that was passed, now modified by listeners.
      */
-    public function dispatch(object $event);
+    public function dispatch(EventInterface $event);
 }
 ```
 
@@ -156,13 +155,13 @@ namespace Psr\EventDispatcher;
 interface ListenerProviderInterface
 {
     /**
-     * @param object $event
+     * @param EventInterface $event
      *   An event for which to return the relevant listeners.
      * @return iterable[callable]
      *   An iterable (array, iterator, or generator) of callables.  Each
      *   callable MUST be type-compatible with $event.
      */
-    public function getListenersForEvent(object $event) : iterable;
+    public function getListenersForEvent(EventInterface $event) : iterable;
 }
 ```
 

--- a/accepted/PSR-14-event-dispatcher.md
+++ b/accepted/PSR-14-event-dispatcher.md
@@ -117,6 +117,19 @@ A Dispatcher SHOULD compose a Listener Provider to determine relevant listeners.
 namespace Psr\EventDispatcher;
 
 /**
+ * Defines a event.
+ */
+class EventInterface
+{
+
+}
+
+```
+
+```php
+namespace Psr\EventDispatcher;
+
+/**
  * Defines a dispatcher for events.
  */
 interface EventDispatcherInterface


### PR DESCRIPTION
Current realization of EventDispatcherInterface not compatible with overloading:
```php
class Dispatcher implements EventDispatcherInterface
{
    public function dispatch(EventInterface $event) { ... }
    // Fatal error:  Declaration of Dispatcher::dispatch(EventInterface $event) must be compatible with EventDispatcherInterface::dispatch(object $event)
}
```