### PR TITLE
Add errata for addition of parameter and return type declarations to PSR-7

### DIFF
--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -690,4 +690,23 @@ be normalized to a single SPACE (0x20).
 Further characters or sequences in header values should be rejected according
 to the HTTP specification.
 
+### 7.2 Type Additions
+
+The 1.1 release of the `psr/http-message` package includes scalar parameter types.
+The 2.0 release of the package includes return types.
+This structure leverages PHP 7.2 covariance support to allow for a gradual upgrade process, but requires PHP 8.0 for type compatibility.
+
+Implementers MAY add return types to their own packages at their discretion, provided that:
+
+* the return types match those in the 2.0 package.
+* the implementation specifies a minimum PHP version of 8.0.0 or later.
+
+Implementers MAY add parameter types to their own packages in a new major release, either at the same time as adding return types or in a subsequent release, provided that:
+
+* the parameter types match those in the 1.1 package.
+* the implementation specifies a minimum PHP version of 8.0.0 or later.
+* the implementation depends on `"psr/http-message": "^1.1 || ^2.0"` so as to exclude the untyped 1.0 version.
+
+Implementers are encouraged but not required to transition their packages toward the 2.0 version of the package at their earliest convenience.
+
 [1]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1903,3 +1903,6 @@ interface UploadedFileInterface
     public function getClientMediaType();
 }
 ```
+
+Since [psr/http-message version 1.1](https://packagist.org/packages/psr/http-message#1.1.0), the above interfaces have been updated to add argument type hints.
+Since [psr/http-message version 2.0](https://packagist.org/packages/psr/http-message#2.0.0), the above interfaces have been updated to add return type hints.

--- a/accepted/PSR-7-http-message.md
+++ b/accepted/PSR-7-http-message.md
@@ -1904,5 +1904,5 @@ interface UploadedFileInterface
 }
 ```
 
-Since [psr/http-message version 1.1](https://packagist.org/packages/psr/http-message#1.1.0), the above interfaces have been updated to add argument type hints.
-Since [psr/http-message version 2.0](https://packagist.org/packages/psr/http-message#2.0.0), the above interfaces have been updated to add return type hints.
+Since [psr/http-message version 1.1](https://packagist.org/packages/psr/http-message#1.1.0), the above interfaces have been updated to add argument type declarations.
+Since [psr/http-message version 2.0](https://packagist.org/packages/psr/http-message#2.0.0), the above interfaces have been updated to add return type declarations.


### PR DESCRIPTION
This patch adds section 7.2 to the PSR-7 metadocument, detailing the (proposed) changes to the specification to use explicit, language-level parameter and return type declarations. It documents the addition of parameter type declarations for the 1.1 release, the addition of return type declarations for 2.0, and how implementations may adopt one or both versions. It also documents and links to the (forthcoming) package releases within the primary document, detailing the changes in brief.

The format follows that of the already accepted PSR-13 evolution proposal.

See also:

- [Parameter type declaration additions patch](https://github.com/php-fig/http-message/pull/94)
- [Return type declaration additions patch](https://github.com/php-fig/http-message/pull/95)
