### PR TITLE
Funding bylaw

### DIFF
--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -27,7 +27,7 @@ Direct contributions MUST NOT be accepted through Open Collective, to avoid priv
 
 ### Through TideLift
 
-Contributions will be accepted through [TideLift](https://tidelift.com/). All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's TideLift account, which MUST be configured to pay out to the Open Collective account. 
+Contributions SHALL be accepted through [TideLift](https://tidelift.com/). All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's TideLift account, which MUST be configured to pay out to the Open Collective account. 
 
 ## Spending money
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -1,0 +1,47 @@
+# Funding
+
+## Scope and objectives
+
+PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, like for maintaining a couple of tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization.
+
+This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes or any variation in budget allocation requires a bylaw change vote. 
+
+## Fiscal hosting
+For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
+As for any other tool pertaining to the PHP-FIG, secretary will be the only ones to have full administrative access to PHP-FIG's OpenCollective account, but they will not have any decision power over it, and they are instead bounded by this document.
+
+All monetary contributions will flow through it, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through their budgetary tools.
+
+## Raising money
+### Through OpenCollective
+Contributions will be accepted through OpenCollective; PHP-FIG members will refrain from suggesting or requiring contributions from other members or the community at large if the monetary needs of the PHP-FIG are already met (see "Spending money" section).
+
+### Through TideLift
+As the main way of raising money, PHP-FIG will use [TideLift](https://tidelift.com/).
+The TideLift account will pay out any dividend to the OpenCollective account.
+
+## Spending money
+Any payment has to be budgeted and described in this document. Any payment has to be justified and aligned with the mission of the PHP-FIG, which is to push forward the evolution of the PHP community, through the definition of common standard and tools, and by helping PHP Open Source maintainers which follow the same goals.
+
+### Overfunding, and giving back to the community
+PHP-FIG is allowed to store in its OpenCollective account enough funds to sustain itself for three years in the future, according to the current approved budget.
+At least once a year, any exceeding funds will be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation), as a way to give back to the community, and further increase its growth.
+
+### Approved expenses
+This section will enumerate any approved expense.
+
+#### Domain, site, email
+The main recurring expense will be:
+ * the domains (`php-fig.com` and `php-fig.org`)
+ * the email account (`info@php-fig.org`)
+
+Currently, those are and will be bought using NameCheap as a registrar.
+If paying for multiple years at once allows for a discount, and if enough funding is available, this should be done with an upper limit of five years in the future.
+
+### Chronological list of budgetary decisions
+This section will contain a chronological list of budgeting decisions, either recurring or not.
+
+| Since | Expense | Approximate amount to be spent |
+|-------|---------|--------------------------------|
+| TBA   | Domains | 2 x ~15 USD / year             |
+| TBA   | Email   | ~15 USD / year                 |

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -44,7 +44,8 @@ At least once a year, any surplus funds will be forwarded to the [PHP Foundation
 ### Approved expenses
 
 This section will contain a chronological list of approved budgeting decisions, either recurring or not.
-Changes to this section only will not trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
+
+As an exception to Votes Bylaw, changes to this section only will not trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -13,16 +13,21 @@ All three Secretaries, but only the Secretaries, will have full administrative a
 
 All monetary contributions will flow through OpenCollective, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through OpenCollective's budgetary tools.
 
-## Raising money
+# Raising money
+
+PHP-FIG accepts donations through multiple channels.  Only the Secretaries may actively solicit donations from any party.  No other PHP-FIG member may do so.
 
 ### Through OpenCollective
 
-Contributions will be accepted through OpenCollective; PHP-FIG members will refrain from suggesting or requiring contributions from other members or the community at large if the monetary needs of the PHP-FIG are already met (see "Spending money" section).
+Direct contributions will be accepted through OpenCollective.
 
 ### Through TideLift
 
-As the main way of raising money, PHP-FIG will use [TideLift](https://tidelift.com/).
-The TideLift account will pay out any dividend to the OpenCollective account.
+Contributions will be accepted through [TideLift](https://tidelift.com/).  They will pay out to the OpenCollective account.
+
+### Through Thanks.dev
+
+Contributions will be accepted through [Thanks.dev](https://thanks.dev).  They will pay out to the OpenCollective account.
 
 ## Spending money
 
@@ -39,6 +44,7 @@ At least once a year, any exceeding funds will be forwarded to the [PHP Foundati
 ### Approved expenses
 
 This section will contain a chronological list of approved budgeting decisions, either recurring or not.
+Changes to this section only will not trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -4,7 +4,7 @@
 
 PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, for example maintaining tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization.
 
-This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes or any variation in budget allocation requires a bylaw change vote. 
+This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes requires a bylaw change vote. 
 
 ## Fiscal hosting
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -31,7 +31,7 @@ Contributions SHALL be accepted through [TideLift](https://tidelift.com/). All t
 
 ## Spending money
 
-Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or working groups.
+Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups.
 All expenses MUST be approved by an Approval Vote of the Core Committee.  The expense MUST include whether it is one time or recurring and at which frequency.  All expenses MUST be justified by their contribution to the mission of PHP-FIG.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -2,7 +2,7 @@
 
 ## Scope and objectives
 
-PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, like for maintaining a couple of tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization.
+PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, for example maintaining tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization.
 
 This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes or any variation in budget allocation requires a bylaw change vote. 
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -11,7 +11,7 @@ This document defines the roles, rules and processes that must be followed insid
 For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
 All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
 
-All monetary contributions will flow through OpenCollective, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through OpenCollective's budgetary tools.
+All monetary contributions will flow through OpenCollective, so that any tax considerations will be handled automatically, and every financial decision will be published and publicly available through OpenCollective's budgetary tools.
 
 # Raising money
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -9,7 +9,7 @@ This document defines the roles, rules and processes that must be followed insid
 ## Fiscal hosting
 
 For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
-As for any other tool pertaining to the PHP-FIG, secretary will be the only ones to have full administrative access to PHP-FIG's OpenCollective account, but they will not have any decision power over it, and they are instead bounded by this document.
+All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
 
 All monetary contributions will flow through it, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through their budgetary tools.
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -7,30 +7,38 @@ PHP-FIG is, as it often happens in Open Source communities, an organization comp
 This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes or any variation in budget allocation requires a bylaw change vote. 
 
 ## Fiscal hosting
+
 For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
 As for any other tool pertaining to the PHP-FIG, secretary will be the only ones to have full administrative access to PHP-FIG's OpenCollective account, but they will not have any decision power over it, and they are instead bounded by this document.
 
 All monetary contributions will flow through it, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through their budgetary tools.
 
 ## Raising money
+
 ### Through OpenCollective
+
 Contributions will be accepted through OpenCollective; PHP-FIG members will refrain from suggesting or requiring contributions from other members or the community at large if the monetary needs of the PHP-FIG are already met (see "Spending money" section).
 
 ### Through TideLift
+
 As the main way of raising money, PHP-FIG will use [TideLift](https://tidelift.com/).
 The TideLift account will pay out any dividend to the OpenCollective account.
 
 ## Spending money
+
 Any payment has to be budgeted and described in this document. Any payment has to be justified and aligned with the mission of the PHP-FIG, which is to push forward the evolution of the PHP community, through the definition of common standard and tools, and by helping PHP Open Source maintainers which follow the same goals.
 
 ### Overfunding, and giving back to the community
+
 PHP-FIG is allowed to store in its OpenCollective account enough funds to sustain itself for three years in the future, according to the current approved budget.
 At least once a year, any exceeding funds will be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation), as a way to give back to the community, and further increase its growth.
 
 ### Approved expenses
+
 This section will enumerate any approved expense.
 
 #### Domain, site, email
+
 The main recurring expense will be:
  * the domains (`php-fig.com` and `php-fig.org`)
  * the email account (`info@php-fig.org`)
@@ -39,6 +47,7 @@ Currently, those are and will be bought using NameCheap as a registrar.
 If paying for multiple years at once allows for a discount, and if enough funding is available, this should be done with an upper limit of five years in the future.
 
 ### Chronological list of budgetary decisions
+
 This section will contain a chronological list of budgeting decisions, either recurring or not.
 
 | Since | Expense | Approximate amount to be spent |

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -26,7 +26,10 @@ The TideLift account will pay out any dividend to the OpenCollective account.
 
 ## Spending money
 
-Any payment has to be budgeted and described in this document. Any payment has to be justified and aligned with the mission of the PHP-FIG, which is to push forward the evolution of the PHP community, through the definition of common standard and tools, and by helping PHP Open Source maintainers which follow the same goals.
+Funds donated to the PHP-FIG are to be used for non-personnel operating expenses.  PHP-FIG does not pay individual contributors to PHP-FIG standards or working groups.
+All operating or capital expenses must be approved by an Approval Vote of the Core Committee.  The expense must include whether it is one time or recurring and at which frequency.  All expenses must be justified by their contribution to the mission of PHP-FIG.
+
+Expenses approved by the Core Committee will be listed below.
 
 ### Overfunding, and giving back to the community
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -33,7 +33,7 @@ Contributions SHALL be accepted through [TideLift](https://tidelift.com/). All t
 ## Spending money
 
 Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups.
-All expenses MUST be approved by an Approval Vote of the Core Committee.  The expense MUST include whether it is one time or recurring and at which frequency.  All expenses MUST be justified by their contribution to the mission of PHP-FIG.
+All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and at which frequency. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -11,7 +11,7 @@ This document defines the roles, rules and processes that must be followed insid
 For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
 All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
 
-All monetary contributions will flow through it, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through their budgetary tools.
+All monetary contributions will flow through OpenCollective, so that any tax matter will be handled automatically, and every financial decision will be published and publicly available through OpenCollective's budgetary tools.
 
 ## Raising money
 
@@ -40,7 +40,7 @@ At least once a year, any exceeding funds will be forwarded to the [PHP Foundati
 
 This section will contain a chronological list of approved budgeting decisions, either recurring or not.
 
-| Approved since | Expense                                       | Approved amount and frequency  |
-|----------------|-----------------------------------------------|--------------------------------|
-| TBA            | Two Domains (`php-fig.com` and `php-fig.org`) | Up to 15 USD / year per domain |
-| TBA            | Email account (`info@php-fig.org`)            | Up to 15 USD / year            |
+| Approved since | Expense                                       | Provider  | Approved amount and frequency  |
+|----------------|-----------------------------------------------|-----------|--------------------------------|
+| TBA            | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | Up to 15 USD / year per domain |
+| TBA            | Email account (`info@php-fig.org`)            | Namecheap | Up to 15 USD / year            |

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -8,7 +8,7 @@ This document defines the roles, rules and processes that must be followed insid
 
 ## Fiscal hosting
 
-For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
+For handling money and fiscal matters, the PHP-FIG will use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
 All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
 
 All monetary contributions will flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision will be published and publicly available through Open Collective's budgetary tools.

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -11,6 +11,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 ## Fiscal hosting
 
 For handling money and fiscal matters, the PHP-FIG MUST use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
+
 All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's OpenCollective account. They SHALL NOT use those permissions in a discretionary manner, except as stated explicitly in this bylaw.
 
 All funds MUST be collected into the Open Collective PHP-FIG account, so that any tax considerations will be handled automatically by the fiscal host, and every financial decision MUST be published and publicly available at the bottom of this document in the appropriate table and through Open Collective's budgetary tools.

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -13,7 +13,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 For handling money and fiscal matters, the PHP-FIG MUST use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
 All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's OpenCollective account. They SHALL NOT use those permissions in a discretionary manner, except as stated explicitly in this bylaw.
 
-All funds MUST be collected into the Open Collective PHP-FIG account, so that any tax considerations will be handled automatically by the fiscal host, and every financial decision MUST be published and publicly available here and through Open Collective's budgetary tools.
+All funds MUST be collected into the Open Collective PHP-FIG account, so that any tax considerations will be handled automatically by the fiscal host, and every financial decision MUST be published and publicly available at the bottom of this document in the appropriate table and through Open Collective's budgetary tools.
 
 ## Raising money
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -15,7 +15,7 @@ All three Secretaries, but only the Secretaries, MUST have full administrative a
 
 All monetary contributions MUST flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision MUST be published and publicly available here and through Open Collective's budgetary tools.
 
-# Raising money
+## Raising money
 
 PHP-FIG SHALL NOT solicit donations from any party, especially from private individuals. The only allowed funding sources MUST be listed below.
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -11,7 +11,7 @@ This document defines the roles, rules and processes that must be followed insid
 For handling money and fiscal matters, the PHP-FIG will use [OpenCollective](https://opencollective.com/) as a fiscal host.
 All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
 
-All monetary contributions will flow through OpenCollective, so that any tax considerations will be handled automatically, and every financial decision will be published and publicly available through OpenCollective's budgetary tools.
+All monetary contributions will flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision will be published and publicly available through Open Collective's budgetary tools.
 
 # Raising money
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -45,7 +45,7 @@ At least once a year, any surplus funds MUST be forwarded to the [PHP Foundation
 
 This section will contain a chronological list of approved budgeting decisions, either recurring or not.
 
-As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
+As an exception to [Votes Bylaw][], changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|
@@ -53,3 +53,4 @@ As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger 
 | TBA            | Email account (`info@php-fig.org`)            | Namecheap | Up to 15 USD / year            |
 
 [RFC 2119]: https://tools.ietf.org/html/rfc2119
+[Votes Bylaw]: https://www.php-fig.org/bylaws/voting-protocol/

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -31,8 +31,8 @@ Contributions will be accepted through [TideLift](https://tidelift.com/). All th
 
 ## Spending money
 
-Funds donated to the PHP-FIG MUST NOT be used for non-personnel operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or working groups.
-All operating or capital expenses MUST be approved by an Approval Vote of the Core Committee.  The expense MUST include whether it is one time or recurring and at which frequency.  All expenses MUST be justified by their contribution to the mission of PHP-FIG.
+Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or working groups.
+All expenses MUST be approved by an Approval Vote of the Core Committee.  The expense MUST include whether it is one time or recurring and at which frequency.  All expenses MUST be justified by their contribution to the mission of PHP-FIG.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -6,48 +6,50 @@ PHP-FIG is, as it often happens in Open Source communities, an organization comp
 
 This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes requires a bylaw change vote. 
 
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
+
 ## Fiscal hosting
 
-For handling money and fiscal matters, the PHP-FIG will use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
-All three Secretaries, but only the Secretaries, will have full administrative access to PHP-FIG's OpenCollective account.  They do not have discretionary authority, however, except as stated explicitly in this bylaw.
+For handling money and fiscal matters, the PHP-FIG MUST use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
+All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's OpenCollective account. They SHALL NOT use those permissions in a discretionary manner, except as stated explicitly in this bylaw.
 
-All monetary contributions will flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision will be published and publicly available through Open Collective's budgetary tools.
+All monetary contributions MUST flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision MUST be published and publicly available here and through Open Collective's budgetary tools.
 
 # Raising money
 
-PHP-FIG accepts donations through multiple channels.  Only the Secretaries may actively solicit donations from any party.  No other PHP-FIG member may do so.
+PHP-FIG SHALL NOT solicit donations from any party, especially from private individuals. The only allowed funding sources MUST be listed below.
 
 ### Through OpenCollective
 
-Direct contributions will be accepted through OpenCollective.
+Direct contributions MUST NOT be accepted through OpenCollective; the collective home page MUST be set up in a way that:
+ * all contribution sections and features are hidden and/or disabled, if possible;
+ * explicit wording will be visible reminding visitors of the PHP-FIG stance in the matter.
 
 ### Through TideLift
 
-Contributions will be accepted through [TideLift](https://tidelift.com/).  They will pay out to the OpenCollective account.
-
-### Through Thanks.dev
-
-Contributions will be accepted through [Thanks.dev](https://thanks.dev).  They will pay out to the OpenCollective account.
+Contributions will be accepted through [TideLift](https://tidelift.com/). All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's TideLift account, which MUST be configured to pay out to the Open Collective account. 
 
 ## Spending money
 
-Funds donated to the PHP-FIG are to be used for non-personnel operating expenses.  PHP-FIG does not pay individual contributors to PHP-FIG standards or working groups.
-All operating or capital expenses must be approved by an Approval Vote of the Core Committee.  The expense must include whether it is one time or recurring and at which frequency.  All expenses must be justified by their contribution to the mission of PHP-FIG.
+Funds donated to the PHP-FIG MUST NOT be used for non-personnel operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or working groups.
+All operating or capital expenses MUST be approved by an Approval Vote of the Core Committee.  The expense MUST include whether it is one time or recurring and at which frequency.  All expenses MUST be justified by their contribution to the mission of PHP-FIG.
 
-Expenses approved by the Core Committee will be listed below.
+Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
 
 ### Overfunding, and giving back to the community
 
-PHP-FIG will maintain financial reserves to account for three years of the currently approved budget.
-At least once a year, any surplus funds will be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation) as a way to further support the PHP ecosystem.
+PHP-FIG SHOULD maintain financial reserves to account for three years of the currently approved budget.
+At least once a year, any surplus funds MUST be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation), as a way to further support the PHP ecosystem.
 
 ### Approved expenses
 
 This section will contain a chronological list of approved budgeting decisions, either recurring or not.
 
-As an exception to Votes Bylaw, changes to this section only will not trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
+As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|
 | TBA            | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | Up to 15 USD / year per domain |
 | TBA            | Email account (`info@php-fig.org`)            | Namecheap | Up to 15 USD / year            |
+
+[RFC 2119]: https://tools.ietf.org/html/rfc2119

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -38,22 +38,9 @@ At least once a year, any exceeding funds will be forwarded to the [PHP Foundati
 
 ### Approved expenses
 
-This section will enumerate any approved expense.
+This section will contain a chronological list of approved budgeting decisions, either recurring or not.
 
-#### Domain, site, email
-
-The main recurring expense will be:
- * the domains (`php-fig.com` and `php-fig.org`)
- * the email account (`info@php-fig.org`)
-
-Currently, those are and will be bought using NameCheap as a registrar.
-If paying for multiple years at once allows for a discount, and if enough funding is available, this should be done with an upper limit of five years in the future.
-
-### Chronological list of budgetary decisions
-
-This section will contain a chronological list of budgeting decisions, either recurring or not.
-
-| Since | Expense | Approximate amount to be spent |
-|-------|---------|--------------------------------|
-| TBA   | Domains | 2 x ~15 USD / year             |
-| TBA   | Email   | ~15 USD / year                 |
+| Approved since | Expense                                       | Approved amount and frequency  |
+|----------------|-----------------------------------------------|--------------------------------|
+| TBA            | Two Domains (`php-fig.com` and `php-fig.org`) | Up to 15 USD / year per domain |
+| TBA            | Email account (`info@php-fig.org`)            | Up to 15 USD / year            |

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -33,7 +33,7 @@ Contributions SHALL be accepted through [TideLift](https://tidelift.com/). All t
 ## Spending money
 
 Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups.
-All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and at which frequency. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount.
+All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and at which frequency. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount, only if that does not exceed a 10% increase.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -38,8 +38,8 @@ Expenses approved by the Core Committee will be listed below.
 
 ### Overfunding, and giving back to the community
 
-PHP-FIG is allowed to store in its OpenCollective account enough funds to sustain itself for three years in the future, according to the current approved budget.
-At least once a year, any exceeding funds will be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation), as a way to give back to the community, and further increase its growth.
+PHP-FIG will maintain financial reserves to account for three years of the currently approved budget.
+At least once a year, any surplus funds will be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation) as a way to further support the PHP ecosystem.
 
 ### Approved expenses
 

--- a/bylaws/009-funding.md
+++ b/bylaws/009-funding.md
@@ -2,7 +2,7 @@
 
 ## Scope and objectives
 
-PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, for example maintaining tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization.
+PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, for example maintaining tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization. At the same time, we will avoid soliciting and collecting donations from private individuals, while instead trying to obtain funding from commercial companies and similar entities that, due to their profit which stems from the usage of Open Source Software, should contribute to the costs of the Open Source community at large. 
 
 This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes requires a bylaw change vote. 
 
@@ -13,17 +13,17 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 For handling money and fiscal matters, the PHP-FIG MUST use [Open Collective](https://opencollective.com/) as a platform and [Open Source Collective](https://opencollective.com/opensource) as a fiscal host.
 All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's OpenCollective account. They SHALL NOT use those permissions in a discretionary manner, except as stated explicitly in this bylaw.
 
-All monetary contributions MUST flow through Open Collective, so that any tax considerations will be handled automatically, and every financial decision MUST be published and publicly available here and through Open Collective's budgetary tools.
+All funds MUST be collected into the Open Collective PHP-FIG account, so that any tax considerations will be handled automatically by the fiscal host, and every financial decision MUST be published and publicly available here and through Open Collective's budgetary tools.
 
 ## Raising money
 
-PHP-FIG SHALL NOT solicit donations from any party, especially from private individuals. The only allowed funding sources MUST be listed below.
+PHP-FIG SHALL NOT solicit donations from any party, especially from private individuals; all exceptions to this rule MUST be listed below.
 
 ### Through OpenCollective
 
-Direct contributions MUST NOT be accepted through OpenCollective; the collective home page MUST be set up in a way that:
+Direct contributions MUST NOT be accepted through Open Collective, to avoid private/personal donations; the collective home page MUST be set up in a way that:
  * all contribution sections and features are hidden and/or disabled, if possible;
- * explicit wording will be visible reminding visitors of the PHP-FIG stance in the matter.
+ * explicit wording will be visible reminding visitors of the PHP-FIG stance in the matter (see "Scope and objectives").
 
 ### Through TideLift
 


### PR DESCRIPTION
This is a long overdue idea of mine, useful to avoid having to pay out-of-pocket for the (luckily small) needs of the PHP-FIG (as it happened often up until now).

I structured the document in a way that allows easy changes in the future, so that if any other need arise, it just requires a bylaw vote to be acted upon; if an urgent matter arise, out-of-pocket would still be possible, but OpenCollective already provides ways to [reimburse expenses](https://docs.opencollective.com/help/expenses-and-getting-paid/submitting-expenses).

This is still a rough draft and, since I'm not a native speaker, surely needs some wording adjustments; still, I hope it still conveys my idea clearly. I'll be leaving some inline comments to this PR to add some details.

[EDIT] Link to the relevant mailing list discussion: https://groups.google.com/g/php-fig/c/6uC3hjL0Nig