### PR TITLE
Add errata for expected behaviour of UriInterface::withUserInfo to PSR-7

### DIFF
--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -710,3 +710,15 @@ Implementers MAY add parameter types to their own packages in a new major releas
 Implementers are encouraged but not required to transition their packages toward the 2.0 version of the package at their earliest convenience.
 
 [1]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+
+### 7.3 Escaping User Info
+
+Some characters are reserved in the user info part of the authority section.
+According to (RFC3986 2.2 and 3.2.1)[https://www.rfc-editor.org/rfc/rfc3986], the reserved characters are `"/" / "?" / "#" / "[" / "]" / "@"`.
+Additionally, `:` must be encoded when in the username because it is used to separate username and password.
+
+`UriInterface::withUserInfo` MUST NOT double urlencode reserved characters.
+
+`UriInterface::getUserInfo` MUST urlencode the reserved characters when returning the authority.
+If there is a password, the `:` between username and password MUST NOT be urlencoded.
+

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -717,8 +717,8 @@ Some characters are reserved in the user info part of the authority section.
 According to (RFC3986 2.2 and 3.2.1)[https://www.rfc-editor.org/rfc/rfc3986], the reserved characters are `"/" / "?" / "#" / "[" / "]" / "@"`.
 Additionally, `:` must be encoded when in the username because it is used to separate username and password.
 
-`UriInterface::withUserInfo` MUST NOT double encode reserved characters.
+`UriInterface::withUserInfo()` MUST NOT double encode reserved characters.
 
-`UriInterface::getUserInfo` MUST encode the reserved characters according to RFC3986 when returning the authority.
+`UriInterface::getUserInfo()` MUST encode the reserved characters according to RFC3986 when returning the authority.
 If there is a password, the `:` between username and password MUST NOT be encoded.
 

--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -717,8 +717,8 @@ Some characters are reserved in the user info part of the authority section.
 According to (RFC3986 2.2 and 3.2.1)[https://www.rfc-editor.org/rfc/rfc3986], the reserved characters are `"/" / "?" / "#" / "[" / "]" / "@"`.
 Additionally, `:` must be encoded when in the username because it is used to separate username and password.
 
-`UriInterface::withUserInfo` MUST NOT double urlencode reserved characters.
+`UriInterface::withUserInfo` MUST NOT double encode reserved characters.
 
-`UriInterface::getUserInfo` MUST urlencode the reserved characters when returning the authority.
-If there is a password, the `:` between username and password MUST NOT be urlencoded.
+`UriInterface::getUserInfo` MUST encode the reserved characters according to RFC3986 when returning the authority.
+If there is a password, the `:` between username and password MUST NOT be encoded.
 


### PR DESCRIPTION
This suggestion comes out of a discussion we had in https://github.com/php-http/discovery/issues/222

The "urlencode when necessary but don't double encode" behaviour is already implemented in laminas, guzzle and slim, and with https://github.com/Nyholm/psr7/pull/213/ was adopted in nyholm. It seems to be expected behviour, but the specification did not define it. Can we add this precision?

If i understand correctly, we are are not supposed to change the main document but only the meta document and the actual interface phpdoc in php-fig/http-message. If this suggestion seems acceptable, i can create the pull requests for http-message