### PR TITLE
PSR-12 Section 4.2: fix insteadof operator example

### DIFF
--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -375,9 +375,12 @@ note of indentation, spacing, and new lines.
 
 class Talker
 {
-    use A, B, C {
-        B::smallTalk insteadof A;
-        A::bigTalk insteadof C;
+    use A;
+    use B {
+        A::smallTalk insteadof B;
+    }
+    use C {
+        B::bigTalk insteadof C;
         C::mediumTalk as FooBar;
     }
 }


### PR DESCRIPTION
The existing example contradicts the previous statement:
> Each individual trait that is imported into a class MUST be included one-per-line and each inclusion MUST have its own use import statement.