### PR TITLE
Use "Structural Elements" in reference @internal

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -212,7 +212,7 @@ Other "Structural Elements" with a public visibility MAY be listed less
 prominently in generated documentation.
 
 See also the [`@internal`](#55-internal), which MAY be used to hide internal
-API components from generated documentation.
+"Structural Elements" from generated documentation.
 
 #### Examples
 


### PR DESCRIPTION
API components is a new definition which does not allign with the rest of the document where we are using "Structural Elements"