### PR TITLE
PSR-12: Clarify no newline between typed properties without comment

### DIFF
--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -397,6 +397,8 @@ The `var` keyword MUST NOT be used to declare a property.
 
 There MUST NOT be more than one property declared per statement.
 
+There MUST NOT be a newline between properties when they don't have a comment.
+
 Property names MUST NOT be prefixed with a single underscore to indicate
 protected or private visibility. That is, an underscore prefix explicitly has
 no meaning.


### PR DESCRIPTION
## Problem

The [example shows](https://www.php-fig.org/psr/psr-12/#43-properties-and-constants) without newlines, but there is no rule for it.
```php
<?php

namespace Vendor\Package;

class ClassName
{
    public $foo = null;
    public static int $bar = 0;
}
```

## Solution

With PHP 7.4, typed properties are a thing.

Before PHP 7.4, we would write them like this:
```php
<?php

namespace Vendor\Package;

class ClassName
{
    /**
     * @var string|null
     */
    public $foo = null;

    /**
     * @var int
     */
    public $bar = 0;
}
```

and now with PHP 7.4 we can write them like:

```php
<?php

namespace Vendor\Package;

class ClassName
{
    public ?string $foo = null;
    public int $bar = 0;
}
```

