### PR TITLE
Update the personell page with new elections

### DIFF
--- a/personnel.md
+++ b/personnel.md
@@ -6,7 +6,7 @@
 
 | Name                                  | Term                    |
 |---------------------------------------|-------------------------|
-| Alessandro Lai ([@AlessandroLai])     | 2017-11-12 - 2022-08-31 |
+| Alessandro Lai ([@AlessandroLai])     | 2017-11-12 - 2024-08-31 |
 | Vincent de Lau ([@vdelau])            | 2021-06-25 - 2023-05-30 |
 | Steve Winter ([@SteveWinterNZ])       | 2022-01-30 - 2024-01-28 |
 
@@ -15,20 +15,20 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 
 ### Core Committee Members
 
-| Name                                  | Term                    |
-|---------------------------------------|-------------------------|
-| Larry Garfield ([@Crell])             | 2016-12-24 - 2023-05-30 |
-| Matthew Weier O'Phinney ([@mwop])     | 2016-12-24 - 2023-05-30 |
-| Cees-Jan Kiewiet ([@WyriHaximus])     | 2016-12-24 - 2022-08-31 |
-| Chris Tankersley ([@dragonmantank])   | 2016-12-24 - 2024-01-28 |
-| Korvin Szanto ([@korvinszanto])       | 2016-12-24 - 2024-01-28 |
-| Chuck Burgess ([@ashnazg])            | 2018-08-26 - 2022-08-31 |
-| Woody Gilk ([@shadowhand])            | 2019-05-26 - 2022-08-31 |
-| Enrico Zimuel ([@ezimuel])            | 2020-01-25 - 2024-01-28 |
-| Ben Edmunds ([@benedmunds])           | 2020-08-31 - 2022-08-31 |
-| Michelle Sanver ([@michellesanver])   | 2021-06-25 - 2023-05-30 |
-| Alessandro Chitolina ([@alekitto])    | 2021-06-25 - 2023-05-30 |
-| Ken Guest ([@kenguest])               | 2022-01-30 - 2024-01-28 |
+| Name                                | Term                    |
+|-------------------------------------|-------------------------|
+| Larry Garfield ([@Crell])           | 2016-12-24 - 2023-05-30 |
+| Matthew Weier O'Phinney ([@mwop])   | 2016-12-24 - 2023-05-30 |
+| Cees-Jan Kiewiet ([@WyriHaximus])   | 2016-12-24 - 2024-08-31 |
+| Chris Tankersley ([@dragonmantank]) | 2016-12-24 - 2024-01-28 |
+| Korvin Szanto ([@korvinszanto])     | 2016-12-24 - 2024-01-28 |
+| Chuck Burgess ([@ashnazg])          | 2018-08-26 - 2024-08-31 |
+| Enrico Zimuel ([@ezimuel])          | 2020-01-25 - 2024-01-28 |
+| Michelle Sanver ([@michellesanver]) | 2021-06-25 - 2023-05-30 |
+| Alessandro Chitolina ([@alekitto])  | 2021-06-25 - 2023-05-30 |
+| Ken Guest ([@kenguest])             | 2022-01-30 - 2024-01-28 |
+| Jaap van Otterdijk ([@jaapio])      | 2022-08-28 - 2024-08-28 |
+| Navarr Barnier ([@navarr])          | 2022-08-28 - 2024-08-28 |
 
 ### Member Projects
 
@@ -104,6 +104,8 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 | Michael Cullum ([@michaelcullumuk])   | 2018-01-28 - 2020-01-25 |
 | Matteo Beccati ([@mbeccati])          | 2019-05-26 - 2021-05-30 |
 | Massimiliano Arione ([@garakkio])     | 2020-01-25 - 2022-01-31 |
+| Ben Edmunds ([@benedmunds])           | 2020-08-31 - 2022-08-31 |
+| Woody Gilk ([@shadowhand])            | 2019-05-26 - 2022-08-31 |
 
 ### Former Member Projects
 
@@ -192,6 +194,8 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 [@xtaz07]: https://twitter.com/xtaz07
 [@yellowandy]: https://twitter.com/yellowandy
 [@yunosh]: https://twitter.com/yunosh
+[@jaapio]: https://twitter.com/jaapio
+[@navarr]: https://twitter.com/navarr
 
 [Agavi]: http://www.agavi.org
 [Assetic]: https://github.com/kriswallsmith/assetic


### PR DESCRIPTION
I'm not sure if I'm supposed to do this, however, this document seemed to be outdated. 

I added 2 years for all people mentioned for re-election. And added me and Navarr to the list of core committee members. 