### PR TITLE
Update personnel.md based on 2024-02 elections and nominations

### DIFF
--- a/personnel.md
+++ b/personnel.md
@@ -7,8 +7,8 @@
 | Name                                              | Term                    |
 |---------------------------------------------------|-------------------------|
 | Alessandro Lai ([@AlessandroLai@phpc.social])     | 2017-11-12 - 2024-08-31 |
-| Steve Winter ([@SteveWinterNZ])                   | 2022-01-30 - 2024-01-28 |
 | Mark Niebergall ([@mbniebergall@phpc.social])     | 2023-05-25 - 2025-05-30 |
+| Vacancy                                           | 2024-02-25 - TBD        |
 
 Feel free to contact the secretaries at info AT php-fig.org. For more information on the secretaries' role, see the [bylaws](https://www.php-fig.org/bylaws/mission-and-structure/#secretaries).
 
@@ -20,15 +20,15 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 | Larry Garfield ([@Crell@phpc.social])             | 2016-12-24 - 2025-05-30 |
 | Matthew Weier O'Phinney ([@mwop])                 | 2016-12-24 - 2025-05-30 |
 | Cees-Jan Kiewiet ([@wyri@haxim.us])               | 2016-12-24 - 2024-08-31 |
-| Chris Tankersley ([@dragonmantank])               | 2016-12-24 - 2024-01-28 |
-| Korvin Szanto ([@korvinszanto])                   | 2016-12-24 - 2024-01-28 |
+| Korvin Szanto ([@korvinszanto])                   | 2016-12-24 - 2026-02-22 |
 | Chuck Burgess ([@ashnazg@phpc.social])            | 2018-08-26 - 2024-08-31 |
-| Enrico Zimuel ([@ezimuel])                        | 2020-01-25 - 2024-01-28 |
 | Alessandro Chitolina ([@alekitto@phpc.social])    | 2021-06-25 - 2025-05-30 |
 | Ken Guest ([@kenguest@phpc.social])               | 2022-01-30 - 2024-01-28 |
 | Jaap van Otterdijk ([@jaapio@phpc.social])        | 2022-08-28 - 2024-08-28 |
 | Navarr Barnier ([@navarr])                        | 2022-08-28 - 2024-08-28 |
 | Vincent de Lau ([@vdelau])                        | 2023-05-25 - 2025-05-30 |
+| Steve McDougall                                   | 2024-02-25 - 2026-02-22 |
+| Matteo Beccati ([@mbeccati])                      | 2024-02-25 - 2026-02-22 |
 
 ### Member Projects
 
@@ -89,6 +89,7 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 | Asmir Mustafic ([@goetas_asmir])      | 2019-05-26 - 2021-05-30 |
 | Buster Neece ([@BusterNeece])         | 2020-01-25 - 2022-01-31 |
 | Vincent de Lau ([@vdelau])            | 2021-06-25 - 2023-05-25 |
+| Steve Winter ([@SteveWinterNZ])       | 2022-01-30 - 2024-02-25 |
 
 ### Former Core Committee Members
 
@@ -107,6 +108,8 @@ Feel free to contact the secretaries at info AT php-fig.org. For more informatio
 | Ben Edmunds ([@benedmunds])           | 2020-08-31 - 2022-08-31 |
 | Woody Gilk ([@shadowhand])            | 2019-05-26 - 2022-08-31 |
 | Michelle Sanver ([@michellesanver])   | 2021-06-25 - 2023-05-25 |
+| Chris Tankersley ([@dragonmantank])   | 2016-12-24 - 2026-02-22 |
+| Enrico Zimuel ([@ezimuel])            | 2020-01-25 - 2026-02-22 |
 
 ### Former Member Projects
 


### PR DESCRIPTION
Updating based on the results of the 2024-02 election and nomination cycle.

CC memebers:
- Steve McDougall (new)
- Ken Guest (re-elected)
- Korvin Szanto (re-elected)
- Matteo Beccati (new)