### PR TITLE
change psr-4-autoloader deadlink from php.net/autoload to php.net/man…

### DIFF
--- a/accepted/PSR-4-autoloader.md
+++ b/accepted/PSR-4-autoloader.md
@@ -70,6 +70,6 @@ For example implementations of autoloaders conforming to the specification,
 please see the [examples file][]. Example implementations MUST NOT be regarded
 as part of the specification and MAY change at any time.
 
-[autoloading]: http://php.net/autoload
+[autoloading]: php.net/manual/en/language.oop5.autoload.php
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [examples file]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md


### PR DESCRIPTION
This change fixes a dead link on PSR-4-Autoloader (php.net/autoload -> php.net/manual/en/language.oop5.autoload.php)