### PR TITLE
Bylaw change: Correct elections cycles to be 8 months apart

### DIFF
--- a/bylaws/005-elections-and-vacancies.md
+++ b/bylaws/005-elections-and-vacancies.md
@@ -2,7 +2,7 @@
 
 ## Election Calendar
 
-Both Secretaries and Core Committee members are elected for two year terms with votes staggered eight months apart. One election is held in January of even numbered years, one election is held in August of even numbered years, and one election is held in May of odd numbered years. For example there would be elections in January 2018, August 2018 and May 2019. Each regular election includes a single Secretary and four (4) Core Committee members, plus any potential unplanned vacancies.
+Both Secretaries and Core Committee members are elected for two year terms with votes staggered eight months apart. One election is held in January of even numbered years, one election is held in September of even numbered years, and one election is held in May of odd numbered years. For example there would be elections in January 2026, September 2026 and May 2027. Each regular election includes a single Secretary and four (4) Core Committee members, plus any potential unplanned vacancies.
 
 The election calendar will be established by the Secretaries at least one week before the start of the election month. Nominations must run for a minimum of seven (7) days. The vote will open immediately upon the end of the nomination period and must run for fourteen (14) days. The new Secretary and Core Committee members will take office at 5pm UTC time on the last Sunday of the month, and the voting period must conclude at least 24 hours prior to that.
 


### PR DESCRIPTION
As the bylaw text states, the term were intended to be eight months apart. Starting in January (month 1), the next one should have been +8 months, bringing it to September (month 9). The May term (month 5) is correct.

Official discussion should be on the list: https://groups.google.com/g/php-fig/c/lDLfSB9NoWs

This change is subject to a vote.