### PR TITLE
Add Vincent de Lau as an Internationalization WG member

### DIFF
--- a/proposed/internationalization-meta.md
+++ b/proposed/internationalization-meta.md
@@ -35,6 +35,7 @@ To solve this, we currently aim to create an interface that a framework-independ
 * Susanne Moog
 * Ken Guest
 * Ben Ramsey
+* Vincent de Lau
 
 ## 6. Votes
 


### PR DESCRIPTION
Vincent de Lau (@vdelau) was accepted by the Editor of the WG (@navarr) on Oct 14th, 2024.