### PR TITLE
Upgrade PSR interfaces

### DIFF
--- a/accepted/PSR-15-request-handlers-meta.md
+++ b/accepted/PSR-15-request-handlers-meta.md
@@ -263,7 +263,7 @@ Using `__invoke` is less transparent than using a named method. It also makes
 it easier to call the request handler when it is assigned to a class variable,
 without using `call_user_func` or other less common syntax.
 
-_See "discussion of FrameInterface" in [relevant links](#9-relevant-links) for
+_See [PHP-FIG discussion of FrameInterface][] for
  additional information._
 
 ### 6.2 Middleware Design
@@ -323,8 +323,7 @@ Attempting to define client middleware would be premature at this point. Any fut
 proposal that is focused on client side request processing should have the opportunity
 to define a standard that is specific to the nature of asynchronous middleware.
 
-_See "client vs server side middleware" in [relevant links](#9-relevant-links) for
-additional information._
+_See [PHP-FIG discussion about client vs server side middleware][] for additional information._
 
 #### What is the role of the request handler?
 
@@ -627,11 +626,16 @@ The working group would also like to acknowledge the contributions of:
 
 _**Note:** Order descending chronologically._
 
-* [PHP-FIG mailing list thread](https://groups.google.com/d/msg/php-fig/vTtGxdIuBX8/NXKieN9vDQAJ)
-* [The PHP League middleware proposal](https://groups.google.com/d/msg/thephpleague/jyztj-Nz_rw/I4lHVFigAAAJ)
-* [PHP-FIG discussion of FrameInterface](https://groups.google.com/d/msg/php-fig/V12AAcT_SxE/aRXmNnIVCwAJ)
-* [PHP-FIG discussion about client vs server side middleware](https://groups.google.com/d/msg/php-fig/vBk0BRgDe2s/GTaT0yKNBgAJ)
+* [PHP-FIG mailing list thread][]
+* [The PHP League middleware proposal][]
+* [PHP-FIG discussion of FrameInterface][]
+* [PHP-FIG discussion about client vs server side middleware][]
 
 ## 10. Errata
 
 ...
+
+[PHP-FIG mailing list thread]: https://groups.google.com/d/msg/php-fig/vTtGxdIuBX8/NXKieN9vDQAJ
+[The PHP League middleware proposal]: https://groups.google.com/d/msg/thephpleague/jyztj-Nz_rw/I4lHVFigAAAJ
+[PHP-FIG discussion of FrameInterface]: https://groups.google.com/d/msg/php-fig/V12AAcT_SxE/aRXmNnIVCwAJ
+[PHP-FIG discussion about client vs server side middleware]: https://groups.google.com/d/topic/php-fig/vBk0BRgDe2s/discussion

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -5,6 +5,7 @@
 A PSR is often comprised of text and code, more specifically interfaces. Those interfaces are pieces of code that are released and tagged at a specific moment in time, but the PHP language doesn't stand still... it evolves over time.
 
 This means that those interfaces need to withstand that evolution, and sometimes they need to be updated, to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
+
 At the same time, a PSR cannot be changed after its release (only erratas allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
 
 This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the packages.

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -1,0 +1,73 @@
+# PSR evolution
+
+## Scope and objectives
+
+A PSR is often comprised of text and code, more specifically interfaces; those interfaces are pieces of code that are released and tagged in a specific moment in time, but the PHP language and ecosystem doesn't stand still, it evolves over time.
+
+This means that those interfaces needs to withstand those evolutions, and sometimes they need to be updated, to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
+At the same time, a PSR cannot be changed after its release if not with erratas, to avoid that a package that declared compatibility would be de-facto not compatible anymore.    
+
+This document defines a guideline to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the packages.
+
+## New releases
+
+A new minor release of a PHP-FIG package containing interfaces for a PSR MUST follow these rules:
+ * the new release MUST follow [Semantic Versioning](https://semver.org/) rules;
+ * the PSR behavior MUST NOT be altered;
+ * the packages that implement the interfaces or users that are consuming them MUST NOT suffer breaking changes;
+ * the PHP version constraint of the PHP-FIG package MAY be altered to require newer language features that would aid cross-compatibility;
+ * the PHP version constraint of the PHP-FIG package MUST NOT be altered to use newer language features that would create cross-compatibility issues.
+ 
+A new major release of a PHP-FIG package containing interfaces for a PSR MUST follow the same rules, with this exception:
+ * the new major version of the package MAY contain breaking changes if the implementing packages have a reasonable upgrading path, like the possibility of releasing a cross-compatible implementation with the previous releases.
+ * the new major version of the package MAY refer to a new, superseding PSR.
+
+### Workflow
+
+Since releasing new versions of the interfaces MUST NOT alter the PSR in its behavior, those releases can be voted in with the same process as errata changes. The new releases MUST be declared and embedded in the PSR document, with eventual indications on the upgrade path in the meta document.
+
+### Practical example
+
+A common case for an upgrade in the interfaces is to add parameters and return types, since they are a new language feature introduced by PHP 7, and many PSR interfaces predates that release. In the next paragraph, we'll try to use PSR-3 as an example to show how a PSR interface should be updated.
+
+#### PSR-3: the interface
+
+PSR-3 is released with the [`psr/log` package](https://packagist.org/packages/psr/log) and it contains the `LoggerInterface`, which has this method:
+```php
+/**
+ * Logs with an arbitrary level.
+ *
+ * @param mixed  $level
+ * @param string $message
+ * @param array  $context
+ *
+ * @return void
+ */
+public function log($level, $message, array $context = array());
+```
+This method could be updated with a new minor release that adds the argument type for `$message`:
+```php
+public function log($level, string $message, array $context = []);
+```
+This change would be technically a breaking change but, thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `prs/log` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/log": "^1.0"` (or equivalent) as a constraint, which they should.
+
+After this intermediate step, it would be possible to release a new major, that would add the return type:
+```php
+public function log($level, string $message, array $context = []): void;
+```
+This must be released as a new major version of `psr/log` (2.0); any package that would implement this would be able to declare `"psr/log": "^1.2 || ^2.0"`, since backward compatibility to the first release would be impossible, due to the sum of covariance and contravariance rules.
+
+#### PSR-3: the implementation
+
+On the other side, the implementing packages would be able to do a release cycle in the opposite fashion. Using Monolog as an example, the first release looks like this:
+```php
+public function log($level, $message, array $context = array());
+```
+The second release (which at the time of this writing is already tagged as 2.0) adds the return type, maintaining compatibility with the original interface:
+```php
+public function log($level, $message, array $context = []): void;
+```
+A possible third release could be tagged in the future, adding the argument type too:
+```php
+public function log($level, string $message, array $context = []): void;
+```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -43,7 +43,9 @@ PSR-11 is released with the [`psr/container` package](https://packagist.org/pack
      */
     public function has($id);
 ```
+
 This method could be updated with a new minor release that adds the argument type for `$id`:
+
 ```php
 public function has(string $id);
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -45,7 +45,7 @@ This method could be updated with a new minor release that adds the argument typ
 ```php
 public function has(string $id);
 ```
-This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `prs/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint, which they should.
+This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint, which they should.
 
 After this intermediate step, it would be possible to release a new major version, that would add the return type:
 ```php

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -35,7 +35,18 @@ Note that if the upgrade path causes the consumers to maintain multiple versions
 
 ### Workflow
 
-Since releasing new versions of the interfaces MUST NOT alter the PSR in its behavior, those releases can be voted in with the same process as errata changes. The new releases MUST be declared and embedded in the PSR document, with eventual indications on the upgrade path in the meta document.
+Since releasing new versions of the interfaces MUST NOT alter the PSR in its behavior, those releases can be voted in with the same process as errata changes. The new releases MUST be declared and embedded with a brief explanation and a link in the PSR document, like in the following example:
+
+> \`\`\`php
+interface ContainerInterface
+{
+> // code snippet here
+}
+\`\`\`
+>
+> Since [psr/container version 1.1](#), the above interface has been updated to add argument type hints.
+
+The meta document MUST be amended with eventual indications on the upgrade path for the consumers.
 
 ### Practical example
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -12,8 +12,8 @@ This document defines a process to be followed in updating PSR interfaces, in a 
 
 ## Definitions
 
- * **Consumer** - libraries and projects that implement and/or consume the code released as part of the PSR in question;
- * **Cross-compatibility** - the ability for a consumer to support more than one code version of the PSR with a single release of their own;
+ * **Consumer** - libraries and projects that implement and/or consume the code released as part of the PSR in question.
+ * **Cross-compatibility** - the ability for a consumer to support more than one code version of the PSR with a single release of their own.
 
 ## New releases
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -69,7 +69,9 @@ The second release would adds the return type, maintaining compatibility with th
 ```php
 public function has($id): bool;
 ```
-A third release would be tagged then, adding the argument type too:
+
+A third release would also add the argument type hint:
+
 ```php
 public function has(string $id): bool;
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -4,7 +4,7 @@
 
 A PSR is often comprised of text and code, generally interfaces. Those interfaces are pieces of code that are released and tagged at a specific moment in time. However, the PHP language doesn't stand still; it evolves over time.
 
-This means that those interfaces need to both provide a stable contract, as well as evolve to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
+This means that those interfaces need to both provide a stable contract, as well as evolve to leverage new language features that could help better enforce the behaviors described in the PSR itself.
 
 At the same time, a PSR cannot be changed after its release (at which point only erratas are allowed), to protect a package that declared compatibility from becoming de facto incompatible.
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -57,6 +57,7 @@ After this intermediate step, it would be possible to release a new major versio
 ```php
 public function has(string $id): bool;
 ```
+
 This must be released as a new major version of `psr/container` (2.0); any package that would implement this would be able to declare `"psr/container": "^1.1 || ^2.0"`, since backward compatibility to the first release would be impossible, due to the sum of covariance and contravariance rules.
 
 #### PSR-11: the implementation

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -10,13 +10,10 @@ At the same time, a PSR cannot be changed after its release (at which point only
 
 This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the consumers.
 
-## Terminology
+## Definitions
 
-Here are listed some words that are used in this document, with a brief explanation of their meaning in this context:
-
- * consumer: libraries and projects that implement and/or consume the code released as part of the PSR in question;
- * cross-compatibility: the ability for a consumer to support more than one code version of the PSR with a single release of their own;
- *  
+ * **Consumer** - libraries and projects that implement and/or consume the code released as part of the PSR in question;
+ * **Cross-compatibility** - the ability for a consumer to support more than one code version of the PSR with a single release of their own;
 
 ## New releases
 
@@ -46,7 +43,9 @@ interface ContainerInterface
 >
 > Since [psr/container version 1.1](#), the above interface has been updated to add argument type hints.
 
-The meta document MUST be amended with eventual indications on the upgrade path for the consumers.
+In the example above, the last line is indicative of what should be added to the specification.
+
+The meta document MUST be amended with information detailing the consumer upgrade path.
 
 ### Practical example
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -22,6 +22,8 @@ A new minor release of a PHP-FIG package containing interfaces for a PSR MUST fo
 A new major release of a PHP-FIG package containing interfaces for a PSR MUST follow the same rules, with this exception:
  * the new major version of the package MAY contain breaking changes if the implementing packages have a reasonable upgrade path, like the possibility of releasing a cross-compatible implementation with the previous releases;
  * the new major version of the package MAY refer to a new, superseding PSR.
+ 
+Note that if the upgrade path causes the consumers to maintain multiple versions of their libraries side-by-side, only to support multiple versions of the same PSR, the upgrade path is to be considered too steep.
 
 ### Workflow
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -28,46 +28,42 @@ Since releasing new versions of the interfaces MUST NOT alter the PSR in its beh
 
 ### Practical example
 
-A common case for an upgrade in the interfaces is to add types for parameters and returns, since they are new language features introduced by PHP 7, and many PSR interfaces predate that release. We'll use a method from PSR-3 as an example of how a PSR interface could be updated.
+A common case for an upgrade in the interfaces is to add types for parameters and returns, since they are new language features introduced by PHP 7, and many PSR interfaces predate that release. We'll use a method from PSR-11 as an example of how a PSR interface could be updated.
 
-#### PSR-3: the interface
+#### PSR-11: the interface
 
-PSR-3 is released with the [`psr/log` package](https://packagist.org/packages/psr/log) and contains the `LoggerInterface`, which has this method:
+PSR-11 is released with the [`psr/container` package](https://packagist.org/packages/psr/container) and it holds the `ContainerInterface`, which has this method:
 ```php
-/**
- * Logs with an arbitrary level.
- *
- * @param mixed  $level
- * @param string $message
- * @param array  $context
- *
- * @return void
- */
-public function log($level, $message, array $context = array());
+    /**
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has($id);
 ```
-This method could be updated with a new minor release that adds the argument type for `$message`:
+This method could be updated with a new minor release that adds the argument type for `$id`:
 ```php
-public function log($level, string $message, array $context = []);
+public function has(string $id);
 ```
-This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `prs/log` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/log": "^1.0"` (or equivalent) as a constraint, which they should.
+This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `prs/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint, which they should.
 
 After this intermediate step, it would be possible to release a new major version, that would add the return type:
 ```php
-public function log($level, string $message, array $context = []): void;
+public function has(string $id): bool;
 ```
-This must be released as a new major version of `psr/log` (2.0); any package that would implement this would be able to declare `"psr/log": "^1.2 || ^2.0"`, since backward compatibility to the first release would be impossible, due to the sum of covariance and contravariance rules.
+This must be released as a new major version of `psr/container` (2.0); any package that would implement this would be able to declare `"psr/container": "^1.1 || ^2.0"`, since backward compatibility to the first release would be impossible, due to the sum of covariance and contravariance rules.
 
-#### PSR-3: the implementation
+#### PSR-11: the implementation
 
-On the other side, the implementing packages would be able to do a release cycle in the opposite fashion. Using Monolog as an example, the first release looks like this:
+On the other side, the implementing packages would be able to do a release cycle in the opposite fashion. The first release looks like this:
 ```php
-public function log($level, $message, array $context = array());
+public function has($id);
 ```
-The second release (which at the time of this writing is already tagged as 2.0) adds the return type, maintaining compatibility with the original interface:
+The second release would adds the return type, maintaining compatibility with the original interface:
 ```php
-public function log($level, $message, array $context = []): void;
+public function has($id): bool;
 ```
-A possible third release could be tagged in the future, adding the argument type too:
+A third release would be tagged then, adding the argument type too:
 ```php
-public function log($level, string $message, array $context = []): void;
+public function has(string $id): bool;
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -21,7 +21,7 @@ A new minor release of a PHP-FIG package containing interfaces for a PSR MUST fo
  * the new release MUST follow [Semantic Versioning](https://semver.org/) rules;
  * the PSR behavior MUST NOT be altered;
  * packages that implement the interfaces or consume them MUST NOT suffer breaking changes;
- * the PHP version constraint of the PHP-FIG package MAY be altered to require newer language features that would aid cross-compatibility;
+ * the PHP version constraint of the PHP-FIG package MAY be increased to leverage newer language features, especially those that would aid cross-compatibility of consumers with the old and the new versions;
  * the PHP version constraint of the PHP-FIG package MUST NOT be altered to use newer language features that would create cross-compatibility issues.
  
 A new major release of a PHP-FIG package containing interfaces for a PSR MUST follow the same rules, with this exception:

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -6,7 +6,7 @@ A PSR is often comprised of text and code, generally interfaces. Those interface
 
 This means that those interfaces need to both provide a stable contract, as well as evolve to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
 
-At the same time, a PSR cannot be changed after its release (at which point only erratas are allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
+At the same time, a PSR cannot be changed after its release (at which point only erratas are allowed), to protect a package that declared compatibility from becoming de facto incompatible.
 
 This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the consumers.
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -12,23 +12,24 @@ This document defines a process to be followed in updating PSR interfaces, in a 
 
 ## Definitions
 
- * **Consumer** - libraries and projects that implement and/or consume the code released as part of the PSR in question.
- * **Cross-compatibility** - the ability for a consumer to support more than one code version of the PSR with a single release of their own.
+ * **Consumer** - libraries and projects that consume one or more interfaces from the code released as part of the PSR in question.
+ * **Implementer** - libraries and projects that implement one or more interfaces from code released as part of the PSR in question.
+ * **Cross-compatibility** - the ability for a consumer or an implementer to support more than one code version of the PSR with a single release of their own.
 
 ## New releases
 
 A new minor release of a PHP-FIG package containing interfaces for a PSR MUST follow these rules:
  * the new release MUST follow [Semantic Versioning](https://semver.org/) rules;
  * the PSR behavior MUST NOT be altered;
- * packages that implement the interfaces or consume them MUST NOT suffer breaking changes;
- * the PHP version constraint of the PHP-FIG package MAY be increased to leverage newer language features, especially those that would aid cross-compatibility of consumers with the old and the new versions;
+ * consumers or implementers of those interfaces MUST NOT suffer breaking changes;
+ * the PHP version constraint of the PHP-FIG package MAY be increased to leverage newer language features, especially those that would aid cross-compatibility of consumers and implementers with the old and the new versions;
  * the PHP version constraint of the PHP-FIG package MUST NOT be altered to use newer language features that would create cross-compatibility issues.
  
 A new major release of a PHP-FIG package containing interfaces for a PSR MUST follow the same rules, with this exception:
  * the new major version of the package MAY contain breaking changes if the implementing packages have a reasonable upgrade path, like the possibility of releasing a cross-compatible implementation with the previous releases;
  * the new major version of the package MAY refer to a new, superseding PSR.
  
-Note that if the upgrade path causes the consumers to maintain multiple versions of their libraries side-by-side, only to support multiple versions of the same PSR, the upgrade path is to be considered too steep.
+Note that if the upgrade path causes the consumers or implementers to maintain multiple versions of their libraries side-by-side, only to support multiple versions of the same PSR, the upgrade path is to be considered too steep.
 
 ### Workflow
 
@@ -45,7 +46,7 @@ interface ContainerInterface
 
 In the example above, the last line is indicative of what should be added to the specification.
 
-The meta document MUST be amended with information detailing the consumer upgrade path.
+The meta document MUST be amended with information detailing the consumer and/or implementer upgrade path.
 
 ### Practical example
 
@@ -70,7 +71,7 @@ This method could be updated with a new minor release that adds the argument typ
 public function has(string $id);
 ```
 
-This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the consumers be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
+This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the consumers and implementers be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
 
 After this intermediate step, it would be possible to release a new major version, adding a return type hint:
 
@@ -82,7 +83,7 @@ This must be released as a new major version of `psr/container` (2.0); any packa
 
 #### PSR-11: the implementation
 
-On the other side, the consumers would be able to do a release cycle in the opposite fashion. The first release looks like this:
+On the other side, the implementers would be able to do a release cycle in the opposite fashion. The first release looks like this:
 
 ```php
 public function has($id);

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -4,7 +4,7 @@
 
 A PSR is often comprised of text and code, generally interfaces. Those interfaces are pieces of code that are released and tagged at a specific moment in time. However, the PHP language doesn't stand still; it evolves over time.
 
-This means that those interfaces need to withstand that evolution, and sometimes they need to be updated, to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
+This means that those interfaces need to both provide a stable contract, as well as evolve to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
 
 At the same time, a PSR cannot be changed after its release (only erratas allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -52,7 +52,8 @@ public function has(string $id);
 
 This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
 
-After this intermediate step, it would be possible to release a new major version, that would add the return type:
+After this intermediate step, it would be possible to release a new major version, adding a return type hint:
+
 ```php
 public function has(string $id): bool;
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -49,7 +49,8 @@ This method could be updated with a new minor release that adds the argument typ
 ```php
 public function has(string $id);
 ```
-This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint, which they should.
+
+This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
 
 After this intermediate step, it would be possible to release a new major version, that would add the return type:
 ```php

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -65,7 +65,9 @@ On the other side, the implementing packages would be able to do a release cycle
 ```php
 public function has($id);
 ```
-The second release would adds the return type, maintaining compatibility with the original interface:
+
+The second release would add the return type, maintaining compatibility with the original interface:
+
 ```php
 public function has($id): bool;
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -8,7 +8,15 @@ This means that those interfaces need to both provide a stable contract, as well
 
 At the same time, a PSR cannot be changed after its release (at which point only erratas are allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
 
-This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the packages.
+This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the consumers.
+
+## Terminology
+
+Here are listed some words that are used in this document, with a brief explanation of their meaning in this context:
+
+ * consumer: libraries and projects that implement and/or consume the code released as part of the PSR in question;
+ * cross-compatibility: the ability for a consumer to support more than one code version of the PSR with a single release of their own;
+ *  
 
 ## New releases
 
@@ -52,7 +60,7 @@ This method could be updated with a new minor release that adds the argument typ
 public function has(string $id);
 ```
 
-This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the implementors be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
+This change would technically be a breaking change, but thanks to the [limited contravariance possible in PHP 7.2](https://wiki.php.net/rfc/parameter-no-type-variance), we can avoid that. This means that just by requiring `"php": "^7.2"` in the `psr/container` `composer.json`, we could tag this change as a minor release, and have all the consumers be automatically cross-compatible, provided that they declare `"psr/container": "^1.0"` (or equivalent) as a constraint.
 
 After this intermediate step, it would be possible to release a new major version, adding a return type hint:
 
@@ -64,7 +72,7 @@ This must be released as a new major version of `psr/container` (2.0); any packa
 
 #### PSR-11: the implementation
 
-On the other side, the implementing packages would be able to do a release cycle in the opposite fashion. The first release looks like this:
+On the other side, the consumers would be able to do a release cycle in the opposite fashion. The first release looks like this:
 
 ```php
 public function has($id);

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -62,6 +62,7 @@ This must be released as a new major version of `psr/container` (2.0); any packa
 #### PSR-11: the implementation
 
 On the other side, the implementing packages would be able to do a release cycle in the opposite fashion. The first release looks like this:
+
 ```php
 public function has($id);
 ```

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -2,7 +2,7 @@
 
 ## Scope and objectives
 
-A PSR is often comprised of text and code, more specifically interfaces. Those interfaces are pieces of code that are released and tagged at a specific moment in time, but the PHP language doesn't stand still... it evolves over time.
+A PSR is often comprised of text and code, generally interfaces. Those interfaces are pieces of code that are released and tagged at a specific moment in time. However, the PHP language doesn't stand still; it evolves over time.
 
 This means that those interfaces need to withstand that evolution, and sometimes they need to be updated, to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
 

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -34,6 +34,7 @@ A common case for an upgrade in the interfaces is to add types for parameters an
 #### PSR-11: the interface
 
 PSR-11 is released with the [`psr/container` package](https://packagist.org/packages/psr/container) and it holds the `ContainerInterface`, which has this method:
+
 ```php
     /**
      * @param string $id Identifier of the entry to look for.

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -15,7 +15,7 @@ This document defines a process to be followed in updating PSR interfaces, in a 
 A new minor release of a PHP-FIG package containing interfaces for a PSR MUST follow these rules:
  * the new release MUST follow [Semantic Versioning](https://semver.org/) rules;
  * the PSR behavior MUST NOT be altered;
- * the packages that implement the interfaces or users that are consuming them MUST NOT suffer breaking changes;
+ * packages that implement the interfaces or consume them MUST NOT suffer breaking changes;
  * the PHP version constraint of the PHP-FIG package MAY be altered to require newer language features that would aid cross-compatibility;
  * the PHP version constraint of the PHP-FIG package MUST NOT be altered to use newer language features that would create cross-compatibility issues.
  

--- a/bylaws/008-psr-evolution.md
+++ b/bylaws/008-psr-evolution.md
@@ -6,7 +6,7 @@ A PSR is often comprised of text and code, generally interfaces. Those interface
 
 This means that those interfaces need to both provide a stable contract, as well as evolve to leverage new language features that could help better enforce the behaviors exposed in the PSR itself.
 
-At the same time, a PSR cannot be changed after its release (only erratas allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
+At the same time, a PSR cannot be changed after its release (at which point only erratas are allowed), to protect a package that declared compatibility from becoming de-facto not compatible anymore.
 
 This document defines a process to be followed in updating PSR interfaces, in a way that is not breaking in regard to behavior for end users, and with an appropriate upgrade path for the packages.
 


### PR DESCRIPTION
This is a draft of the new bylaw that I would like to propose to overcome the issue of evolving PSR interfaces. 

For reference, the discussion started [here on the ML](https://groups.google.com/d/topic/php-fig/OyC3plRYhqg/discussion), and this proposal was published [as a blog post](https://www.php-fig.org/blog/2019/10/upgrading-psr-interfaces/); the blog post (written by @Crell) also included a poll to gauge the interest from the community, that seems overall positive.