### PR TITLE
Fix spelling mistake in PSR-3-logger-interface.md

### DIFF
--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -74,7 +74,7 @@ Users of loggers are referred to as `user`.
       // build a replacement array with braces around the context keys
       $replace = array();
       foreach ($context as $key => $val) {
-          // check that the value can be casted to string
+          // check that the value can be cast to string
           if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
               $replace['{' . $key . '}'] = $val;
           }


### PR DESCRIPTION
Shouldn't it be `[...] can be cast [...]` instead of `[...] can be casted [...]`?