### PR TITLE
[PHPDoc] Clarify that @property/@var names are prefixed with a $

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -583,7 +583,7 @@ The `@property` tag is used to declare which "magic" properties are supported.
 
 #### Syntax
 
-    @property[<-read|-write>] ["Type"] [name] [<description>]
+    @property[<-read|-write>] ["Type"] $[name] [<description>]
 
 #### Description
 

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -542,7 +542,7 @@ The @param tag is used to document a single parameter of a function or method.
 
 #### Syntax
 
-    @param ["Type"] [name] [<description>]
+    @param ["Type"] $[name] [<description>]
 
 #### Description
 


### PR DESCRIPTION
## Problem

The examples for the `@property` tag all prefix the property name with a sigil ($), even though the specified syntax omits this.

## Solution

To avoid confusion, the sigil ($) should be added explicitly to the syntax specification.

## Context

- PhpStorm's `Add @property` quickfix does omit the sigil, but this behavior is tracked as a bug: https://youtrack.jetbrains.com/issue/WI-34398
- I brought this issue up in https://github.com/vimeo/psalm/issues/6028, because Psalm currently ignores `@property` annotations that omit the sigil.