### PR TITLE
docs: Correct Github with GitHub (with capital H) as it is a brand name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The master branch of all repositories are protected and therefore cannot be forc
 pushed to.
 
 Secretaries have, and are the only ones to have, full administrative access to all
-repositories and to the github organisation.
+repositories and to the GitHub organisation.
 
 ## Guidelines for merging
 
@@ -56,7 +56,7 @@ they cannot close a pull request or issue affecting other PSRs
 must be approved by a secretary; who is required to give suitable notice and seek
 comment from the working group team, but it is not required that they approve
 * Tags on utility and interface repositories should be created and PGP signed by
-Secretaries, who should publish their PGP public keys and register them on github
+Secretaries, who should publish their PGP public keys and register them on GitHub
 
 These guidelines are subject to exceptions and changes at secretaries discretion.
 Should you have any questions please contact the secretaries on info [at] php-fig

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Proposing a Standard Recommendation
 To propose a PHP Standard Recommendation (PSR):
 
 - fork this repo, create a branch, checkout that branch, add the PSR in
-  `proposed/`, push the branch to Github, and send a pull request; or,
+  `proposed/`, push the branch to GitHub, and send a pull request; or,
 
-- create a ticket to start a discussion on Github; or,
+- create a ticket to start a discussion on GitHub; or,
 
 - start a conversation on the [mailing list][].
 

--- a/bylaws/001-mission-and-structure.md
+++ b/bylaws/001-mission-and-structure.md
@@ -57,7 +57,7 @@ There are a number of defined functions that the FIG Secretaries are expected to
 * Ensuring bylaws are being followed
 * Clarifying any interpretation of bylaw text, subject to a lack of objection from Core Committee members and Project Representatives**
 * Ensure that relevant marketing mediums (e.g. Twitter and Facebook) are kept professional, up to date and impartial
-* Moderate discussions on github, the mailing list, IRC channels and other official communication mediums to ensure that an appropriate environment is maintained. This includes the ability to restrict posting and impose bans with the exception that they cannot permanently ban or restrict a Core Committee member or Project Representative
+* Moderate discussions on GitHub, the mailing list, IRC channels and other official communication mediums to ensure that an appropriate environment is maintained. This includes the ability to restrict posting and impose bans with the exception that they cannot permanently ban or restrict a Core Committee member or Project Representative
 * Should there be a FIG meeting at a conference or other ad hoc gathering any Secretary in attendance should take notes to report back to the mailing list
 * Acting throughout their term essentially as Developer Advocates for the PHP FIG
 

--- a/proposed/security-reporting-process.md
+++ b/proposed/security-reporting-process.md
@@ -43,7 +43,7 @@ Projects MAY choose to list any part of the procedures that is not a MUST
 which they choose to omit.
 
 Note that projects MAY not have a dedicated domain. For example a project
-hosted on Github, Bitbucket or other service should still ensure that the
+hosted on GitHub, Bitbucket or other service should still ensure that the
 process is referenced on the landing page, ie. for example
 http://github.com/example/somelib should ensure that the default branch
 has a README file which references the procedures used so that it is


### PR DESCRIPTION
`GitHub` is the correct spelling (with a capital H) of the brand that is being referred to.

One (of many) examples is the GitHub [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service)