### PR TITLE
Reduce names on PSR index

### DIFF
--- a/PSR.md
+++ b/PSR.md
@@ -8,31 +8,31 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 
 ### Accepted
 
-| Num | Title                          | Editor                         |  Coordinator            | Sponsor                 |
-|:---:|--------------------------------|--------------------------------|-------------------------|-------------------------|
-| 1   | [Basic Coding Standard][psr1]  | Paul M. Jones                  | _N/A_                   | _N/A_                   |
-| 3   | [Logger Interface][psr3]       | Jordi Boggiano                 | _N/A_                   | _N/A_                   |
-| 4   | [Autoloading Standard][psr4]   | Paul M. Jones                  | Phil Sturgeon           | Larry Garfield          |
-| 6   | [Caching Interface][psr6]      | Larry Garfield                 | Paul Dragoonis          | Robert Hafner           |
-| 7   | [HTTP Message Interface][psr7] | Matthew Weier O'Phinney        | Beau Simensen           | Paul M. Jones           |
-| 11  | [Container Interface][psr11]   | Matthieu Napoli, David Négrier | Matthew Weier O'Phinney | Korvin Szanto           |
-| 12  | [Extended Coding Style Guide][psr12] | Korvin Szanto            | Alexander Makarov       |  Chris Tankersley       | 
-| 13  | [Hypermedia Links][psr13]      | Larry Garfield                 | Matthew Weier O'Phinney | Marc Alexander          |
-| 14  | [Event Dispatcher][psr14]      | Larry Garfield                 | _N/A_                   | Cees-Jan Kiewiet        |
-| 15  | [HTTP Handlers][psr15]         | Woody Gilk                     | _N/A_                   | Matthew Weier O'Phinney |
-| 16  | [Simple Cache][psr16]          | Paul Dragoonis                 | Jordi Boggiano          | Fabien Potencier        |
-| 17  | [HTTP Factories][psr17]        | Woody Gilk                     | _N/A_                   | Matthew Weier O'Phinney |
-| 18  | [HTTP Client][psr18]           | Tobias Nyholm                  | _N/A_                   | Sara Golemon            |
+| Num | Title                                | Maintainer                     |
+|:---:|--------------------------------------|--------------------------------|
+| 1   | [Basic Coding Standard][psr1]        | _vacant_                       |
+| 3   | [Logger Interface][psr3]             | Jordi Boggiano                 |
+| 4   | [Autoloading Standard][psr4]         | _vacant_                       |
+| 6   | [Caching Interface][psr6]            | Larry Garfield                 |
+| 7   | [HTTP Message Interface][psr7]       | Matthew Weier O'Phinney        |
+| 11  | [Container Interface][psr11]         | Matthieu Napoli, David Négrier |
+| 12  | [Extended Coding Style Guide][psr12] | Korvin Szanto                  |
+| 13  | [Hypermedia Links][psr13]            | Larry Garfield                 |
+| 14  | [Event Dispatcher][psr14]            | Larry Garfield                 |
+| 15  | [HTTP Handlers][psr15]               | Woody Gilk                     |
+| 16  | [Simple Cache][psr16]                | Paul Dragoonis                 |
+| 17  | [HTTP Factories][psr17]              | Woody Gilk                     |
+| 18  | [HTTP Client][psr18]                 | Tobias Nyholm                  |
 
 ### Draft
 
-| Num | Title                                | Editor(s)                      |
-|:---:|--------------------------------------|--------------------------------|
-| 5   | [PHPDoc Standard][psr5]              | Chuck Burgess                  |
-| 19  | [PHPDoc tags][psr19]                 | Chuck Burgess                  |
-| 20  | [Clock][psr20]                       | Chris Seufert                  |
-| 21  | [Internationalization][psr21]        | Navarr Barnier                 |
-| 22  | [Application Tracing][psr22]         | Adam Allport                   |
+| Num | Title                                | Editor(s)                      | Sponsor                        |
+|:---:|--------------------------------------|--------------------------------|--------------------------------|
+| 5   | [PHPDoc Standard][psr5]              | Chuck Burgess                  | Michael Cullum                 |
+| 19  | [PHPDoc tags][psr19]                 | Chuck Burgess                  | Michael Cullum                 |
+| 20  | [Clock][psr20]                       | Chris Seufert                  | Chuck Burgess                  |
+| 21  | [Internationalization][psr21]        | Navarr Barnier                 | Larry Garfield                 |
+| 22  | [Application Tracing][psr22]         | Adam Allport                   | Alessandro Chitolina           |
 
 ### Abandoned
 
@@ -44,10 +44,10 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 
 ### Deprecated
 
-| Num | Title                          | Editor                  |
-|:---:|--------------------------------|-------------------------|
-| 0   | [Autoloading Standard][psr0]   | Matthew Weier O'Phinney |
-| 2   | [Coding Style Guide][psr2]     | Paul M. Jones           |
+| Num | Title                                |
+|:---:|--------------------------------------|
+| 0   | [Autoloading Standard][psr0]         |
+| 2   | [Coding Style Guide][psr2]           |
 
 ## Numerical Index
 

--- a/PSR.md
+++ b/PSR.md
@@ -44,20 +44,20 @@ As also described in the [PSR Workflow Bylaw][workflow]. The Editor, or editors,
 
 ### Deprecated
 
-| Num | Title                                |
-|:---:|--------------------------------------|
-| 0   | [Autoloading Standard][psr0]         |
-| 2   | [Coding Style Guide][psr2]           |
+| Num | Title                                |     |
+|:---:|--------------------------------------|-----|
+| 0   | [Autoloading Standard][psr0]         |     |
+| 2   | [Coding Style Guide][psr2]           |     |
 
 ## Numerical Index
 
-| Num | Title                                | Editor(s)                      | Status     |
+| Num | Title                                | Editor(s) / Maintainers        | Status     |
 |:---:|--------------------------------------|--------------------------------|------------|
-| 0   | [Autoloading Standard][psr0]         | Matthew Weier O'Phinney        | Deprecated |
-| 1   | [Basic Coding Standard][psr1]        | Paul M. Jones                  | Accepted   |
-| 2   | [Coding Style Guide][psr2]           | Paul M. Jones                  | Deprecated |
+| 0   | [Autoloading Standard][psr0]         |                                | Deprecated |
+| 1   | [Basic Coding Standard][psr1]        | _vacant_                       | Accepted   |
+| 2   | [Coding Style Guide][psr2]           |                                | Deprecated |
 | 3   | [Logger Interface][psr3]             | Jordi Boggiano                 | Accepted   |
-| 4   | [Autoloading Standard][psr4]         | Paul M. Jones                  | Accepted   |
+| 4   | [Autoloading Standard][psr4]         | _vacant_                       | Accepted   |
 | 5   | [PHPDoc Standard][psr5]              | Chuck Burgess                  | Draft      |
 | 6   | [Caching Interface][psr6]            | Larry Garfield                 | Accepted   |
 | 7   | [HTTP Message Interface][psr7]       | Matthew Weier O'Phinney        | Accepted   |

--- a/accepted/PSR-0-meta.md
+++ b/accepted/PSR-0-meta.md
@@ -1,0 +1,14 @@
+# PSR-0 Meta Document
+
+## 1. Summary
+
+PSR-0 predates the official FIG structure and describes a standard for 
+autoloader interoperability. It is superseded by PSR-4. This meta document
+was added after the PSR has been deprecated. 
+
+## 2. People
+
+### 2.1 Editor
+
+* Matthew Weier O'Phinney
+

--- a/accepted/PSR-1-basic-coding-standard-meta.md
+++ b/accepted/PSR-1-basic-coding-standard-meta.md
@@ -1,4 +1,4 @@
-# PSR-0 Meta Document
+# PSR-1 Meta Document
 
 ## 1. Summary
 

--- a/accepted/PSR-1-basic-coding-standard-meta.md
+++ b/accepted/PSR-1-basic-coding-standard-meta.md
@@ -1,0 +1,15 @@
+# PSR-0 Meta Document
+
+## 1. Summary
+
+This section of the standard comprises what should be considered the standard
+coding elements that are required to ensure a high level of technical
+interoperability between shared PHP code. This meta document is added after the
+document was accepted. 
+
+## 2. People
+
+### 2.1 Editor
+
+* Paul M. Jones
+

--- a/accepted/PSR-2-coding-style-guide-meta.md
+++ b/accepted/PSR-2-coding-style-guide-meta.md
@@ -38,3 +38,10 @@ $app->get('/hello/{name}', function ($name) use ($app) {
 
 When extending multiple interfaces, the list of `extends` should be treated the same as a list
 of `implements`, as declared in Section 4.1.
+
+## 4. People
+
+### 4.1 Editor
+
+* Paul M. Jones
+


### PR DESCRIPTION
- Editors become maintainers after PSR is accepted, updated labels
- Move credits of past contributors to meta files, to reduce clutter
- Add meta file for PSR-0 and PSR-1
- Reference new PSR for PSR-0 and PSR-2

See also php-fig/www.php-fig.org#302