### PR TITLE
[PSR-5] enhancements

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -10,6 +10,7 @@ PSR-5: PHPDoc
 - [5. The PHPDoc Format](#5-the-phpdoc-format)
   - [5.1. Summary](#51-summary)
   - [5.2. Description](#52-description)
+    - [5.2.1 Inline tags](#521-inline-tags)
   - [5.3. Tags](#53-tags)
     - [5.3.1. Tag Name](#531-tag-name)
   - [5.4. Examples](#54-examples)
@@ -237,6 +238,33 @@ Common uses for the Description:
 * To provide a set of common use cases or scenarios in which the "Structural
   Element" may be applied
 
+#### 5.2.1 Inline tags
+
+A description MAY contain inline tags. Inline tags MUST follow the specification of
+tags with the same syntax. An inline tag MUST start with `{@` and MUST with `}`
+
+```php
+  /** 
+   * Summary.
+   * 
+   * This is a description with an inline tag {@tag rest of the tag format}
+   */
+```
+
+Inline tags are only covering regular tags and SHALL NOT cover _Annotation_ tags.
+
+As inline tags are always closed with a `}` developers cannot use this char in a 
+description. To overcome this issue parsers MUST support escape char `{` followed
+by `}` to be interpreted as a single `}` 
+
+```php
+   /**
+    * Summary.
+    *
+    * This is a description with an inline tag {@tag show case {} escape of ending char}
+    */
+```
+
 ### 5.3. Tags
 
 Tags supply concise metadata for a "Structural Element". Each tag starts on a
@@ -253,8 +281,8 @@ format, as dictated by the specific tag.
 > _type_ (`string`), variable name (`$argument1`),  and description (`This is a
 > parameter.`).
 
-The description MUST support Markdown as a formatting language.  The
-description of the tag MAY start on the same line or next line.  The following
+The description MUST support Markdown as a formatting language. The
+description of the tag MAY start on the same line or next line. The following
 tags are semantically identical:
 
 ```php

--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -12,7 +12,8 @@ PSR-5: PHPDoc
   - [5.2. Description](#52-description)
     - [5.2.1 Inline tags](#521-inline-tags)
   - [5.3. Tags](#53-tags)
-    - [5.3.1. Tag Name](#531-tag-name)
+    - [5.3.1. Tag Specialization](#531-tag-specialization) 
+    - [5.3.2. Tag Name](#532-tag-name)
   - [5.4. Examples](#54-examples)
 - [Appendix A. Types](#appendix-a-types)
   - [ABNF](#abnf)
@@ -198,9 +199,9 @@ The PHPDoc format has the following [ABNF][RFC5234] definition:
                                                      ; with inline tags inside
     tags               = *(tag 1*eol)
     inline-tag         = "{" tag "}"
-    tag                = "@" tag-name [":" tag-specialization] [tag-details]
+    tag                = "@"[tag-specialization "-"] tag-name [tag-details]
     tag-name           = (ALPHA / "\") *(ALPHA / DIGIT / "\" / "-" / "_")
-    tag-specialization = 1*(ALPHA / DIGIT / "-")
+    tag-specialization = 1*(ALPHA / DIGIT)
     tag-details        = (1*SP tag-description)
     tag-description    = (CHAR / inline-tag) *(CHAR / inline-tag / eol)
     tag-argument       = *SP 1*CHAR [","] *SP
@@ -297,7 +298,21 @@ tags are semantically identical:
 
 This definition does NOT apply to _Annotation_ tags, which are not in scope.
 
-#### 5.3.1. Tag Name
+#### 5.3.1 Tag Specialization
+
+Tag specialization give a scope to the tag. It is RECOMMENDED to follow the
+list of tags in the tag [Tag Catalog PSR][TAG_PSR]. But the metadata of specialized
+tags MAY differ from the list.
+
+```php
+  /**
+   * @vendor-tag This is a description
+   */
+```
+
+Parsers MAY ignore specialized tags when they are in a supported format.
+
+#### 5.3.2. Tag Name
 
 Tag names indicate what type of information is represented by this tag.
 


### PR DESCRIPTION
This pull request introduces enhancements to the PHPDoc specification (`proposed/phpdoc.md`) by refining tag handling and adding support for inline tags. The most important changes include updates to the ABNF definition for tags, the introduction of inline tags, and the addition of tag specialization for improved metadata organization.

### Enhancements to tag handling:

* Updated the ABNF definition to modify the syntax for `tag-specialization` and `tag`:
  - `tag-specialization` now excludes the `-` character, and `tag` syntax includes an optional specialization prefix followed by a hyphen.

* Added the concept of tag specialization (`5.3.1 Tag Specialization`) to provide a scoped context for tags. Specialized tags can differ from the standard catalog, and parsers may ignore unsupported specialized tags.

### Support for inline tags:

* Introduced inline tags (`5.2.1 Inline tags`) within descriptions. Inline tags must start with `{@` and end with `}`. Escaping is supported for closing braces using `{}`. Inline tags are limited to regular tags and do not apply to annotation tags.

### Structural refinements:

* Updated the table of contents to reflect the addition of inline tags and the reorganization of tag-related sections.