### PR TITLE
Update minimum PHP version for PSR-7 meta section 7.2

### DIFF
--- a/accepted/PSR-7-http-message-meta.md
+++ b/accepted/PSR-7-http-message-meta.md
@@ -699,12 +699,12 @@ This structure leverages PHP 7.2 covariance support to allow for a gradual upgra
 Implementers MAY add return types to their own packages at their discretion, provided that:
 
 * the return types match those in the 2.0 package.
-* the implementation specifies a minimum PHP version of 8.0.0 or later.
+* the implementation specifies a minimum PHP version of 7.2.0 or later.
 
 Implementers MAY add parameter types to their own packages in a new major release, either at the same time as adding return types or in a subsequent release, provided that:
 
 * the parameter types match those in the 1.1 package.
-* the implementation specifies a minimum PHP version of 8.0.0 or later.
+* the implementation specifies a minimum PHP version of 7.2.0 or later.
 * the implementation depends on `"psr/http-message": "^1.1 || ^2.0"` so as to exclude the untyped 1.0 version.
 
 Implementers are encouraged but not required to transition their packages toward the 2.0 version of the package at their earliest convenience.


### PR DESCRIPTION
Updates the PSR-7 errata section 7.2 to correctly reference PHP 7.2 as the minimum required version, not 8.0.0.
