### PR TITLE
Change example class name

### DIFF
--- a/accepted/PSR-4-autoloader.md
+++ b/accepted/PSR-4-autoloader.md
@@ -61,7 +61,7 @@ class name, namespace prefix, and base directory.
 
 | Fully Qualified Class Name    | Namespace Prefix   | Base Directory           | Resulting File Path
 | ----------------------------- |--------------------|--------------------------|-------------------------------------------
-| \Acme\Log\Writer\File_Writer  | Acme\Log\Writer    | ./acme-log-writer/lib/   | ./acme-log-writer/lib/File_Writer.php
+| \Acme\Log\Writer\FileWriter   | Acme\Log\Writer    | ./acme-log-writer/lib/   | ./acme-log-writer/lib/FileWriter.php
 | \Aura\Web\Response\Status     | Aura\Web           | /path/to/aura-web/src/   | /path/to/aura-web/src/Response/Status.php
 | \Symfony\Core\Request         | Symfony\Core       | ./vendor/Symfony/Core/   | ./vendor/Symfony/Core/Request.php
 | \Zend\Acl                     | Zend               | /usr/includes/Zend/      | /usr/includes/Zend/Acl.php


### PR DESCRIPTION
The example class name for the file writer contradicts PSR-1 when it comes to the naming of classes.

PSR-1 states that:

**Class names MUST be declared in StudlyCaps.** but the example shows a class name that doesn't follow PSR-1.