### PR TITLE
Fix: Use backticks

### DIFF
--- a/accepted/PSR-0.md
+++ b/accepted/PSR-0.md
@@ -51,7 +51,7 @@ Example Implementation
 Below is an example function to simply demonstrate how the above
 proposed standards are autoloaded.
 
-~~~php
+```php
 <?php
 
 function autoload($className)
@@ -69,7 +69,7 @@ function autoload($className)
     require $fileName;
 }
 spl_autoload_register('autoload');
-~~~
+```
 
 SplClassLoader Implementation
 -----------------------------

--- a/accepted/PSR-1-basic-coding-standard.md
+++ b/accepted/PSR-1-basic-coding-standard.md
@@ -59,7 +59,7 @@ reading from or writing to a file, and so on.
 The following is an example of a file with both declarations and side effects;
 i.e, an example of what to avoid:
 
-~~~php
+```php
 <?php
 // side effect: change ini settings
 ini_set('error_reporting', E_ALL);
@@ -75,12 +75,12 @@ function foo()
 {
     // function body
 }
-~~~
+```
 
 The following example is of a file that contains declarations without side
 effects; i.e., an example of what to emulate:
 
-~~~php
+```php
 <?php
 // declaration
 function foo()
@@ -95,7 +95,7 @@ if (! function_exists('bar')) {
         // function body
     }
 }
-~~~
+```
 
 ## 3. Namespace and Class Names
 
@@ -110,7 +110,7 @@ Code written for PHP 5.3 and after MUST use formal namespaces.
 
 For example:
 
-~~~php
+```php
 <?php
 // PHP 5.3 and later:
 namespace Vendor\Model;
@@ -118,18 +118,18 @@ namespace Vendor\Model;
 class Foo
 {
 }
-~~~
+```
 
 Code written for 5.2.x and before SHOULD use the pseudo-namespacing convention
 of `Vendor_` prefixes on class names.
 
-~~~php
+```php
 <?php
 // PHP 5.2.x and earlier:
 class Vendor_Model_Foo
 {
 }
-~~~
+```
 
 ## 4. Class Constants, Properties, and Methods
 
@@ -140,7 +140,7 @@ The term "class" refers to all classes, interfaces, and traits.
 Class constants MUST be declared in all upper case with underscore separators.
 For example:
 
-~~~php
+```php
 <?php
 namespace Vendor\Model;
 
@@ -149,7 +149,7 @@ class Foo
     const VERSION = '1.0';
     const DATE_APPROVED = '2012-06-01';
 }
-~~~
+```
 
 ### 4.2. Properties
 

--- a/accepted/PSR-11-container.md
+++ b/accepted/PSR-11-container.md
@@ -68,7 +68,7 @@ Projects requiring an implementation should require `psr/container-implementatio
 <a name="container-interface"></a>
 ### 3.1. `Psr\Container\ContainerInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Container;
 
@@ -102,7 +102,7 @@ interface ContainerInterface
      */
     public function has($id);
 }
-~~~
+```
 
 
 Since [psr/container version 1.1](https://packagist.org/packages/psr/container#1.1.0),
@@ -115,7 +115,7 @@ the above interface has been updated to add return type hints (but only to the
 <a name="container-exception"></a>
 ### 3.2. `Psr\Container\ContainerExceptionInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Container;
 
@@ -125,12 +125,12 @@ namespace Psr\Container;
 interface ContainerExceptionInterface
 {
 }
-~~~
+```
 
 <a name="not-found-exception"></a>
 ### 3.3. `Psr\Container\NotFoundExceptionInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Container;
 
@@ -140,4 +140,4 @@ namespace Psr\Container;
 interface NotFoundExceptionInterface extends ContainerExceptionInterface
 {
 }
-~~~
+```

--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -36,7 +36,7 @@ of PHP supported by your project.
 
 This example encompasses some of the rules below as a quick overview:
 
-~~~php
+```php
 <?php
 
 declare(strict_types=1);
@@ -68,7 +68,7 @@ class Foo extends Bar implements FooInterface
         // method body
     }
 }
-~~~
+```
 
 ## 2. General
 
@@ -147,7 +147,7 @@ must always be fully qualified.
 
 The following example illustrates a complete list of all blocks:
 
-~~~php
+```php
 <?php
 
 /**
@@ -176,11 +176,11 @@ class FooBar
     // ... additional PHP code ...
 }
 
-~~~
+```
 
 Compound namespaces with a depth of more than two MUST NOT be used. Therefore the
 following is the maximum compounding depth allowed:
-~~~php
+```php
 <?php
 
 use Vendor\Package\SomeNamespace\{
@@ -189,11 +189,11 @@ use Vendor\Package\SomeNamespace\{
     SubnamespaceTwo\ClassY,
     ClassZ,
 };
-~~~
+```
 
 And the following would not be allowed:
 
-~~~php
+```php
 <?php
 
 use Vendor\Package\SomeNamespace\{
@@ -201,14 +201,14 @@ use Vendor\Package\SomeNamespace\{
     SubnamespaceOne\ClassB,
     ClassZ,
 };
-~~~
+```
 
 When wishing to declare strict types in files containing markup outside PHP
 opening and closing tags, the declaration MUST be on the first line of the file
 and include an opening PHP tag, the strict types declaration and closing tag.
 
 For example:
-~~~php
+```php
 <?php declare(strict_types=1) ?>
 <html>
 <body>
@@ -217,18 +217,18 @@ For example:
     ?>
 </body>
 </html>
-~~~
+```
 
 Declare statements MUST contain no spaces and MUST be exactly `declare(strict_types=1)`
 (with an optional semi-colon terminator).
 
 Block declare statements are allowed and MUST be formatted as below. Note position of
 braces and spacing:
-~~~php
+```php
 declare(ticks=1) {
     // some code
 }
-~~~
+```
 
 ## 4. Classes, Properties, and Methods
 
@@ -240,9 +240,9 @@ same line.
 When instantiating a new class, parentheses MUST always be present even when
 there are no arguments passed to the constructor.
 
-~~~php
+```php
 new Foo();
-~~~
+```
 
 ### 4.1 Extends and Implements
 
@@ -258,7 +258,7 @@ by a blank line.
 Closing braces MUST be on their own line and MUST NOT be preceded by a blank
 line.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -271,14 +271,14 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {
     // constants, properties, methods
 }
-~~~
+```
 
 Lists of `implements` and, in the case of interfaces, `extends` MAY be split
 across multiple lines, where each subsequent line is indented once. When doing
 so, the first item in the list MUST be on the next line, and there MUST be only
 one interface per line.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -294,14 +294,14 @@ class ClassName extends ParentClass implements
 {
     // constants, properties, methods
 }
-~~~
+```
 
 ### 4.2 Using traits
 
 The `use` keyword used inside the classes to implement traits MUST be
 declared on the next line after the opening brace.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -312,12 +312,12 @@ class ClassName
 {
     use FirstTrait;
 }
-~~~
+```
 
 Each individual trait that is imported into a class MUST be included
 one-per-line and each inclusion MUST have its own `use` import statement.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -332,12 +332,12 @@ class ClassName
     use SecondTrait;
     use ThirdTrait;
 }
-~~~
+```
 
 When the class has nothing after the `use` import statement, the class
 closing brace MUST be on the next line after the `use` import statement.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -348,11 +348,11 @@ class ClassName
 {
     use FirstTrait;
 }
-~~~
+```
 
 Otherwise, it MUST have a blank line after the `use` import statement.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -365,12 +365,12 @@ class ClassName
 
     private $property;
 }
-~~~
+```
 
 When using the `insteadof` and `as` operators they must be used as follows taking
 note of indentation, spacing, and new lines.
 
-~~~php
+```php
 <?php
 
 class Talker
@@ -384,7 +384,7 @@ class Talker
         C::mediumTalk as FooBar;
     }
 }
-~~~
+```
 
 ### 4.3 Properties and Constants
 
@@ -405,7 +405,7 @@ There MUST be a space between type declaration and property name.
 
 A property declaration looks like the following:
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -415,7 +415,7 @@ class ClassName
     public $foo = null;
     public static int $bar = 0;
 }
-~~~
+```
 
 ### 4.4 Methods and Functions
 
@@ -433,7 +433,7 @@ parenthesis, and there MUST NOT be a space before the closing parenthesis.
 A method declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -445,19 +445,19 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 A function declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-~~~php
+```php
 <?php
 
 function fooBarBaz($arg1, &$arg2, $arg3 = [])
 {
     // function body
 }
-~~~
+```
 
 ### 4.5 Method and Function Arguments
 
@@ -467,7 +467,7 @@ MUST be one space after each comma.
 Method and function arguments with default values MUST go at the end of the argument
 list.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -479,7 +479,7 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -489,7 +489,7 @@ When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space
 between them.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -504,14 +504,14 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 When you have a return type declaration present, there MUST be one space after
 the colon followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parenthesis with no spaces between
 the two characters.
 
-~~~php
+```php
 <?php
 
 declare(strict_types=1);
@@ -533,12 +533,12 @@ class ReturnTypeVariations
         return 'foo';
     }
 }
-~~~
+```
 
 In nullable type declarations, there MUST NOT be a space between the question mark
 and the type.
 
-~~~php
+```php
 <?php
 
 declare(strict_types=1);
@@ -552,7 +552,7 @@ class ReturnTypeVariations
         return 'foo';
     }
 }
-~~~
+```
 
 When using the reference operator `&` before an argument, there MUST NOT be
 a space after it, like in the previous example.
@@ -585,7 +585,7 @@ visibility declaration.
 When present, the `static` declaration MUST come after the visibility
 declaration.
 
-~~~php
+```php
 <?php
 
 namespace Vendor\Package;
@@ -601,7 +601,7 @@ abstract class ClassName
         // method body
     }
 }
-~~~
+```
 
 ### 4.7 Method and Function Calls
 
@@ -611,13 +611,13 @@ after the opening parenthesis, and there MUST NOT be a space before the
 closing parenthesis. In the argument list, there MUST NOT be a space before
 each comma, and there MUST be one space after each comma.
 
-~~~php
+```php
 <?php
 
 bar();
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
-~~~
+```
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -625,7 +625,7 @@ next line, and there MUST be only one argument per line. A single argument being
 split across multiple lines (as might be the case with an anonymous function or
 array) does not constitute splitting the argument list itself.
 
-~~~php
+```php
 <?php
 
 $foo->bar(
@@ -633,9 +633,9 @@ $foo->bar(
     $longerArgument,
     $muchLongerArgument
 );
-~~~
+```
 
-~~~php
+```php
 <?php
 
 somefunction($foo, $bar, [
@@ -645,7 +645,7 @@ somefunction($foo, $bar, [
 $app->get('/hello/{name}', function ($name) use ($app) {
     return 'Hello ' . $app->escape($name);
 });
-~~~
+```
 
 ## 5. Control Structures
 
@@ -670,7 +670,7 @@ An `if` structure looks like the following. Note the placement of parentheses,
 spaces, and braces; and that `else` and `elseif` are on the same line as the
 closing brace from the earlier body.
 
-~~~php
+```php
 <?php
 
 if ($expr1) {
@@ -680,7 +680,7 @@ if ($expr1) {
 } else {
     // else body;
 }
-~~~
+```
 
 The keyword `elseif` SHOULD be used instead of `else if` so that all control
 keywords look like single words.
@@ -692,7 +692,7 @@ placed together on their own line with one space between them. Boolean
 operators between conditions MUST always be at the beginning or at the end of
 the line, not a mix of both.
 
-~~~php
+```php
 <?php
 
 if (
@@ -706,7 +706,7 @@ if (
 ) {
     // elseif body
 }
-~~~
+```
 
 ### 5.2 `switch`, `case`
 
@@ -716,7 +716,7 @@ from `switch`, and the `break` keyword (or other terminating keywords) MUST be
 indented at the same level as the `case` body. There MUST be a comment such as
 `// no break` when fall-through is intentional in a non-empty `case` body.
 
-~~~php
+```php
 <?php
 
 switch ($expr) {
@@ -735,7 +735,7 @@ switch ($expr) {
         echo 'Default case';
         break;
 }
-~~~
+```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
@@ -744,7 +744,7 @@ placed together on their own line with one space between them. Boolean
 operators between conditions MUST always be at the beginning or at the end of
 the line, not a mix of both.
 
-~~~php
+```php
 <?php
 
 switch (
@@ -753,20 +753,20 @@ switch (
 ) {
     // structure body
 }
-~~~
+```
 
 ### 5.3 `while`, `do while`
 
 A `while` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 
 while ($expr) {
     // structure body
 }
-~~~
+```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
@@ -775,7 +775,7 @@ placed together on their own line with one space between them. Boolean
 operators between conditions MUST always be at the beginning or at the end of
 the line, not a mix of both.
 
-~~~php
+```php
 <?php
 
 while (
@@ -784,25 +784,25 @@ while (
 ) {
     // structure body
 }
-~~~
+```
 
 Similarly, a `do while` statement looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 
 do {
     // structure body;
 } while ($expr);
-~~~
+```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. Boolean operators between conditions MUST
 always be at the beginning or at the end of the line, not a mix of both.
 
-~~~php
+```php
 <?php
 
 do {
@@ -811,27 +811,27 @@ do {
     $expr1
     && $expr2
 );
-~~~
+```
 
 ### 5.4 `for`
 
 A `for` statement looks like the following. Note the placement of parentheses,
 spaces, and braces.
 
-~~~php
+```php
 <?php
 
 for ($i = 0; $i < 10; $i++) {
     // for body
 }
-~~~
+```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first expression
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them.
 
-~~~php
+```php
 <?php
 
 for (
@@ -841,27 +841,27 @@ for (
 ) {
     // for body
 }
-~~~
+```
 
 ### 5.5 `foreach`
 
 A `foreach` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 
 foreach ($iterable as $key => $value) {
     // foreach body
 }
-~~~
+```
 
 ### 5.6 `try`, `catch`, `finally`
 
 A `try-catch-finally` block looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 
 try {
@@ -873,7 +873,7 @@ try {
 } finally {
     // finally body
 }
-~~~
+```
 
 ## 6. Operators
 
@@ -888,43 +888,43 @@ All operators not described here are left undefined.
 
 The increment/decrement operators MUST NOT have any space between
 the operator and operand.
-~~~php
+```php
 $i++;
 ++$j;
-~~~
+```
 
 Type casting operators MUST NOT have any space within the parentheses:
-~~~php
+```php
 $intValue = (int) $input;
-~~~
+```
 
 ### 6.2. Binary operators
 
 All binary [arithmetic][], [comparison][], [assignment][], [bitwise][],
 [logical][], [string][], and [type][] operators MUST be preceded and
 followed by at least one space:
-~~~php
+```php
 if ($a === $b) {
     $foo = $bar ?? $a ?? $b;
 } elseif ($a > $b) {
     $foo = $a + $b * $c;
 }
-~~~
+```
 
 ### 6.3. Ternary operators
 
 The conditional operator, also known simply as the ternary operator, MUST be
 preceded and followed by at least one space around both the `?`
 and `:` characters:
-~~~php
+```php
 $variable = $foo ? 'foo' : 'bar';
-~~~
+```
 
 When the middle operand of the conditional operator is omitted, the operator
 MUST follow the same style rules as other binary [comparison][] operators:
-~~~php
+```php
 $variable = $foo ?: 'bar';
-~~~
+```
 
 ## 7. Closures
 
@@ -951,7 +951,7 @@ the `use` list closing parentheses with no spaces between the two characters.
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-~~~php
+```php
 <?php
 
 $closureWithArgs = function ($arg1, $arg2) {
@@ -965,7 +965,7 @@ $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
 $closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
     // body
 };
-~~~
+```
 
 Argument lists and variable lists MAY be split across multiple lines, where
 each subsequent line is indented once. When doing so, the first item in the
@@ -979,7 +979,7 @@ together on their own line with one space between them.
 The following are examples of closures with and without argument lists and
 variable lists split across multiple lines.
 
-~~~php
+```php
 <?php
 
 $longArgs_noVars = function (
@@ -1025,12 +1025,12 @@ $shortArgs_longVars = function ($arg) use (
 ) {
    // body
 };
-~~~
+```
 
 Note that the formatting rules also apply when the closure is used directly
 in a function or method call as an argument.
 
-~~~php
+```php
 <?php
 
 $foo->bar(
@@ -1040,25 +1040,25 @@ $foo->bar(
     },
     $arg3
 );
-~~~
+```
 
 ## 8. Anonymous Classes
 
 Anonymous Classes MUST follow the same guidelines and principles as closures
 in the above section.
 
-~~~php
+```php
 <?php
 
 $instance = new class {};
-~~~
+```
 
 The opening brace MAY be on the same line as the `class` keyword so long as
 the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the brace MUST be placed on the line immediately following the last
 interface.
 
-~~~php
+```php
 <?php
 
 // Brace on the same line
@@ -1074,7 +1074,7 @@ $instance = new class extends \Foo implements
 {
     // Class content
 };
-~~~
+```
 
 [PSR-1]: https://www.php-fig.org/psr/psr-1/
 [PSR-2]: https://www.php-fig.org/psr/psr-2/

--- a/accepted/PSR-13-links.md
+++ b/accepted/PSR-13-links.md
@@ -131,7 +131,7 @@ The interfaces and classes described are provided as part of the
 
 ### 3.1 `Psr\Link\LinkInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Link;
@@ -184,11 +184,11 @@ interface LinkInterface
      */
     public function getAttributes();
 }
-~~~
+```
 
 ### 3.2 `Psr\Link\EvolvableLinkInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Link;
@@ -267,11 +267,11 @@ interface EvolvableLinkInterface extends LinkInterface
      */
     public function withoutAttribute($attribute);
 }
-~~~
+```
 
 #### 3.2 `Psr\Link\LinkProviderInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Link;
@@ -301,11 +301,11 @@ interface LinkProviderInterface
      */
     public function getLinksByRel($rel);
 }
-~~~
+```
 
 #### 3.3 `Psr\Link\EvolvableLinkProviderInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Link;
@@ -341,7 +341,7 @@ interface EvolvableLinkProviderInterface extends LinkProviderInterface
      */
     public function withoutLink(LinkInterface $link);
 }
-~~~
+```
 
 Since [psr/link version 1.1](https://packagist.org/packages/psr/link#1.1.0), the above interfaces have been updated to add argument type hints.
 Since [psr/link version 2.0](https://packagist.org/packages/psr/link#2.0.0), the above interfaces have been updated to add return type hints.  References to `array|\Traversable` have been replaced with `iterable`.

--- a/accepted/PSR-16-simple-cache.md
+++ b/accepted/PSR-16-simple-cache.md
@@ -131,7 +131,7 @@ An instance of CacheInterface corresponds to a single collection of cache items 
 and is equivalent to a "Pool" in PSR-6. Different CacheInterface instances MAY be backed by the same
 datastore, but MUST be logically independent.
 
-~~~php
+```php
 <?php
 
 namespace Psr\SimpleCache;
@@ -246,11 +246,11 @@ interface CacheInterface
      */
     public function has($key);
 }
-~~~
+```
 
 ## 2.2 CacheException
 
-~~~php
+```php
 
 <?php
 
@@ -262,11 +262,11 @@ namespace Psr\SimpleCache;
 interface CacheException
 {
 }
-~~~
+```
 
 ## 2.3 InvalidArgumentException
 
-~~~php
+```php
 <?php
 
 namespace Psr\SimpleCache;
@@ -280,4 +280,4 @@ namespace Psr\SimpleCache;
 interface InvalidArgumentException extends CacheException
 {
 }
-~~~
+```

--- a/accepted/PSR-2-coding-style-guide-meta.md
+++ b/accepted/PSR-2-coding-style-guide-meta.md
@@ -23,7 +23,7 @@ functions are able to span multiple lines.
 
 The following examples are perfectly valid in PSR-2:
 
-~~~php
+```php
 <?php
 somefunction($foo, $bar, [
   // ...
@@ -32,7 +32,7 @@ somefunction($foo, $bar, [
 $app->get('/hello/{name}', function ($name) use ($app) {
     return 'Hello '.$app->escape($name);
 });
-~~~
+```
 
 ### 3.2 - Extending Multiple Interfaces (10/17/2013)
 

--- a/accepted/PSR-2-coding-style-guide.md
+++ b/accepted/PSR-2-coding-style-guide.md
@@ -60,7 +60,7 @@ interpreted as described in [RFC 2119].
 
 This example encompasses some of the rules below as a quick overview:
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -86,7 +86,7 @@ class Foo extends Bar implements FooInterface
         // method body
     }
 }
-~~~
+```
 
 ## 2. General
 
@@ -149,7 +149,7 @@ There MUST be one blank line after the `use` block.
 
 For example:
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -159,7 +159,7 @@ use OtherVendor\OtherPackage\BazClass;
 
 // ... additional PHP code ...
 
-~~~
+```
 
 ## 4. Classes, Properties, and Methods
 
@@ -173,7 +173,7 @@ the class name.
 The opening brace for the class MUST go on its own line; the closing brace
 for the class MUST go on the next line after the body.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -185,13 +185,13 @@ class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {
     // constants, properties, methods
 }
-~~~
+```
 
 Lists of `implements` MAY be split across multiple lines, where each
 subsequent line is indented once. When doing so, the first item in the list
 MUST be on the next line, and there MUST be only one interface per line.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -206,7 +206,7 @@ class ClassName extends ParentClass implements
 {
     // constants, properties, methods
 }
-~~~
+```
 
 ### 4.2. Properties
 
@@ -221,7 +221,7 @@ protected or private visibility.
 
 A property declaration looks like the following.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -229,7 +229,7 @@ class ClassName
 {
     public $foo = null;
 }
-~~~
+```
 
 ### 4.3. Methods
 
@@ -246,7 +246,7 @@ parenthesis, and there MUST NOT be a space before the closing parenthesis.
 A method declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -257,7 +257,7 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 ### 4.4. Method Arguments
 
@@ -267,7 +267,7 @@ MUST be one space after each comma.
 Method arguments with default values MUST go at the end of the argument
 list.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -278,7 +278,7 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
@@ -288,7 +288,7 @@ When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space
 between them.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -302,7 +302,7 @@ class ClassName
         // method body
     }
 }
-~~~
+```
 
 ### 4.5. `abstract`, `final`, and `static`
 
@@ -312,7 +312,7 @@ visibility declaration.
 When present, the `static` declaration MUST come after the visibility
 declaration.
 
-~~~php
+```php
 <?php
 namespace Vendor\Package;
 
@@ -327,7 +327,7 @@ abstract class ClassName
         // method body
     }
 }
-~~~
+```
 
 ### 4.6. Method and Function Calls
 
@@ -337,25 +337,25 @@ after the opening parenthesis, and there MUST NOT be a space before the
 closing parenthesis. In the argument list, there MUST NOT be a space before
 each comma, and there MUST be one space after each comma.
 
-~~~php
+```php
 <?php
 bar();
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
-~~~
+```
 
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
 next line, and there MUST be only one argument per line.
 
-~~~php
+```php
 <?php
 $foo->bar(
     $longArgument,
     $longerArgument,
     $muchLongerArgument
 );
-~~~
+```
 
 ## 5. Control Structures
 
@@ -379,7 +379,7 @@ An `if` structure looks like the following. Note the placement of parentheses,
 spaces, and braces; and that `else` and `elseif` are on the same line as the
 closing brace from the earlier body.
 
-~~~php
+```php
 <?php
 if ($expr1) {
     // if body
@@ -388,7 +388,7 @@ if ($expr1) {
 } else {
     // else body;
 }
-~~~
+```
 
 The keyword `elseif` SHOULD be used instead of `else if` so that all control
 keywords look like single words.
@@ -401,7 +401,7 @@ from `switch`, and the `break` keyword (or other terminating keyword) MUST be
 indented at the same level as the `case` body. There MUST be a comment such as
 `// no break` when fall-through is intentional in a non-empty `case` body.
 
-~~~php
+```php
 <?php
 switch ($expr) {
     case 0:
@@ -419,60 +419,60 @@ switch ($expr) {
         echo 'Default case';
         break;
 }
-~~~
+```
 
 ### 5.3. `while`, `do while`
 
 A `while` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 while ($expr) {
     // structure body
 }
-~~~
+```
 
 Similarly, a `do while` statement looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 do {
     // structure body;
 } while ($expr);
-~~~
+```
 
 ### 5.4. `for`
 
 A `for` statement looks like the following. Note the placement of parentheses,
 spaces, and braces.
 
-~~~php
+```php
 <?php
 for ($i = 0; $i < 10; $i++) {
     // for body
 }
-~~~
+```
 
 ### 5.5. `foreach`
 
 A `foreach` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 foreach ($iterable as $key => $value) {
     // foreach body
 }
-~~~
+```
 
 ### 5.6. `try`, `catch`
 
 A `try catch` block looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
-~~~php
+```php
 <?php
 try {
     // try body
@@ -481,7 +481,7 @@ try {
 } catch (OtherExceptionType $e) {
     // catch body
 }
-~~~
+```
 
 ## 6. Closures
 
@@ -504,7 +504,7 @@ list.
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
-~~~php
+```php
 <?php
 $closureWithArgs = function ($arg1, $arg2) {
     // body
@@ -513,7 +513,7 @@ $closureWithArgs = function ($arg1, $arg2) {
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     // body
 };
-~~~
+```
 
 Argument lists and variable lists MAY be split across multiple lines, where
 each subsequent line is indented once. When doing so, the first item in the
@@ -527,7 +527,7 @@ together on their own line with one space between them.
 The following are examples of closures with and without argument lists and
 variable lists split across multiple lines.
 
-~~~php
+```php
 <?php
 $longArgs_noVars = function (
     $longArgument,
@@ -572,12 +572,12 @@ $shortArgs_longVars = function ($arg) use (
 ) {
     // body
 };
-~~~
+```
 
 Note that the formatting rules also apply when the closure is used directly
 in a function or method call as an argument.
 
-~~~php
+```php
 <?php
 $foo->bar(
     $arg1,
@@ -586,7 +586,7 @@ $foo->bar(
     },
     $arg3
 );
-~~~
+```
 
 ## 7. Conclusion
 

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -63,7 +63,7 @@ Users of loggers are referred to as `user`.
   The following is an example implementation of placeholder interpolation
   provided for reference purposes only:
 
-  ~~~php
+  ```php
   <?php
 
   /**
@@ -92,7 +92,7 @@ Users of loggers are referred to as `user`.
 
   // echoes "User bolivar created"
   echo interpolate($message, $context);
-  ~~~
+  ```
 
 ### 1.3 Context
 
@@ -141,7 +141,7 @@ and a test suite to verify your implementation are provided as part of the
 
 ## 3. `Psr\Log\LoggerInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Log;
@@ -256,11 +256,11 @@ interface LoggerInterface
      */
     public function log($level, $message, array $context = array());
 }
-~~~
+```
 
 ## 4. `Psr\Log\LoggerAwareInterface`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Log;
@@ -278,11 +278,11 @@ interface LoggerAwareInterface
      */
     public function setLogger(LoggerInterface $logger);
 }
-~~~
+```
 
 ## 5. `Psr\Log\LogLevel`
 
-~~~php
+```php
 <?php
 
 namespace Psr\Log;
@@ -301,4 +301,4 @@ class LogLevel
     const INFO      = 'info';
     const DEBUG     = 'debug';
 }
-~~~
+```

--- a/accepted/PSR-4-autoloader-examples.md
+++ b/accepted/PSR-4-autoloader-examples.md
@@ -6,7 +6,7 @@ The following examples illustrate PSR-4 compliant code:
 Closure Example
 ---------------
 
-~~~php
+```php
 <?php
 /**
  * An example of a project-specific implementation.
@@ -48,7 +48,7 @@ spl_autoload_register(function ($class) {
         require $file;
     }
 });
-~~~
+```
 
 Class Example
 -------------
@@ -56,7 +56,7 @@ Class Example
 The following is an example class implementation to handle multiple
 namespaces:
 
-~~~php
+```php
 <?php
 namespace Example;
 
@@ -244,13 +244,13 @@ class Psr4AutoloaderClass
         return false;
     }
 }
-~~~
+```
 
 ### Unit Tests
 
 The following example is one way of unit testing the above class loader:
 
-~~~php
+```php
 <?php
 namespace Example\Tests;
 
@@ -347,4 +347,4 @@ class Psr4AutoloaderClassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 }
-~~~
+```

--- a/accepted/PSR-6-cache-meta.md
+++ b/accepted/PSR-6-cache-meta.md
@@ -86,7 +86,7 @@ Examples:
 Some common usage patterns are shown below.  These are non-normative but should
 demonstrate the application of some design decisions.
 
-~~~php
+```php
 /**
  * Gets a list of available widgets.
  *
@@ -104,9 +104,9 @@ function get_widget_list()
     }
     return $item->get();
 }
-~~~
+```
 
-~~~php
+```php
 /**
  * Caches a list of available widgets.
  *
@@ -120,9 +120,9 @@ function save_widget_list($list)
     $item->set($list);
     $pool->save($item);
 }
-~~~
+```
 
-~~~php
+```php
 /**
  * Clears the list of available widgets.
  *
@@ -134,9 +134,9 @@ function clear_widget_list()
     $pool = get_cache_pool('widgets');
     $pool->deleteItems(['widget_list']);
 }
-~~~
+```
 
-~~~php
+```php
 /**
  * Clears all widget information.
  *
@@ -148,9 +148,9 @@ function clear_widget_cache()
     $pool = get_cache_pool('widgets');
     $pool->clear();
 }
-~~~
+```
 
-~~~php
+```php
 /**
  * Load widgets.
  *
@@ -187,9 +187,9 @@ function load_widgets(array $ids)
 
     return $widgets;
 }
-~~~
+```
 
-~~~php
+```php
 /**
  * This examples reflects functionality that is NOT included in this
  * specification, but is shown as an example of how such functionality MIGHT
@@ -221,7 +221,7 @@ function set_widget(TaggablePoolInterface $pool, Widget $widget)
     $item->set($widget);
     $pool->save($item);
 }
-~~~
+```
 
 ### 4.2 Alternative: "Weak item" approach
 

--- a/accepted/PSR-6-cache.md
+++ b/accepted/PSR-6-cache.md
@@ -164,7 +164,7 @@ be requested from a Pool object via the `getItem()` method.  Calling Libraries
 SHOULD NOT assume that an Item created by one Implementing Library is
 compatible with a Pool from another Implementing Library.
 
-~~~php
+```php
 <?php
 
 namespace Psr\Cache;
@@ -255,7 +255,7 @@ interface CacheItemInterface
     public function expiresAfter($time);
 
 }
-~~~
+```
 
 ### CacheItemPoolInterface
 
@@ -265,7 +265,7 @@ It is also the primary point of interaction with the entire cache collection.
 All configuration and initialization of the Pool is left up to an Implementing
 Library.
 
-~~~php
+```php
 <?php
 
 namespace Psr\Cache;
@@ -398,7 +398,7 @@ interface CacheItemPoolInterface
      */
     public function commit();
 }
-~~~
+```
 
 ### CacheException
 
@@ -408,7 +408,7 @@ or invalid credentials supplied.
 
 Any exception thrown by an Implementing Library MUST implement this interface.
 
-~~~php
+```php
 <?php
 
 namespace Psr\Cache;
@@ -419,11 +419,11 @@ namespace Psr\Cache;
 interface CacheException
 {
 }
-~~~
+```
 
 ### InvalidArgumentException
 
-~~~php
+```php
 <?php
 
 namespace Psr\Cache;
@@ -437,7 +437,7 @@ namespace Psr\Cache;
 interface InvalidArgumentException extends CacheException
 {
 }
-~~~
+```
 
 Since [psr/cache version 2.0](https://packagist.org/packages/psr/cache#2.0.0), the above interfaces have been updated to add argument type hints.
 Since [psr/cache version 3.0](https://packagist.org/packages/psr/cache#3.0.0), the above interfaces have been updated to add return type hints.  References to `array|\Traversable` have been replaced with `iterable`.

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -250,7 +250,7 @@ For HTTP clients, they allow consumers to build a base request with data such
 as the base URI and required headers, without needing to build a brand new
 request or reset request state for each message the client sends:
 
-~~~php
+```php
 $uri = new Uri('http://api.example.com');
 $baseRequest = new Request($uri, null, [
     'Authorization' => 'Bearer ' . $token,
@@ -276,7 +276,7 @@ $response = $client->sendRequest($request)
 // No need to overwrite headers or body!
 $request = $baseRequest->withUri($uri->withPath('/tasks'))->withMethod('GET');
 $response = $client->sendRequest($request);
-~~~
+```
 
 On the server-side, developers will need to:
 
@@ -299,17 +299,17 @@ changes necessary in consuming true value objects are:
 
 As an example, in Zend Framework 2, instead of the following:
 
-~~~php
+```php
 function (MvcEvent $e)
 {
     $response = $e->getResponse();
     $response->setHeaderLine('x-foo', 'bar');
 }
-~~~
+```
 
 one would now write:
 
-~~~php
+```php
 function (MvcEvent $e)
 {
     $response = $e->getResponse();
@@ -317,7 +317,7 @@ function (MvcEvent $e)
         $response->withHeader('x-foo', 'bar')
     );
 }
-~~~
+```
 
 The above combines assignment and notification in a single call.
 
@@ -375,11 +375,11 @@ like `isReadable()`, `isWritable()`, etc. This approach is used by Python,
 In some cases, you may want to return a file from the filesystem. The typical
 way to do this in PHP is one of the following:
 
-~~~php
+```php
 readfile($filename);
 
 stream_copy_to_stream(fopen($filename, 'r'), fopen('php://output', 'w'));
-~~~
+```
 
 Note that the above omits sending appropriate `Content-Type` and
 `Content-Length` headers; the developer would need to emit these prior to
@@ -390,7 +390,7 @@ implementation that accepts a filename and/or stream resource, and to provide
 this to the response instance. A complete example, including setting appropriate
 headers:
 
-~~~php
+```php
 // where Stream is a concrete StreamInterface:
 $stream   = new Stream($filename);
 $finfo    = new finfo(FILEINFO_MIME);
@@ -398,7 +398,7 @@ $response = $response
     ->withHeader('Content-Type', $finfo->file($filename))
     ->withHeader('Content-Length', (string) filesize($filename))
     ->withBody($stream);
-~~~
+```
 
 Emitting this response will send the file to the client.
 
@@ -413,7 +413,7 @@ example](https://github.com/phly/psr7examples#direct-output). Wrap any code
 emitting output directly in a callback, pass that to an appropriate
 `StreamInterface` implementation, and provide it to the message body:
 
-~~~php
+```php
 $output = new CallbackStream(function () use ($request) {
     printf("The requested URI was: %s<br>\n", $request->getUri());
     return '';
@@ -421,7 +421,7 @@ $output = new CallbackStream(function () use ($request) {
 return (new Response())
     ->withHeader('Content-Type', 'text/html')
     ->withBody($output);
-~~~
+```
 
 #### What if I want to use an iterator for content?
 
@@ -496,11 +496,11 @@ to be an array, with the following rationale:
 The main argument is that if the body parameters are an array, developers have
 predictable access to values:
 
-~~~php
+```php
 $foo = isset($request->getBodyParams()['foo'])
     ? $request->getBodyParams()['foo']
     : null;
-~~~
+```
 
 The argument for using "parsed body" was made by examining the domain. A message
 body can contain literally anything. While traditional web applications use
@@ -519,7 +519,7 @@ parsing the body. These might include:
 
 The end result is that a developer now has to look in multiple locations:
 
-~~~php
+```php
 $data = $request->getBodyParams();
 if (isset($data['__parsed__']) && is_object($data['__parsed__'])) {
     $data = $data['__parsed__'];
@@ -530,20 +530,20 @@ $data = $request->getBodyParams();
 if ($request->hasAttribute('__body__')) {
     $data = $request->getAttribute('__body__');
 }
-~~~
+```
 
 The solution presented is to use the terminology "ParsedBody", which implies
 that the values are the results of parsing the message body. This also means
 that the return value _will_ be ambiguous; however, because this is an attribute
 of the domain, this is also expected. As such, usage will become:
 
-~~~php
+```php
 $data = $request->getParsedBody();
 if (! $data instanceof \stdClass) {
     // raise an exception!
 }
 // otherwise, we have what we expected
-~~~
+```
 
 This approach removes the limitations of forcing an array, at the expense of
 ambiguity of return value. Considering that the other suggested solutions —

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -17,12 +17,12 @@ making a request to an HTTP API, or handling an incoming request.
 
 Every HTTP request message has a specific form:
 
-~~~http
+```http
 POST /path HTTP/1.1
 Host: example.com
 
 foo=bar&baz=bat
-~~~
+```
 
 The first line of a request is the "request line", and contains, in order, the
 HTTP request method, the request target (usually either an absolute URI or a
@@ -31,12 +31,12 @@ or more HTTP headers, an empty line, and the message body.
 
 HTTP response messages have a similar structure:
 
-~~~http
+```http
 HTTP/1.1 200 OK
 Content-Type: text/plain
 
 This is the response body
-~~~
+```
 
 The first line is the "status line", and contains, in order, the HTTP protocol
 version, the HTTP status code, and a "reason phrase," a human-readable
@@ -83,7 +83,7 @@ manner. For example, retrieving the `foo` header will return the same result as
 retrieving the `FoO` header. Similarly, setting the `Foo` header will overwrite
 any previously set `foo` header value.
 
-~~~php
+```php
 $message = $message->withHeader('foo', 'bar');
 
 echo $message->getHeaderLine('foo');
@@ -95,7 +95,7 @@ echo $message->getHeaderLine('FOO');
 $message = $message->withHeader('fOO', 'baz');
 echo $message->getHeaderLine('foo');
 // Outputs: baz
-~~~
+```
 
 Despite that headers may be retrieved case-insensitively, the original case
 MUST be preserved by the implementation, in particular when retrieved with
@@ -115,7 +115,7 @@ header values of a case-insensitive header by name concatenated with a comma.
 Use `getHeader()` to retrieve an array of all the header values for a
 particular case-insensitive header by name.
 
-~~~php
+```php
 $message = $message
     ->withHeader('foo', 'bar')
     ->withAddedHeader('foo', 'baz');
@@ -125,7 +125,7 @@ $header = $message->getHeaderLine('foo');
 
 $header = $message->getHeader('foo');
 // ['bar', 'baz']
-~~~
+```
 
 Note: Not all header values can be concatenated using a comma (e.g.,
 `Set-Cookie`). When working with such headers, consumers of
@@ -251,18 +251,18 @@ Calling this method does not affect the URI, as it is returned from `getUri()`.
 
 For example, a user may want to make an asterisk-form request to a server:
 
-~~~php
+```php
 $request = $request
     ->withMethod('OPTIONS')
     ->withRequestTarget('*')
     ->withUri(new Uri('https://example.org/'));
-~~~
+```
 
 This example may ultimately result in an HTTP request that looks like this:
 
-~~~http
+```http
 OPTIONS * HTTP/1.1
-~~~
+```
 
 But the HTTP client will be able to use the effective URL (from `getUri()`),
 to determine the protocol, hostname and TCP port.
@@ -329,7 +329,7 @@ of file inputs. As an example, if you have a form that submits an array of files
 — e.g., the input name "files", submitting `files[0]` and `files[1]` — PHP will
 represent this as:
 
-~~~php
+```php
 array(
     'files' => array(
         'name' => array(
@@ -343,11 +343,11 @@ array(
         /* etc. */
     ),
 )
-~~~
+```
 
 instead of the expected:
 
-~~~php
+```php
 array(
     'files' => array(
         0 => array(
@@ -362,7 +362,7 @@ array(
         ),
     ),
 )
-~~~
+```
 
 The result is that consumers need to know this language implementation detail,
 and write code for gathering the data for a given upload.
@@ -397,13 +397,13 @@ were submitted.
 
 In the simplest example, this might be a single named form element submitted as:
 
-~~~html
+```html
 <input type="file" name="avatar" />
-~~~
+```
 
 In this case, the structure in `$_FILES` would look like:
 
-~~~php
+```php
 array(
     'avatar' => array(
         'tmp_name' => 'phpUxcOty',
@@ -413,25 +413,25 @@ array(
         'error' => 0,
     ),
 )
-~~~
+```
 
 The normalized form returned by `getUploadedFiles()` would be:
 
-~~~php
+```php
 array(
     'avatar' => /* UploadedFileInterface instance */
 )
-~~~
+```
 
 In the case of an input using array notation for the name:
 
-~~~html
+```html
 <input type="file" name="my-form[details][avatar]" />
-~~~
+```
 
 `$_FILES` ends up looking like this:
 
-~~~php
+```php
 array (
     'my-form' => array (
         'name' => array (
@@ -461,11 +461,11 @@ array (
         ),
     ),
 )
-~~~
+```
 
 And the corresponding tree returned by `getUploadedFiles()` should be:
 
-~~~php
+```php
 array(
     'my-form' => array(
         'details' => array(
@@ -473,14 +473,14 @@ array(
         ),
     ),
 )
-~~~
+```
 
 In some cases, you may specify an array of files:
 
-~~~html
+```html
 Upload an avatar: <input type="file" name="my-form[details][avatars][]" />
 Upload an avatar: <input type="file" name="my-form[details][avatars][]" />
-~~~
+```
 
 (As an example, JavaScript controls might spawn additional file upload inputs to
 allow uploading multiple files at once.)
@@ -489,7 +489,7 @@ In such a case, the specification implementation must aggregate all information
 related to the file at the given index. The reason is because `$_FILES` deviates
 from its normal structure in such cases:
 
-~~~php
+```php
 array (
     'my-form' => array (
         'name' => array (
@@ -539,12 +539,12 @@ array (
         ),
     ),
 )
-~~~
+```
 
 The above `$_FILES` array would correspond to the following structure as
 returned by `getUploadedFiles()`:
 
-~~~php
+```php
 array(
     'my-form' => array(
         'details' => array(
@@ -556,13 +556,13 @@ array(
         ),
     ),
 )
-~~~
+```
 
 Consumers would access index `1` of the nested array using:
 
-~~~php
+```php
 $request->getUploadedFiles()['my-form']['details']['avatars'][1];
-~~~
+```
 
 Because the uploaded files data is derivative (derived from `$_FILES` or the
 request body), a mutator method, `withUploadedFiles()`, is also present in the
@@ -570,7 +570,7 @@ interface, allowing delegation of the normalization to another process.
 
 In the case of the original examples, consumption resembles the following:
 
-~~~php
+```php
 $file0 = $request->getUploadedFiles()['files'][0];
 $file1 = $request->getUploadedFiles()['files'][1];
 
@@ -581,7 +581,7 @@ printf(
 );
 
 // "Received the files file0.txt and file1.html"
-~~~
+```
 
 This proposal also recognizes that implementations may operate in non-SAPI
 environments. As such, `UploadedFileInterface` provides methods for ensuring
@@ -598,7 +598,7 @@ operations will work regardless of environment. In particular:
 
 As examples:
 
-~~~
+```
 // Move a file to an upload directory
 $filename = sprintf(
     '%s.%s',
@@ -613,7 +613,7 @@ $file0->moveTo(DATA_DIR . '/' . $filename);
 // StreamWrapper.
 $stream = new Psr7StreamWrapper($file1->getStream());
 stream_copy_to_stream($stream, $s3wrapper);
-~~~
+```
 
 ## 2. Package
 
@@ -624,7 +624,7 @@ The interfaces and classes described are provided as part of the
 
 ### 3.1 `Psr\Http\Message\MessageInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -812,11 +812,11 @@ interface MessageInterface
      */
     public function withBody(StreamInterface $body);
 }
-~~~
+```
 
 ### 3.2 `Psr\Http\Message\RequestInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -945,11 +945,11 @@ interface RequestInterface extends MessageInterface
      */
     public function withUri(UriInterface $uri, $preserveHost = false);
 }
-~~~
+```
 
 #### 3.2.1 `Psr\Http\Message\ServerRequestInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -1210,11 +1210,11 @@ interface ServerRequestInterface extends RequestInterface
      */
     public function withoutAttribute($name);
 }
-~~~
+```
 
 ### 3.3 `Psr\Http\Message\ResponseInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -1282,11 +1282,11 @@ interface ResponseInterface extends MessageInterface
      */
     public function getReasonPhrase();
 }
-~~~
+```
 
 ### 3.4 `Psr\Http\Message\StreamInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -1444,11 +1444,11 @@ interface StreamInterface
      */
     public function getMetadata($key = null);
 }
-~~~
+```
 
 ### 3.5 `Psr\Http\Message\UriInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -1773,11 +1773,11 @@ interface UriInterface
      */
     public function __toString();
 }
-~~~
+```
 
 ### 3.6 `Psr\Http\Message\UploadedFileInterface`
 
-~~~php
+```php
 <?php
 namespace Psr\Http\Message;
 
@@ -1900,4 +1900,4 @@ interface UploadedFileInterface
      */
     public function getClientMediaType();
 }
-~~~
+```

--- a/proposed/clock.md
+++ b/proposed/clock.md
@@ -48,7 +48,7 @@ $timestamp = $clock->now()->getTimestamp();
 The clock interface defines the most basic operation to read the current time and date from the clock. 
 It MUST return the time as a `DateTimeImmutable`.
 
-~~~php
+```php
 <?php
 
 namespace Psr\Clock;
@@ -61,4 +61,4 @@ interface ClockInterface
     public function now(): \DateTimeImmutable;
 
 }
-~~~
+```

--- a/proposed/psr-8-hug/psr-8-hug.md
+++ b/proposed/psr-8-hug/psr-8-hug.md
@@ -42,7 +42,7 @@ to support and affirm multiple objects at once.
 
 ### HuggableInterface
 
-~~~php
+```php
 namespace Psr\Hug;
 
 /**
@@ -65,9 +65,9 @@ interface Huggable
      */
     public function hug(Huggable $h);
 }
-~~~
+```
 
-~~~php
+```php
 namespace Psr\Hug;
 
 /**
@@ -90,4 +90,4 @@ interface GroupHuggable extends Huggable
    */
   public function groupHug($huggables);
 }
-~~~
+```


### PR DESCRIPTION
This pull request

- [x] consistently uses backticks instead of tildes for fenced code blocks

💁‍♂️ For reference, see https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code.