### PR TITLE
Clarification: Update PSR-3 wording to reference Throwable instead of Exception

### DIFF
--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -102,11 +102,11 @@ Users of loggers are referred to as `user`.
   as much lenience as possible. A given value in the context MUST NOT throw
   an exception nor raise any php error, warning or notice.
 
-- If an `Exception` object is passed in the context data, it MUST be in the
+- If any `Throwable` object is passed in the context data, it MUST be in the
   `'exception'` key. Logging exceptions is a common pattern, and this allows
   implementors to extract a stack trace from the exception when the log
   backend supports it. Implementors MUST still verify that the `'exception'`
-  key is actually an `Exception` before using it as such, as it MAY contain
+  key is actually a `Throwable` before using it as such, as it MAY contain
   anything.
 
 ### 1.4 Helper classes and interfaces

--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -103,7 +103,7 @@ Users of loggers are referred to as `user`.
   an exception nor raise any php error, warning or notice.
 
 - If an `Exception` object is passed in the context data, it MUST be in the
-  `'exception'` key. Logging exceptions is a common pattern and this allows
+  `'exception'` key. Logging exceptions is a common pattern, and this allows
   implementors to extract a stack trace from the exception when the log
   backend supports it. Implementors MUST still verify that the `'exception'`
   key is actually an `Exception` before using it as such, as it MAY contain


### PR DESCRIPTION
PSR-3 currently states that an `Exception` object passed via the log context MUST be provided under the `exception` key.

Since PHP 7.0, the language introduced the `Throwable` interface, which is implemented by both `Exception` and `Error`. In modern PHP applications, it is common practice to catch and log all throwables, not only exceptions:

```php
try {
    // ...
} catch (\Throwable $e) {
    $logger->critical('Unhandled error', ['exception' => $e]);
}
```

Most widely used PSR-3 implementations (e.g. Monolog, Symfony, Laravel) already support logging any `Throwable`. However, the current wording of PSR-3 does not reflect this and may be misleading for developers reading the specification today.

This PR proposes updating the wording to reference `Throwable` instead of `Exception`.
The change is purely clarifying and does not alter the behavior or intent of the standard. It remains fully backward-compatible, as `Exception` implements `Throwable`.

⸻

### Rationale

- Align PSR-3 with modern PHP language features
- Reflect real-world usage of PSR-3 loggers
- Avoid confusion for developers working with PHP 7+
- Keep the specification accurate and future-proof