### PR TITLE
Add errata clarifying `Exception` vs. `Throwable` usage in PSR-3

### DIFF
--- a/accepted/PSR-3-logger-interface-meta.md
+++ b/accepted/PSR-3-logger-interface-meta.md
@@ -42,3 +42,13 @@ Implementers MAY add parameter types to their own packages in a new major releas
 * the implementation depends on `"psr/log": "^2.0 || ^3.0"` so as to exclude the untyped 1.0 version.
 
 Implementers are encouraged but not required to transition their packages toward the 3.0 version of the package at their earliest convenience.
+
+### 5.2 Throwable vs. Exception
+
+At the time PSR-3 was written, PHP only had the `Exception` type and the more general `Throwable` interface did not yet exist.
+
+In modern PHP versions, `Throwable` is the common base interface for both `Exception` and `Error`.
+
+Wherever this specification refers to an `Exception` being passed in the `exception` context key, it SHOULD be interpreted as allowing any `Throwable` instance.
+
+Implementations MUST still verify that the value in the `exception` context key is actually a `Throwable` before using it as such.


### PR DESCRIPTION
PSR-3 was written before PHP introduced the `Throwable` interface. At that time, `Exception` was the only error-related base type available.

In modern PHP versions, both `Exception` and `Error` implement `Throwable`, and it is common practice for logging libraries to accept any `Throwable` when logging failures.

This PR adds an Errata section to PSR-3 clarifying that references to `Exception` in the specification - specifically the `exception` context key - should be interpreted as allowing any `Throwable` instance.

The main specification text is intentionally left unchanged. This errata is meant to:

- reflect modern PHP language semantics;
- improve clarity for implementors;
- increase awareness without introducing breaking changes.

Per FIG process, this change is intended to go through the errata vote.

@Seldaek please, take a look once again if possible

Related pr: https://github.com/php-fig/fig-standards/pull/1345