### PR TITLE
Update Personnel

### DIFF
--- a/personnel.md
+++ b/personnel.md
@@ -34,7 +34,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 
 | Project                           | Representative                        |
 |-----------------------------------|---------------------------------------|
-| [AzuraCast]                       | Felix Bachmann ([@VaalynDev])         |
+| [AzuraCast]                       | Buster Neece ([@BusterNeece])         |
 | [CakePHP]                         | Larry Masters ([@PhpNut])             |
 | [Composer]                        | Jordi Boggiano ([@seldaek])           |
 | [Concrete CMS]                    | Korvin Szanto ([@korvinszanto])       |
@@ -88,7 +88,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 | Margret Staples ([@dead_lugosi])      | 2017-11-12 - 2019-05-31 |
 | Ian Littman ([@iansltx])              | 2018-08-26 - 2020-01-25 |
 | Asmir Mustafic ([@goetas_asmir])      | 2019-05-26 - 2021-05-30 |
-| Buster Neece ([@SlvrEagle23])         | 2020-01-25 - 2022-01-31 |
+| Buster Neece ([@BusterNeece])         | 2020-01-25 - 2022-01-31 |
 
 ### Former Core Committee Members
 
@@ -135,6 +135,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 [@beausimensen]: https://twitter.com/beausimensen
 [@bernhard_rusch]: https://twitter.com/bernhard_rusch
 [@bretterer]: https://twitter.com/bretterer
+[@BusterNeece]: https://twitter.com/BusterNeece
 [@couac]: https://twitter.com/couac
 [@Crell]: https://twitter.com/Crell
 [@dead_lugosi]: https://twitter.com/dead_lugosi
@@ -182,13 +183,11 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 [@seldaek]: https://twitter.com/seldaek
 [@shadowhand]: https://twitter.com/shadowhand
 [@shefik_info]: https://twitter.com/shefik_info
-[@SlvrEagle23]: https://twitter.com/SlvrEagle23
 [@SteveWinterNZ]: http://www.tedivm.com/SteveWinterNZ
 [@storresi]: https://twitter.com/storresi
 [@taylorotwell]: https://twitter.com/taylorotwell
 [@tedivm]: https://twitter.com/tedivm
 [@trowski2002]: https://twitter.com/trowski2002
-[@VaalynDev]: https://twitter.com/vaalyndev
 [@vdelau]: https://twitter.com/vdelau
 [@WyriHaximus]: https://twitter.com/WyriHaximus
 [@xtaz07]: https://twitter.com/xtaz07


### PR DESCRIPTION
This commit updates my Twitter to its correct new value and also lists me as the project representative for the AzuraCast project. The FIG was notified of that switch quite some time ago, but the personnel page was never updated accordingly.