### PR TITLE
Updates to funding bylaw

### DIFF
--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -45,34 +45,6 @@ Contributions SHALL be accepted via [Open Collective](https://opencollective.com
     4. The total amount of money remaining in the account;
     5. The itemized transactions, including the date, amount, and description
 
-### Via print-on-demand swag
-
-Secretaries MAY, at their own discretion but with regard to the following rules, create and sell print-on-demand swag, such as shirts, mugs, stickers, and any other items that the secretaries deem appropriate. By providing this option, the PHP-FIG allows individuals to contribute financially and advertise the PHP-FIG at the same time, while also receiving a tangible item in return.
-
-When selecting print-on-demand providers, the provider:
-
-- MUST be able to pay out to the PHP-FIG Open Collective account. This might require coordination with the fiscal host.
-- SHOULD ship to as many people around the world as possible.
-- SHOULD be sustainably and ethically sourced and produced.
-- SHOULD provide a level of quality that meets or exceeds the expectation for the price.
-- SHOULD provide sizes and shapes that are inclusive of as many body types as possible.
-
-When creating a new product design, the Secretaries MUST notify the mailing list with an attached image of the design. This notification serves as both an opportunity for the core committee to vote to remove the design, and as a way to inform the community about the new product. When reusing an existing design in a new form factor, such as a new shirt color underneath an existing design, or putting an existing shirt design on a mug, the Secretaries MAY skip this notification step at their own discretion.
-
-Product designs:
-
-- MUST only use intellectual property that is owned by the PHP-FIG, or for which the PHP-FIG has been granted a clear license to use.
-- MUST not be offensive, discriminatory, inflamatory, or otherwise inappropriate.
-- MUST not be used to promote any specific person, company, or product, except for the PHP-FIG itself, and as allowed by this document.
-- MAY include member project logos so long as all available member project logos are included in similar scale and position, and the logos are used in a way that does not imply endorsement by the PHP-FIG, and a licence has been explicitly granted by the member project to use their logo in this way.
-
-At any time, any member of the Core Committee MAY call an approval vote to remove a design or product whether actively sold or not, or to reinstate a previously removed design or product.
-
-- If an approval vote passes, another approval vote SHALL NOT be called for the same design or product for a period of 30 days. 
-- If an approval vote passes causing a design or product to be reinstated, the Secretaries SHALL have the final say in whether the design or product will be sold.
-
-All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's print-on-demand providers.
-
 ## Spending money
 
 Funds donated to the PHP-FIG MUST be used solely for non-personnel operating expenses. The PHP-FIG MUST NOT pay individual contributors or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups unless the payment is associated with an approved expense, such as reimbursing a Secretary that has paid for an approved expense out of pocket.

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -82,7 +82,7 @@ Expenses approved by the Core Committee MUST be listed below, and reported in th
 
 ### Overfunding and disbursement
 
-Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years.
+Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years with a 10% cost increase year over year.  (For example, if the approved budget is $10, the maximum amount before funds are considered overfunding would be $10 + ($10 + $10 × 10% = $11) + ($11 + $11 × 10% = $12.10) = $33.10)
 
 Every year in January, the Secretaries SHALL review the Open Collective account and disburse any overfunding to the list of recipients defined in the Approved disbursement recipients section below, in the amounts defined in aforementioned section. Disbursements MUST be made in such a way to prevent any additional tax or fees from being incurred by the PHP-FIG or the recipient, such as via [Collective to Collective Donations][c2c].
 

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -75,7 +75,7 @@ All three Secretaries, but only the Secretaries, MUST have full administrative a
 
 ## Spending money
 
-Funds donated to the PHP-FIG MUST be used solely for non-personnel operating expenses. The PHP-FIG MUST NOT pay individual contributors or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups unless the payment is associated with an approved expense, such as reimbursing a Secretay that has paid for an approved expense out of pocket.
+Funds donated to the PHP-FIG MUST be used solely for non-personnel operating expenses. The PHP-FIG MUST NOT pay individual contributors or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups unless the payment is associated with an approved expense, such as reimbursing a Secretary that has paid for an approved expense out of pocket.
 All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and the frequency at which the expense is incurred. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount, only if that does not exceed a 10% increase.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
@@ -84,7 +84,7 @@ Expenses approved by the Core Committee MUST be listed below, and reported in th
 
 Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years.
 
-Every year in January, the Secretaries SHALL review the Open Collective account and disburse any overfunding to the list of recipients defined in the Approved disbursement recipients section below, in the amounts defined in aforementions section. Disbursements MUST be made in such a way to prevent any additional tax or fees from being incurred by the PHP-FIG or the recipient, such as via [Collective to Collective Donations][c2c].
+Every year in January, the Secretaries SHALL review the Open Collective account and disburse any overfunding to the list of recipients defined in the Approved disbursement recipients section below, in the amounts defined in aforementioned section. Disbursements MUST be made in such a way to prevent any additional tax or fees from being incurred by the PHP-FIG or the recipient, such as via [Collective to Collective Donations][c2c].
 
 If for any reason disbursement to a recipient is not possible, the recipient MUST be skipped and the Core Committee MUST be notified so this bylaw can be updated accordingly.
 

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -34,8 +34,8 @@ Contributions SHALL be accepted via [Open Collective](https://opencollective.com
 
 - The description MUST include the following:
     1. A link back to this document on the PHP-FIG website.
-    2. A statement that we'd prefer contributions from companies that benefit
-    monetarily from the PHP-FIG recommendations, rather than from private individuals.
+    2. A statement that we'd prefer contributions from companies rather than from private individuals.
+    3. A statement that remarks how donations do not give any rights nor provides any corresponding service
     3. Links to other preferred options for individuals to contribute as listed in this document, if any such exist.
     4. A list of overfunding recipients as listed in this document, if any such exist.
 - The following information MUST be configured to show:
@@ -82,7 +82,7 @@ As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger 
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|
-| 2023-09-14     | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | $30 USD / year |
+| 2023-09-14     | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | $33 USD / year |
 | 2023-09-14     | Email account (`info@php-fig.org`)            | Namecheap | $15 USD / year            |
 
 [RFC 2119]: https://tools.ietf.org/html/rfc2119

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -2,11 +2,19 @@
 
 ## Scope and objectives
 
-PHP-FIG is, as it often happens in Open Source communities, an organization composed by volunteers only; this doesn't exclude the fact that the organization itself may have some costs to sustain itself, for example maintaining tools such as a site and an email account. For such and similar reasons, we need a way to raise and govern money inside our organization. At the same time, we will avoid soliciting and collecting donations from private individuals, while instead trying to obtain funding from commercial companies and similar entities that, due to their profit which stems from the usage of Open Source Software, should contribute to the costs of the Open Source community at large. 
+The PHP-FIG is an organization composed entirely of unpaid volunteers and community members focused on improving the PHP ecosystem. As part of realizing its goals, the PHP-FIG has limited operating expenses like domain names, email accounts, and similar that require ongoing funding.  
 
 This document defines the roles, rules and processes that must be followed inside the PHP-FIG in all matters regarding money, to guarantee fairness, transparency and impartiality. This document intentionally describes the only allowed processes and ways to raise, administer and spend money, so that any change to such processes requires a bylaw change vote. 
 
-The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+"MAY", and "OPTIONAL" in this document are to be interpreted as
+described in [BCP 14][] [[RFC 2119][]] [[RFC 8174][]] when, and only when, they
+appear in all capitals, as shown here.
+
+[BCP 14]: https://datatracker.ietf.org/doc/html/bcp14/
+[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[RFC 8174]: https://datatracker.ietf.org/doc/html/rfc8174
 
 ## Fiscal hosting
 
@@ -22,36 +30,87 @@ PHP-FIG SHALL NOT solicit donations from any party, especially from private indi
 
 ### Through OpenCollective
 
-Direct contributions MUST NOT be accepted through Open Collective, to avoid private/personal donations; the collective home page MUST be set up in a way that:
- * all contribution sections and features are hidden and/or disabled, if possible;
- * explicit wording will be visible reminding visitors of the PHP-FIG stance in the matter (see "Scope and objectives").
+Contributions SHALL be accepted via [Open Collective](https://opencollective.com/) with the following requirements:
 
-### Through TideLift
+- The description MUST include the following:
+    1. A link back to this document on the PHP-FIG website.
+    2. A statement that we'd prefer contributions from companies that benefit
+    monetarily from the PHP-FIG recommendations, rather than from private individuals.
+    3. Links to other preferred options for individuals to contribute as listed in this document, if any such exist.
+    4. A list of overfunding recipients as listed in this document, if any such exist.
+- The following information MUST be configured to show:
+    1. Contributors and the amounts they contributed;
+    2. The total amount of money raised;
+    3. The total amount of money spent;
+    4. The total amount of money remaining in the account;
+    5. The itemized transactions, including the date, amount, and description
 
-Contributions SHALL be accepted through [TideLift](https://tidelift.com/). All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's TideLift account, which MUST be configured to pay out to the Open Collective account. 
+### Via print-on-demand swag
+
+Secretaries MAY, at their own discretion but with regard to the following rules, create and sell print-on-demand swag, such as shirts, mugs, stickers, and any other items that the secretaries deem appropriate. By providing this option, the PHP-FIG allows individuals to contribute financially and advertise the PHP-FIG at the same time, while also receiving a tangible item in return.
+
+When selecting print-on-demand providers, the provider:
+
+- MUST be able to pay out to the PHP-FIG Open Collective account. This might require coordination with the fiscal host.
+- SHOULD ship to as many people around the world as possible.
+- SHOULD be sustainably and ethically sourced and produced.
+- SHOULD provide a level of quality that meets or exceeds the expectation for the price.
+- SHOULD provide sizes and shapes that are inclusive of as many body types as possible.
+
+When creating a new product design, the Secretaries MUST notify the mailing list with an attached image of the design. This notification serves as both an opportunity for the core committee to vote to remove the design, and as a way to inform the community about the new product. When reusing an existing design in a new form factor, such as a new shirt color underneath an existing design, or putting an existing shirt design on a mug, the Secretaries MAY skip this notification step at their own discretion.
+
+Product designs:
+
+- MUST only use intellectual property that is owned by the PHP-FIG, or for which the PHP-FIG has been granted a clear license to use.
+- MUST not be offensive, discriminatory, inflamatory, or otherwise inappropriate.
+- MUST not be used to promote any specific person, company, or product, except for the PHP-FIG itself, and as allowed by this document.
+- MAY include member project logos so long as all available member project logos are included in similar scale and position, and the logos are used in a way that does not imply endorsement by the PHP-FIG, and a licence has been explicitly granted by the member project to use their logo in this way.
+
+At any time, any member of the Core Committee MAY call an approval vote to remove a design or product whether actively sold or not, or to reinstate a previously removed design or product.
+
+- If an approval vote passes, another approval vote SHALL NOT be called for the same design or product for a period of 30 days. 
+- If an approval vote passes causing a design or product to be reinstated, the Secretaries SHALL have the final say in whether the design or product will be sold.
+
+All three Secretaries, but only the Secretaries, MUST have full administrative access to PHP-FIG's print-on-demand providers.
 
 ## Spending money
 
-Funds donated to the PHP-FIG MUST be used solely for non-personnel, operating expenses.  PHP-FIG SHALL NOT pay individual contributors to PHP-FIG standards or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups.
-All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and at which frequency. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount, only if that does not exceed a 10% increase.
+Funds donated to the PHP-FIG MUST be used solely for non-personnel operating expenses. The PHP-FIG MUST NOT pay individual contributors or other personnel, like Core Committee members, Secretaries, Project Representatives or working groups unless the payment is associated with an approved expense, such as reimbursing a Secretay that has paid for an approved expense out of pocket.
+All expenses MUST be approved by an Approval Vote of the Core Committee. The expense MUST include whether it is one time or recurring and the frequency at which the expense is incurred. All expenses MUST be justified by their contribution to the mission of PHP-FIG. In response to supplier price changes for previously accepted recurring expenses, Secretaries MAY request Implicit Approval from the Core Committee to raise the approved amount, only if that does not exceed a 10% increase.
 
 Expenses approved by the Core Committee MUST be listed below, and reported in the Open Collective budget.
 
-### Overfunding, and giving back to the community
+### Overfunding and disbursement
 
-PHP-FIG SHOULD maintain financial reserves to account for three years of the currently approved budget.
-At least once a year, any surplus funds MUST be forwarded to the [PHP Foundation](https://opencollective.com/phpfoundation), as a way to further support the PHP ecosystem.
+Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years.
+
+Every year in January, the Secretaries SHALL review the Open Collective account and disburse any overfunding to the list of recipients defined in the Approved disbursement recipients section below, in the amounts defined in aforementions section. Disbursements MUST be made in such a way to prevent any additional tax or fees from being incurred by the PHP-FIG or the recipient, such as via [Collective to Collective Donations][c2c].
+
+If for any reason disbursement to a recipient is not possible, the recipient MUST be skipped and the Core Committee MUST be notified so this bylaw can be updated accordingly.
+
+### Approved disbursement recipients
+
+This section contains a list of recipients that are eligible to receive disbursements from the PHP-FIG. 
+
+As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee.
+
+
+| Recipient name | Disbursement Method | Disbursement percentage |
+|----------------|----------------------------------|-------------------------| 
+| PHP Foundation | [PHP Foundation Open Collective][phpfoundation] | `100%` |
+
+[phpfoundation]: https://opencollective.com/phpfoundation
+[c2c]: https://documentation.opencollective.com/giving-to-collectives/giving-to-other-collectives
 
 ### Approved expenses
 
-This section will contain a chronological list of approved budgeting decisions, either recurring or not.
+This section contains a chronological list of approved budgeting decisions, either recurring or not.
 
-As an exception to [Votes Bylaw][], changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee, as explained in the "Spending Money" section.
+As an exception to Votes Bylaw, changes to this section only SHOULD NOT trigger a Bylaw Change Vote, but only an Approval Vote by the Core Committee.
 
 | Approved since | Expense                                       | Provider  | Approved amount and frequency  |
 |----------------|-----------------------------------------------|-----------|--------------------------------|
-| 2023-09-14     | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | Up to 15 USD / year per domain |
-| 2023-09-14     | Email account (`info@php-fig.org`)            | Namecheap | Up to 15 USD / year            |
+| 2023-09-14     | Two Domains (`php-fig.com` and `php-fig.org`) | Namecheap | $30 USD / year |
+| 2023-09-14     | Email account (`info@php-fig.org`)            | Namecheap | $15 USD / year            |
 
 [RFC 2119]: https://tools.ietf.org/html/rfc2119
-[Votes Bylaw]: https://www.php-fig.org/bylaws/voting-protocol/

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -82,7 +82,7 @@ Expenses approved by the Core Committee MUST be listed below, and reported in th
 
 ### Overfunding and disbursement
 
-Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years with a 10% cost increase year over year.  (For example, if the approved budget is $10, the maximum amount before funds are considered overfunding would be $10 + ($10 + $10 × 10% = $11) + ($11 + $11 × 10% = $12.10) = $33.10)
+Overfunding SHALL be defined as any amount raised that exceeds the amount needed to cover the existing PHP-FIG's yearly expenses, as defined in the "Approved expenses" section below, for a period of three years with a 10% cost increase year over year. For example, if the approved budget is $10, the maximum amount before funds are considered overfunding would be `$10 + $11 + $12.1 = $33.10`. The amount of funding to keep can be easily calculated by multiplying the total yearly expenses by `3.31` and rounding up.
 
 Every year in January, the Secretaries SHALL review the Open Collective account and disburse any overfunding to the list of recipients defined in the Approved disbursement recipients section below, in the amounts defined in aforementioned section. Disbursements MUST be made in such a way to prevent any additional tax or fees from being incurred by the PHP-FIG or the recipient, such as via [Collective to Collective Donations][c2c].
 

--- a/bylaws/010-funding.md
+++ b/bylaws/010-funding.md
@@ -35,9 +35,9 @@ Contributions SHALL be accepted via [Open Collective](https://opencollective.com
 - The description MUST include the following:
     1. A link back to this document on the PHP-FIG website.
     2. A statement that we'd prefer contributions from companies rather than from private individuals.
-    3. A statement that remarks how donations do not give any rights nor provides any corresponding service
-    3. Links to other preferred options for individuals to contribute as listed in this document, if any such exist.
-    4. A list of overfunding recipients as listed in this document, if any such exist.
+    3. A statement that donations do not give any rights nor provide any corresponding service.
+    4. Links to other preferred options for individuals to contribute as listed in this document, if any such exist.
+    5. A list of overfunding recipients as listed in this document, if any such exist.
 - The following information MUST be configured to show:
     1. Contributors and the amounts they contributed;
     2. The total amount of money raised;


### PR DESCRIPTION
This PR updates the funding bylaws to clarify disbursement, expand allowed funding options, and more.

Key changes are:
- Remove Tidelift as a collection option since they have been purchased and their mission has changed
- Grant permission to collect funding via opencollective directly
- ~~Grant permission to set up print on demand swag options, at the discretion of the secretaries with (essentially) implicit approval from the core committee~~
- Define clear policy for when, how, how much, and to whom disbursements are made
- Explicitly allow repayment to individuals who have covered an expense, so funding at a later date in the year can be used to reimburse folks that quietly cover costs out of their own pocket


And here's what copilot thinks changed (Reviewed by me, no changes were needed):

> This pull request updates the PHP-FIG funding bylaws to refine the organization's approach to raising and managing funds. Key changes include clarifying the funding sources, introducing new methods for contributions, and revising spending guidelines to ensure transparency and alignment with PHP-FIG's mission.
> 
> ### Updates to funding sources and methods:
> * Revised the language to emphasize PHP-FIG's focus on funding from commercial entities benefiting from the PHP ecosystem, rather than private individuals.
> * Added provisions for accepting contributions via [Open Collective](https://opencollective.com/) with detailed requirements for transparency and accountability, including itemized reporting of transactions.
> * Introduced a new option for generating revenue through print-on-demand swag, with specific guidelines for product creation, ethical sourcing, and community oversight.
> 
> ### Spending guidelines and overfunding management:
> * Updated rules for spending funds to allow reimbursement for approved expenses paid out-of-pocket by Secretaries, while maintaining restrictions on personnel payments.
> * Defined "overfunding" and established a process for disbursing surplus funds annually to the PHP Foundation, with safeguards for tax and fee considerations.
> 
> ### Administrative adjustments:
> * Clarified the approved expenses section and updated the formatting for consistency.