### PR TITLE
Everywhere: Standardize RFC links

### DIFF
--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -8,7 +8,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
-[RFC 2119]: http://www.ietf.org/rfc/rfc2119.txt
+[RFC 2119]: http://www.www.rfc-editor.org/rfc/rfc2119.html
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 

--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -8,7 +8,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 

--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -8,7 +8,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
-[RFC 2119]: http://www.www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 

--- a/accepted/PSR-11-container.md
+++ b/accepted/PSR-11-container.md
@@ -13,7 +13,7 @@ The word `implementor` in this document is to be interpreted as someone
 implementing the `ContainerInterface` in a dependency injection-related library or framework.
 Users of dependency injection containers (DIC) are referred to as `user`.
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## 1. Specification
 

--- a/accepted/PSR-11-container.md
+++ b/accepted/PSR-11-container.md
@@ -13,7 +13,7 @@ The word `implementor` in this document is to be interpreted as someone
 implementing the `ContainerInterface` in a dependency injection-related library or framework.
 Users of dependency injection containers (DIC) are referred to as `user`.
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## 1. Specification
 

--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Overview
 

--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Overview
 

--- a/accepted/PSR-13-links.md
+++ b/accepted/PSR-13-links.md
@@ -11,11 +11,11 @@ of the process of deciding what those links should be.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ### References
 
-- [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html)
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html)
 - [RFC 4287](https://www.rfc-editor.org/rfc/rfc4287.html)
 - [RFC 5988](https://www.rfc-editor.org/rfc/rfc5988.html)
 - [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570.html)

--- a/accepted/PSR-13-links.md
+++ b/accepted/PSR-13-links.md
@@ -11,14 +11,14 @@ of the process of deciding what those links should be.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
 
 ### References
 
-- [RFC 2119](http://tools.ietf.org/html/rfc2119)
-- [RFC 4287](https://tools.ietf.org/html/rfc4287)
-- [RFC 5988](https://tools.ietf.org/html/rfc5988)
-- [RFC 6570](https://tools.ietf.org/html/rfc6570)
+- [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html)
+- [RFC 4287](https://www.rfc-editor.org/rfc/rfc4287.html)
+- [RFC 5988](https://www.rfc-editor.org/rfc/rfc5988.html)
+- [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570.html)
 - [IANA Link Relations Registry](http://www.iana.org/assignments/link-relations/link-relations.xhtml)
 - [Microformats Relations List](http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions)
 
@@ -91,7 +91,7 @@ application or use case. Such relationships MUST use an absolute URI.
 
 ## 1.4 Link Templates
 
-[RFC 6570](https://tools.ietf.org/html/rfc6570) defines a format for URI templates, that is,
+[RFC 6570](https://www.rfc-editor.org/rfc/rfc6570.html) defines a format for URI templates, that is,
 a pattern for a URI that is expected to be filled in with values provided by a client
 tool. Some hypermedia formats support templated links while others do not, and may
 have a special way to denote that a link is a template. A Serializer for a format

--- a/accepted/PSR-14-event-dispatcher.md
+++ b/accepted/PSR-14-event-dispatcher.md
@@ -7,7 +7,7 @@ The goal of this PSR is to establish a common mechanism for event-based extensio
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/accepted/PSR-14-event-dispatcher.md
+++ b/accepted/PSR-14-event-dispatcher.md
@@ -7,7 +7,7 @@ The goal of this PSR is to establish a common mechanism for event-based extensio
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/accepted/PSR-15-request-handlers.md
+++ b/accepted/PSR-15-request-handlers.md
@@ -22,7 +22,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119][rfc2119].
 
 [psr7]: https://www.php-fig.org/psr/psr-7/
-[rfc2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[rfc2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ### References
 

--- a/accepted/PSR-15-request-handlers.md
+++ b/accepted/PSR-15-request-handlers.md
@@ -22,7 +22,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119][rfc2119].
 
 [psr7]: https://www.php-fig.org/psr/psr-7/
-[rfc2119]: http://tools.ietf.org/html/rfc2119
+[rfc2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ### References
 

--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -12,7 +12,7 @@ The final implementations MAY decorate the objects with more
 functionality than the one proposed but they MUST implement the indicated
 interfaces/functionality first.
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 # 1. Specification
 

--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -12,7 +12,7 @@ The final implementations MAY decorate the objects with more
 functionality than the one proposed but they MUST implement the indicated
 interfaces/functionality first.
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 # 1. Specification
 

--- a/accepted/PSR-17-http-factory.md
+++ b/accepted/PSR-17-http-factory.md
@@ -16,7 +16,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119][rfc2119].
 
 [psr7]: https://www.php-fig.org/psr/psr-7/
-[rfc2119]: https://tools.ietf.org/html/rfc2119
+[rfc2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## 1. Specification
 

--- a/accepted/PSR-18-http-client.md
+++ b/accepted/PSR-18-http-client.md
@@ -5,7 +5,7 @@ This document describes a common interface for sending HTTP requests and receivi
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## Goal
 

--- a/accepted/PSR-18-http-client.md
+++ b/accepted/PSR-18-http-client.md
@@ -5,7 +5,7 @@ This document describes a common interface for sending HTTP requests and receivi
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## Goal
 

--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -21,7 +21,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
-[RFC 2119]: http://www.ietf.org/rfc/rfc2119.txt
+[RFC 2119]: http://www.www.rfc-editor.org/rfc/rfc2119.html
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
 

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -18,7 +18,7 @@ The word `implementor` in this document is to be interpreted as someone
 implementing the `LoggerInterface` in a log-related library or framework.
 Users of loggers are referred to as `user`.
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## 1. Specification
 
@@ -35,7 +35,7 @@ Users of loggers are referred to as `user`.
   if the implementation does not know about the level. Users SHOULD NOT use a
   custom level without knowing for sure the current implementation supports it.
 
-[RFC 5424]: http://www.rfc-editor.org/rfc/rfc5424.html
+[RFC 5424]: https://www.rfc-editor.org/rfc/rfc5424.html
 
 ### 1.2 Message
 

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -18,7 +18,7 @@ The word `implementor` in this document is to be interpreted as someone
 implementing the `LoggerInterface` in a log-related library or framework.
 Users of loggers are referred to as `user`.
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## 1. Specification
 
@@ -35,7 +35,7 @@ Users of loggers are referred to as `user`.
   if the implementation does not know about the level. Users SHOULD NOT use a
   custom level without knowing for sure the current implementation supports it.
 
-[RFC 5424]: http://tools.ietf.org/html/rfc5424
+[RFC 5424]: http://www.rfc-editor.org/rfc/rfc5424.html
 
 ### 1.2 Message
 

--- a/accepted/PSR-4-autoloader.md
+++ b/accepted/PSR-4-autoloader.md
@@ -2,7 +2,7 @@
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## 1. Overview
 

--- a/accepted/PSR-4-autoloader.md
+++ b/accepted/PSR-4-autoloader.md
@@ -2,7 +2,7 @@
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## 1. Overview
 

--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -18,7 +18,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -18,7 +18,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -7,9 +7,9 @@ messages as described in [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html) 
 [RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html), and URIs as described in
 [RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html) (in the context of HTTP messages).
 
-- RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
-- RFC 7231: http://www.ietf.org/rfc/rfc7231.txt
-- RFC 3986: http://www.ietf.org/rfc/rfc3986.txt
+- RFC 7230: http://www.www.rfc-editor.org/rfc/rfc7230.html
+- RFC 7231: http://www.www.rfc-editor.org/rfc/rfc7231.html
+- RFC 3986: http://www.www.rfc-editor.org/rfc/rfc3986.html
 
 All HTTP messages consist of the HTTP protocol version being used, headers, and
 a message body. A _Request_ builds on the message to include the HTTP method
@@ -449,7 +449,7 @@ server-side requests and client-side responses.
 
 The `RequestInterface` and `ResponseInterface` have essentially 1:1
 correlations with the request and response messages described in
-[RFC 7230](http://www.ietf.org/rfc/rfc7230.txt). They provide interfaces for
+[RFC 7230](http://www.www.rfc-editor.org/rfc/rfc7230.html). They provide interfaces for
 implementing value objects that correspond to the specific HTTP message types
 they model.
 

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -3,9 +3,9 @@
 ## 1. Summary
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
-messages as described in [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html) and
-[RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html), and URIs as described in
-[RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html) (in the context of HTTP messages).
+messages as described in [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230.html) and
+[RFC 7231](https://www.rfc-editor.org/rfc/rfc7231.html), and URIs as described in
+[RFC 3986](https://www.rfc-editor.org/rfc/rfc3986.html) (in the context of HTTP messages).
 
 - RFC 7230: http://www.www.rfc-editor.org/rfc/rfc7230.html
 - RFC 7231: http://www.www.rfc-editor.org/rfc/rfc7231.html

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -3,9 +3,9 @@
 ## 1. Summary
 
 The purpose of this proposal is to provide a set of common interfaces for HTTP
-messages as described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
-[RFC 7231](http://tools.ietf.org/html/rfc7231), and URIs as described in
-[RFC 3986](http://tools.ietf.org/html/rfc3986) (in the context of HTTP messages).
+messages as described in [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html) and
+[RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html), and URIs as described in
+[RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html) (in the context of HTTP messages).
 
 - RFC 7230: http://www.ietf.org/rfc/rfc7230.txt
 - RFC 7231: http://www.ietf.org/rfc/rfc7231.txt

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1,9 +1,9 @@
 # HTTP message interfaces
 
 This document describes common interfaces for representing HTTP messages as
-described in [RFC 7230](http://tools.ietf.org/html/rfc7230) and
-[RFC 7231](http://tools.ietf.org/html/rfc7231), and URIs for use with HTTP
-messages as described in [RFC 3986](http://tools.ietf.org/html/rfc3986).
+described in [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html) and
+[RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html), and URIs for use with HTTP
+messages as described in [RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html).
 
 HTTP messages are the foundation of web development. Web browsers and HTTP
 clients such as cURL create HTTP request messages that are sent to a web server,
@@ -48,14 +48,14 @@ and the elements composing them.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
 
 ### References
 
-- [RFC 2119](http://tools.ietf.org/html/rfc2119)
-- [RFC 3986](http://tools.ietf.org/html/rfc3986)
-- [RFC 7230](http://tools.ietf.org/html/rfc7230)
-- [RFC 7231](http://tools.ietf.org/html/rfc7231)
+- [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html)
+- [RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html)
+- [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html)
+- [RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html)
 
 ## 1. Specification
 
@@ -871,7 +871,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * changed request target.
      *
-     * @see http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
+     * @see http://www.rfc-editor.org/rfc/rfc7230.html#section-5.3 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
      * @return static
@@ -907,7 +907,7 @@ interface RequestInterface extends MessageInterface
      *
      * This method MUST return a UriInterface instance.
      *
-     * @see http://tools.ietf.org/html/rfc3986#section-4.3
+     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
      * @return UriInterface Returns a UriInterface instance
      *     representing the URI of the request.
      */
@@ -938,7 +938,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * new UriInterface instance.
      *
-     * @see http://tools.ietf.org/html/rfc3986#section-4.3
+     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
      * @return static
@@ -1256,7 +1256,7 @@ interface ResponseInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * updated status and reason phrase.
      *
-     * @see http://tools.ietf.org/html/rfc7231#section-6
+     * @see http://www.rfc-editor.org/rfc/rfc7231.html#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @param int $code The 3-digit integer result code to set.
      * @param string $reasonPhrase The reason phrase to use with the
@@ -1276,7 +1276,7 @@ interface ResponseInterface extends MessageInterface
      * listed in the IANA HTTP Status Code Registry) for the response's
      * status code.
      *
-     * @see http://tools.ietf.org/html/rfc7231#section-6
+     * @see http://www.rfc-editor.org/rfc/rfc7231.html#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @return string Reason phrase; must return an empty string if none present.
      */
@@ -1470,7 +1470,7 @@ namespace Psr\Http\Message;
  * For server-side requests, the scheme will typically be discoverable in the
  * server parameters.
  *
- * @see http://tools.ietf.org/html/rfc3986 (the URI specification)
+ * @see http://www.rfc-editor.org/rfc/rfc3986.html (the URI specification)
  */
 interface UriInterface
 {
@@ -1485,7 +1485,7 @@ interface UriInterface
      * The trailing ":" character is not part of the scheme and MUST NOT be
      * added.
      *
-     * @see https://tools.ietf.org/html/rfc3986#section-3.1
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1
      * @return string The URI scheme.
      */
     public function getScheme();
@@ -1505,7 +1505,7 @@ interface UriInterface
      * If the port component is not set or is the standard port for the current
      * scheme, it SHOULD NOT be included.
      *
-     * @see https://tools.ietf.org/html/rfc3986#section-3.2
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2
      * @return string The URI authority, in "[user-info@]host[:port]" format.
      */
     public function getAuthority();
@@ -1535,7 +1535,7 @@ interface UriInterface
      * The value returned MUST be normalized to lowercase, per RFC 3986
      * Section 3.2.2.
      *
-     * @see http://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2
      * @return string The URI host.
      */
     public function getHost();
@@ -1578,8 +1578,8 @@ interface UriInterface
      * delimiter between path segments, that value MUST be passed in encoded
      * form (e.g., "%2F") to the instance.
      *
-     * @see https://tools.ietf.org/html/rfc3986#section-2
-     * @see https://tools.ietf.org/html/rfc3986#section-3.3
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-2
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3
      * @return string The URI path.
      */
     public function getPath();
@@ -1600,8 +1600,8 @@ interface UriInterface
      * include an ampersand ("&") not intended as a delimiter between values,
      * that value MUST be passed in encoded form (e.g., "%26") to the instance.
      *
-     * @see https://tools.ietf.org/html/rfc3986#section-2
-     * @see https://tools.ietf.org/html/rfc3986#section-3.4
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-2
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.4
      * @return string The URI query string.
      */
     public function getQuery();
@@ -1618,8 +1618,8 @@ interface UriInterface
      * any characters. To determine what characters to encode, please refer to
      * RFC 3986, Sections 2 and 3.5.
      *
-     * @see https://tools.ietf.org/html/rfc3986#section-2
-     * @see https://tools.ietf.org/html/rfc3986#section-3.5
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-2
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.5
      * @return string The URI fragment.
      */
     public function getFragment();
@@ -1768,7 +1768,7 @@ interface UriInterface
      * - If a query is present, it MUST be prefixed by "?".
      * - If a fragment is present, it MUST be prefixed by "#".
      *
-     * @see http://tools.ietf.org/html/rfc3986#section-4.1
+     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.1
      * @return string
      */
     public function __toString();

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1,9 +1,9 @@
 # HTTP message interfaces
 
 This document describes common interfaces for representing HTTP messages as
-described in [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html) and
-[RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html), and URIs for use with HTTP
-messages as described in [RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html).
+described in [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230.html) and
+[RFC 7231](https://www.rfc-editor.org/rfc/rfc7231.html), and URIs for use with HTTP
+messages as described in [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986.html).
 
 HTTP messages are the foundation of web development. Web browsers and HTTP
 clients such as cURL create HTTP request messages that are sent to a web server,
@@ -48,14 +48,14 @@ and the elements composing them.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ### References
 
-- [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html)
-- [RFC 3986](http://www.rfc-editor.org/rfc/rfc3986.html)
-- [RFC 7230](http://www.rfc-editor.org/rfc/rfc7230.html)
-- [RFC 7231](http://www.rfc-editor.org/rfc/rfc7231.html)
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html)
+- [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986.html)
+- [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230.html)
+- [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231.html)
 
 ## 1. Specification
 
@@ -871,7 +871,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * changed request target.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc7230.html#section-5.3 (for the various
+     * @see https://www.rfc-editor.org/rfc/rfc7230.html#section-5.3 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
      * @return static
@@ -907,7 +907,7 @@ interface RequestInterface extends MessageInterface
      *
      * This method MUST return a UriInterface instance.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
      * @return UriInterface Returns a UriInterface instance
      *     representing the URI of the request.
      */
@@ -938,7 +938,7 @@ interface RequestInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * new UriInterface instance.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
      * @return static
@@ -1256,7 +1256,7 @@ interface ResponseInterface extends MessageInterface
      * immutability of the message, and MUST return an instance that has the
      * updated status and reason phrase.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc7231.html#section-6
+     * @see https://www.rfc-editor.org/rfc/rfc7231.html#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @param int $code The 3-digit integer result code to set.
      * @param string $reasonPhrase The reason phrase to use with the
@@ -1276,7 +1276,7 @@ interface ResponseInterface extends MessageInterface
      * listed in the IANA HTTP Status Code Registry) for the response's
      * status code.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc7231.html#section-6
+     * @see https://www.rfc-editor.org/rfc/rfc7231.html#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @return string Reason phrase; must return an empty string if none present.
      */
@@ -1470,7 +1470,7 @@ namespace Psr\Http\Message;
  * For server-side requests, the scheme will typically be discoverable in the
  * server parameters.
  *
- * @see http://www.rfc-editor.org/rfc/rfc3986.html (the URI specification)
+ * @see https://www.rfc-editor.org/rfc/rfc3986.html (the URI specification)
  */
 interface UriInterface
 {
@@ -1535,7 +1535,7 @@ interface UriInterface
      * The value returned MUST be normalized to lowercase, per RFC 3986
      * Section 3.2.2.
      *
-     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2
      * @return string The URI host.
      */
     public function getHost();
@@ -1768,7 +1768,7 @@ interface UriInterface
      * - If a query is present, it MUST be prefixed by "?".
      * - If a fragment is present, it MUST be prefixed by "#".
      *
-     * @see http://www.rfc-editor.org/rfc/rfc3986.html#section-4.1
+     * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1
      * @return string
      */
     public function __toString();

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -637,8 +637,8 @@ namespace Psr\Http\Message;
  * be implemented such that they retain the internal state of the current
  * message and return an instance that contains the changed state.
  *
- * @see http://www.ietf.org/rfc/rfc7230.txt
- * @see http://www.ietf.org/rfc/rfc7231.txt
+ * @see http://www.www.rfc-editor.org/rfc/rfc7230.html
+ * @see http://www.www.rfc-editor.org/rfc/rfc7231.html
  */
 interface MessageInterface
 {

--- a/proposed/clock.md
+++ b/proposed/clock.md
@@ -11,7 +11,7 @@ The final implementations MAY decorate the objects with more
 functionality than the one proposed but they MUST implement the indicated
 interfaces/functionality first.
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 # 1. Specification
 

--- a/proposed/clock.md
+++ b/proposed/clock.md
@@ -11,7 +11,7 @@ The final implementations MAY decorate the objects with more
 functionality than the one proposed but they MUST implement the indicated
 interfaces/functionality first.
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 # 1. Specification
 

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -1052,8 +1052,8 @@ class Foo
 ```
 
 
-[RFC2119]:      https://tools.ietf.org/html/rfc2119
-[RFC2396]:      https://tools.ietf.org/html/rfc2396
+[RFC2119]:      https://www.rfc-editor.org/rfc/rfc2119.html
+[RFC2396]:      https://www.rfc-editor.org/rfc/rfc2396.html
 [SEMVER2]:      http://www.semver.org
 [PHP_SUBSTR]:   https://php.net/manual/function.substr.php
 [SPDX]:         https://www.spdx.org/licenses

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -680,8 +680,8 @@ The following keywords are recognized by this PSR:
 
     This type is often used as return value for methods implementing the [Fluent Interface][FLUENT] design pattern.
 
-[RFC2119]:      https://tools.ietf.org/html/rfc2119
-[RFC5234]:      https://tools.ietf.org/html/rfc5234
+[RFC2119]:      https://www.rfc-editor.org/rfc/rfc2119.html
+[RFC5234]:      https://www.rfc-editor.org/rfc/rfc5234.html
 [PHP_RESOURCE]: https://php.net/manual/language.types.resource.php
 [PHP_ITERABLE]: https://php.net/manual/language.types.iterable.php
 [PHP_PSEUDO]:   https://php.net/manual/language.pseudo-types.php

--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -3,7 +3,7 @@ Mutually Assured Hug
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## 1. Overview
 

--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -3,7 +3,7 @@ Mutually Assured Hug
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://www.rfc-editor.org/rfc/rfc2119.html).
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## 1. Overview
 

--- a/proposed/security-disclosure-publication.md
+++ b/proposed/security-disclosure-publication.md
@@ -14,7 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 
@@ -89,7 +89,7 @@ In addition the following tags are added:
 * remediationType (workaround, mitigation, vendor fix, none available, will not fix)
 * remediationLink (URL to give additional information for remediation)
 
-[1] https://tools.ietf.org/html/rfc4287
+[1] https://www.rfc-editor.org/rfc/rfc4287.html
 [2] http://www.icasi.org/cvrf-1.1
 [3] http://www.icasi.org/cvrf-1.1-dictionary
 [4] security-disclosure-publication.xsd

--- a/proposed/security-disclosure-publication.md
+++ b/proposed/security-disclosure-publication.md
@@ -14,7 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/proposed/security-reporting-process.md
+++ b/proposed/security-reporting-process.md
@@ -14,7 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 

--- a/proposed/security-reporting-process.md
+++ b/proposed/security-reporting-process.md
@@ -14,7 +14,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://www.rfc-editor.org/rfc/rfc2119.html
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
 
 ## Goal
 


### PR DESCRIPTION
At the time of this pull request, http://tools.ietf.org/html/* is returning 404 Not Found errors.

Considering this subdomain is an alias of levkowetz.com, let's use an official domain listed on the IETF's website: https://www.rfc-editor.org

This pull request composes of two regex find and replaces on all documents:

Search: tools.ietf.org/html/rfc(\d*)
Replace: www.rfc-editor.org/rfc/rfc$1.html

Search: ietf.org/rfc/rfc(\d*).txt
Replace: www.rfc-editor.org/rfc/rfc$1.html

Additionally, set all links to rfc-editor.org to use https