### PR TITLE
Add proposal for template renderer

### DIFF
--- a/proposed/template-renderer.md
+++ b/proposed/template-renderer.md
@@ -1,0 +1,205 @@
+Common Interface for Rendering Templates
+========================================
+
+This document describes a common interface for template renderers.
+
+The goal set by `TemplateRendererInterface` is to standardize how frameworks, libraries and CMSs
+render their template so that projects are more free to use the template renderer they prefer.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119][].
+
+The word `implementor` in this document is to be interpreted as someone
+implementing the `TemplateRendererInterface` in a [template engine][] library.
+Users of template renderer are referred to as `user`.
+The word `enduser` in this document is to be interpreted as someone using
+a library, framework, cms created by a `user`.
+
+[RFC 2119]: http://tools.ietf.org/html/rfc2119
+
+## Goal
+
+Having common interfaces for rendering templates allows developers to create libraries that can interact with many frameworks and other libraries in a common fashion.
+
+Some examples may use the Interface:
+
+ - Content Management Systems (Sulu CMS, Drupal, Typo3, Contao CMS, ...)
+ - E-Commerce Platforms (Sylius, Spryker)
+ - Newsletter/Mail Libraries (Symfony Mailer, Abstractions over Mailchimp and other Newsletter tools) 
+ - Anything following ["Separating content from presentation"](https://en.wikipedia.org/wiki/Separation_of_content_and_presentation) where the presentation is project specific.
+
+Some examples may implement the Interface or providing a bridge:
+
+ - Blade (Laravel Framework)
+ - Laminas View
+ - Latte (Nette Framework)
+ - Smarty
+ - Twig (Symfony Framework)
+
+## Definitions
+
+* **Template** - A string representation of a template .
+* **Context** - A array of context data given into to the rendered template.
+* **TemplateRenderer** - A service rendering which will render the template with the given context and return the rendered content.
+
+### Template
+
+A template MUST be a string representation of a given template supported by the template renderer. It MAY be a file path
+to the template file, but it can also be a virtual name or path supported only by a specific template renderer. The
+template is not limited by specific characters by definition but a template renderer MAY support only specific one.
+
+### Context
+
+A context is MUST be an array of the available variables given to the template renderer. The array keys represent the
+available variables and MUST be typed as string. The array values represent the variables value and can be anything and
+are so typed by mixed.
+
+### TemplateRenderer
+
+A template renderer is a service object implementing the `TemplateRendererInterface`. It MUST be responsible to render a 
+supported template by a OPTIONAL context. It MUST return the rendered content of the template as a string.
+If a template was not found by the template renderer, an Exception implementing the `TemplateNotFoundExceptionInterface`
+MUST be thrown.
+
+## Usage
+
+While the implementor of `TemplateRendererInterface` MUST make sure that the template renderer behave like defined
+above. The user of `TemplateRendererInterface` MUST allow when providing a library, application, cms for an enduser
+using the Interface to give or configure the `template` used by the template renderer. This can be achieved with any
+type of injection or configuration.
+
+Basic implementor implementation:
+
+```php
+<?php
+
+use Psr\TemplateRenderer\TemplateRendererInterface;
+
+class TemplateRenderer implements TemplateRendererInterface
+{
+    public function render(string $template, array $context = []): string
+    {
+        switch ($template) {
+            case 'home.tpl';
+
+                return $this->renderTemplate('<p>{{name}}</p>', $context);
+            default: 
+                throw new TemplateNotFoundException($template);
+        }
+    }
+    
+    /**
+     * @param array<string, mixed> $context
+     * @return string
+     */
+    private function renderTemplate(string $content, array $context): string
+    {
+        foreach ($context as $key => $value) {
+            $content = str_replace('{{' . $key . '}}', $context[$key], $content);
+        }
+        
+        return $content;
+    }
+}
+
+use Psr\TemplateRenderer\TemplateNotFoundExceptionInterface;
+
+class TemplateNotFoundException extends \RuntimeException implements TemplateNotFoundExceptionInterface
+{
+    public function __construct(private string $template, ?\Throwable $previous = null)
+    {
+        parent::__construct('Template not found: "' . $template . '"', 0 , $previous);
+    }
+    
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+}
+```
+
+Basic user implementation:
+
+```php
+<?php
+
+use Psr\TemplateRenderer\TemplateRendererInterface;
+
+class SomeController
+{
+    public function __construct(
+        private TemplateRendererInterface $templateRenderer,
+        private string $template,
+    )
+
+    public function someAction(): string
+    {
+        $context = [/* load something */]; 
+    
+        return $this->templateRenderer->render($this->template, $context);
+    }
+}
+```
+
+Example enduser implementation A:
+
+```php
+<?php
+
+$controller = new Controller($twig, '@Context/pages/mail.html.twig');
+$controller->someAction();
+```
+
+Example enduser implementation B:
+
+```php
+<?php
+
+$controller = new Controller($blade, 'mail');
+$controller->someAction();
+```
+
+Example enduser implementation C:
+
+```php
+<?php
+
+$controller = new Controller($latte, 'mail.latte');
+$controller->someAction();
+```
+
+## Interfaces
+
+### TemplateRendererInterface
+
+```php
+<?php
+
+namespace Psr\TemplateRenderer;
+
+interface TemplateRendererInterface {
+    /**
+     * Render the template with the given context data.
+     *
+     * @param string $template
+     * @param array<string, mixed> $context
+     *
+     * @return string
+     */
+    public function render(string $template, array $context = []): string;
+}
+```
+
+### TemplateNotFoundExceptionInterface
+
+```php
+<?php
+
+namespace Psr\TemplateRenderer;
+
+interface TemplateNotFoundExceptionInterface
+{
+    public function getTemplate(): string;
+}
+```


### PR DESCRIPTION
It is common that a library, application or CMSs need to renderer a template for rendering content for websites or emails. As a library author I want to make it free that my service can be used with any template engine the developer want to use.

The interface for the template renderer is simple with a template string and an array context:

```php
/**
 * Render the template with the given context data.
 *
 * @param string $template
 * @param array<string, mixed> $context
 *
 * @return string
 *
 * @throw TemplateNotFoundExceptionInterface
 */
public function render(string $template, array $context = []): string;
```

The `$template` does not need to be a real filePath. The used template engine
just need to support it. As an example in twig like template path `@namespace/directory/file.twig.html` is supported or for blade something like `website`, or latte something like `mail.latte`. So `$template` the is a string. It was considered not to be an object given
to the `render` method as such complex `View` class things like example in `laminas view`
where the View can have subviews via children are not supported in most other template engines.
So it is easier for a template engine like `laminas view` to have a bridge which
converts `$template` and `$context` into their View object as for example Twig, Smarty, Latte to have the need to create a View object.

The context need to be an array which key are a string and can contain any additional
objects in it. Where some template engines supporting to give object as context into
the renderer it was for maximum compatibility implemented to support only array by
this proposal.

The implementation of the `TemplateRendererInterface` should throw a `TemplateNotFoundExceptionInterface` when the given template was not found. Any other exception thrown are up to the template engine. There is explicit no method to check if a service exist as it is not supported by all template renderer or are in example case like twig totally different services.

The proposal should describe all requirements for the template renderers.

There are maybe template engines / renderer which will not directly implementing the PSR but it is should hopefully this way not be much work for example creating a `laminas-view-psr-bridge` package to also support that type of template engine over the PSR TemplateRendererInterface.