### PR TITLE
docs: Correct semi-colon for semicolon (without dash)

### DIFF
--- a/accepted/PSR-12-extended-coding-style-guide.md
+++ b/accepted/PSR-12-extended-coding-style-guide.md
@@ -220,7 +220,7 @@ For example:
 ```
 
 Declare statements MUST contain no spaces and MUST be exactly `declare(strict_types=1)`
-(with an optional semi-colon terminator).
+(with an optional semicolon terminator).
 
 Block declare statements are allowed and MUST be formatted as below. Note position of
 braces and spacing:


### PR DESCRIPTION
Semicolon is the correct spelling based on the Oxford Dictionary and dictionary.com. This PR changes all occurrences found into semicolon

Description

This PR is a split on changes proposed earlier in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/457 but limiting to only fixing typos of the word semicolon.
Sources for the correct spelling are:

https://www.oed.com/dictionary/semicolon_n?tab=factsheet#23549945
https://www.dictionary.com/browse/semicolon
https://en.bab.la/dictionary/english/semicolon
https://en.wikipedia.org/wiki/Semicolon

Also [Google trends](https://trends.google.com/trends/explore?geo=NL&q=semicolon,semi-colon&hl=nl) show a difference between semicolon and semi-colon