### PR TITLE
Update AzuraCast project representative twitter handle

### DIFF
--- a/personnel.md
+++ b/personnel.md
@@ -34,7 +34,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 
 | Project                           | Representative                        |
 |-----------------------------------|---------------------------------------|
-| [AzuraCast]                       | Felix Bachmann ([@Vaalyn])            |
+| [AzuraCast]                       | Felix Bachmann ([@VaalynDev])         |
 | [CakePHP]                         | Larry Masters ([@PhpNut])             |
 | [Composer]                        | Jordi Boggiano ([@seldaek])           |
 | [concrete5]                       | Korvin Szanto ([@korvinszanto])       |
@@ -183,7 +183,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 [@taylorotwell]: https://twitter.com/taylorotwell
 [@tedivm]: https://twitter.com/tedivm
 [@trowski2002]: https://twitter.com/trowski2002
-[@Vaalyn]: https://twitter.com/vaalyndev
+[@VaalynDev]: https://twitter.com/vaalyndev
 [@vdelau]: https://twitter.com/vdelau
 [@WyriHaximus]: https://twitter.com/WyriHaximus
 [@xtaz07]: https://twitter.com/xtaz07


### PR DESCRIPTION
This PR updates the Twitter handle for the AzuraCast project representative to match the correct Twitter account.