### PR TITLE
fix: Include the example of using the shortform of a closure

### DIFF
--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -1054,24 +1054,27 @@ in the above section.
 ~~~php
 <?php
 
-$instance = new class {};
+$instance = new class () {};
 ~~~
 
 The opening brace MAY be on the same line as the `class` keyword so long as
 the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the brace MUST be placed on the line immediately following the last
-interface.
+interface. 
+
+This also includes the use of parentheses due to directly instantiating the 
+declared class.
 
 ~~~php
 <?php
 
 // Brace on the same line
-$instance = new class extends \Foo implements \HandleableInterface {
+$instance = new class () extends \Foo implements \HandleableInterface {
     // Class content
 };
 
 // Brace on the next line
-$instance = new class extends \Foo implements
+$instance = new class () extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable

--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -929,7 +929,7 @@ $variable = $foo ?: 'bar';
 ## 7. Closures
 
 Closures MUST be declared with a space after the `function` keyword, and a
-space before and after the `use` keyword.
+space before and after the `use` keyword. This includes the use of the `shortform notation`.
 
 The opening brace MUST go on the same line, and the closing brace MUST go on
 the next line following the body.
@@ -957,6 +957,10 @@ parentheses, commas, spaces, and braces:
 $closureWithArgs = function ($arg1, $arg2) {
     // body
 };
+
+$shortClosureWithoutArgs = fn () => /* body */;
+
+$shortClosureWithArgs = fn ($arg1, $arg2) => /* body */;
 
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     // body


### PR DESCRIPTION
This explains the use of "spaces" around `fn ()`