### PR TITLE
Add very basic draft of some PHP 8 attributes

### DIFF
--- a/proposed/php-8-basic-attributes-meta.md
+++ b/proposed/php-8-basic-attributes-meta.md
@@ -1,0 +1,30 @@
+PHP 8 basic attributes
+=======================
+
+## 1. Summary
+
+PHP has many annotations with similar meaning. 
+The goal of this PSR is to standardize some of them.
+
+### Why Bother?
+
+IDE and static analyzer tools introduce their own attributes (aka annotations)
+with slightly different meaning, but with very similar intentions.
+
+Standardized attributes would help to IDE/framework/library maintainers
+and end-users in result.
+
+They would have declarative purpose, but developer teams would be able
+to force it by checking on git receive hook, for example.
+
+### Basic attributes
+
+This PSR proposes to declare few attributes:
+* `@@Final` (class, method);
+* `@@Immutable` (class, property);
+* `@@ReadOnly` (property);
+* `@@Internal`.
+
+Other PSRs might focus on different aspects of the code:
+generics, documentation, etc.
+

--- a/proposed/php-8-basic-attributes.md
+++ b/proposed/php-8-basic-attributes.md
@@ -1,0 +1,188 @@
+PHP 8 basic attributes
+=======================
+
+TODO: summary
+
+#### `@@Final`
+
+`final` is a very debatable thing in the community because it makes no possible
+to use tools for mocking finalized classes and proxying
+as both use inheritance feature.
+
+On other hand, leaving class open for inheritance often lead to misusages
+and frameworks/libraries become limited to changed for keeping BC.
+
+Some frameworks like Symfony introduced `@Final` (aka "soft `final`) annotation to make sure that with `DebugClassLoader`
+developer will get a warning.
+Some people suggests the same 
+IDE like PhpStorm can show error when one is trying to extend `@@Final` class.
+
+```php
+@@Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)
+final class Final
+{
+    public function __construct(public string $annotation = null)
+    {
+    }
+}
+```
+
+Usage:
+
+```php
+@@Final('It will become final in 42.0') 
+class User
+{
+    // ...
+}
+```
+
+#### `@@Immutable`
+
+Value objects and other immutable structures have to provide
+getters for each property, but in most cases it creates
+[visual debt (noise)](#rbg-color-example).
+
+```php
+namespace Psr\Attributes;
+
+@@Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)
+final class Immutable
+{
+}
+```
+
+##### Mutable objects inside
+
+There is an edge case: some immutable at first glance classes
+may have internal references on mutable objects like notorious `\DateTime`.
+
+It's possible to add special flag like `allowNonPublicMutable`,
+but it makes no sense to properties.
+
+So far it's suggested to allow mutable objects if they are `private`/`protected`
+and are not mutated in any case. However, there is a risk that passed through 
+constructor instance of `\DateTime` will be modified outside. 
+
+##### Example
+
+<a name="rbg-color-example"></a>
+
+```php
+final class RbgColor
+{
+    private int $red;
+    private int $green;
+    private int $blue;
+
+    public function __construct(int $r, int $g, int $b) {
+        assertThat($r >= 0 && $r <= 255)
+            ->that($g >= 0 && $r <= 255)
+            ->that($b >= 0 && $b <= 255);
+
+        $this->red = $r;
+        $this->green = $g;
+        $this->blue = $b;
+    }
+
+    public function getRed(): int
+    {
+        return $this->red;
+    }
+
+    public function getGreen(): int
+    {
+        return $this->green;
+    }
+
+    public function getBlue(): int
+    {
+        return $this->blue;
+    }
+}
+```
+
+... code above becomes 
+
+```
+final class RbgColor
+{
+    public int $red;
+    public int $green;
+    public int $blue;
+
+    public function __construct(int $r, int $g, int $b) {
+        assertThat($r >= 0 && $r <= 255)
+            ->that($g >= 0 && $r <= 255)
+            ->that($b >= 0 && $b <= 255);
+
+        $this->red = $r;
+        $this->green = $g;
+        $this->blue = $b;
+    }
+}
+```
+
+#### `@@ReadOnly`
+
+The idea is to have public read-only properties is very old.
+But for some reasons PHP has very poor ways (`__get` + phpdoc) 
+for achieving similar behaviour for far. 
+
+```php
+namespace Psr\Attributes;
+
+@@Attribute(Attribute::TARGET_PROPERTY)
+final class ReadOnly
+{
+    public function __construct(public bool $strict = false)
+    {
+    }
+}
+```
+
+Usage:
+
+```php
+@@ReadOnly(strict: true)
+public UserId $userId;
+```
+
+`strict` just means where you can modify value inside of the class or not.
+
+#### `@@Internal`
+
+The [phpdoc](https://docs.phpdoc.org/latest/references/phpdoc/tags/internal.html) `@internal` has very vague meaning:
+
+> The @internal tag is used to denote that associated Structural Elements are elements internal to this application or library
+
+But what is "application"? "Library"? PhpStorm just use strikethrough when you use this tag ouside of namespace where the class/function was defined.
+
+I propose something like:
+
+```php
+namespace Psr\Attributes;
+
+@@Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::TARGET_ATTRIBUTE)
+final class Internal
+{
+    public function __construct(public string $namespace = null)
+    {
+    }
+}
+```
+
+Usage:
+
+
+```php
+namespace Acme\Foo\Parser\Utils;
+
+@@Internal('Acme\\Foo\\Parser\\') // It's a shame that PHP has no reference like Acme\Foo\Parser::namespace
+final class PrimitiveLexer
+{
+    // ...
+}
+```
+
+Using `PrimitiveLexer` within `Acme\Foo\Parser` namespace is OK, but when you use it outside of that namespace, IDE should warning user.


### PR DESCRIPTION
Hey,

I'd like to discuss attributes in PHP 8. Most of them will be provided by specific frameworks as soon as they will start to prepare code for PHP 8, and my goal is to have more framework-agnostic ones with explicit declared behavior. 

PhpStorm already released future integration of psalm and PhpStan: https://blog.jetbrains.com/phpstorm/2020/07/phpstan-and-psalm-support-coming-to-phpstorm/
So there is no doubt such features by itself will be supported.

However, it would be cool to get away from phpdoc-annotations like `@psalm-immutable` to the new PHP 8 attributes, framework-agnostic ones.

In short, this PSR is about:
* `@@Final('Do not inherit me unless you are ProxyManager or MockBuilder')`:

    ```php
    @@Final('It will be final in 5.0')
    class StreamLogger implements Logger
    {
        // ...
    }
    ```

    Symfony started to use such annotation (soft `final`) about [3 years ago](https://github.com/symfony/symfony/pull/21452/files#diff-a10c9afd8feaccd1ff66ffd54e2835bcR295) for [classes](https://github.com/symfony/symfony/blob/d25b60961f7d9697fa02eb9cdb37197e0bb6e743/src/Symfony/Component/VarDumper/Caster/StubCaster.php#L21) and methods.
 
    **Added**: probably, it requires also to add new annotation like `@@Proxy` to avoid issues in generated code of proxies and mocks by CI validators.

* `@@Immutable` (https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-immutable, https://wiki.php.net/rfc/immutability);

    ```php
    @@Immutable
    final class RbgColor
    {
        public function __construct(
            public int $red,
            public int $green,
            public int $blue
        ) {
            assertThat($red >= 0 && $red <= 255)
                ->that($green >= 0 && $green <= 255)
                ->that($blue >= 0 && $blue <= 255);
        }
    }
    ```

    This is not just best practice for value objects and similar things, but it also makes code way more readable and compact. Value objects, commands, events, DTOs, etc. No more tons of getters.

* `@@ReadOnly(strict: false)` (like https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-readonly-and-readonly,  `strict` is optional param that implies whether object itself can modify this value after it was set once)
   
    ```php
    final class TokenStream implements \IteratorAggregate
    {
        @@ReadOnly(strict: false)
        public int $line;
        @@ReadOnly(strict: false)
        public int $offset;

        // ...
    }
    ```

* `@@Internal('Acme\Foo')` (`@internal` with explicit acceptable namespace; by default is just current namespace including subnamespaces):

    ```php
    namespace Acme\Foo\Experimental;

    @@Internal('Acme\Foo')
    final class ExperimentalServiceFoo
    {
    }
    ```

   Class `Acme\Foo\Bar` is allowed to use `ExperimentalServiceFoo`, but classes outside of this namespace (e.g. `Acme\`) should not do it. Tools can help to detect incorrect usage here too.

